### PR TITLE
fix(createScanDialog): issues/28 concurrency default

### DIFF
--- a/src/components/createScanDialog/__tests__/__snapshots__/createScanDialog.test.js.snap
+++ b/src/components/createScanDialog/__tests__/__snapshots__/createScanDialog.test.js.snap
@@ -129,7 +129,7 @@ exports[`CreateScanDialog Component should render a basic component 1`] = `
                     id="scanConcurrency"
                     name="scanConcurrency"
                     type="text"
-                    value="50"
+                    value="25"
                   />
                   <span
                     class="input-group-btn"

--- a/src/components/createScanDialog/createScanDialog.js
+++ b/src/components/createScanDialog/createScanDialog.js
@@ -282,7 +282,7 @@ class CreateScanDialog extends React.Component {
           setValues={{
             displayScanDirectories: '',
             displayScanSources: sources.map(item => item.name).join(', '),
-            scanConcurrency: 50,
+            scanConcurrency: 25,
             scanDirectories: [],
             jbossEap: false,
             jbossFuse: false,


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
* fix(createScanDialog): issues/28 concurrency default
  * update concurrency default from 50 to 25

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
* the UI can really set any concurrency default it wants based on the current implementation. In this case however we're aligning the default defined by the API

## How to test
<!-- Are there directions to test/review? -->
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn` then
1. `$ yarn test`
### Interactive unit test check
1. update the NPM packages with `$ yarn` then
1. `$ yarn test:dev`
### Run the UI
1. clone the repo, create a branch, pull the changes from `cdcabrera issues/28` 
1. cd into the repo, update the NPM packages with `$ yarn`, if you don't have yarn installed you can use brew or `$ npm install yarn -g`, next
1. make sure Docker is running, then
1. `$ yarn start:review` ... this should compile the image, then run the container with the latest changes
1. You'll need to create a source first in order to access the scans dialog
  ![Screen Shot 2019-03-26 at 2 02 47 PM](https://user-images.githubusercontent.com/3761375/55021880-e2003600-4fcf-11e9-9cf4-b5b4019ecdfe.png)


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2019-03-26 at 1 55 58 PM](https://user-images.githubusercontent.com/3761375/55021339-f3950e00-4fce-11e9-90fe-aadf9964b4d1.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
* #28 
* https://github.com/quipucords/quipucords/issues/1858
