### PR TITLE
fix(build): issues/29 version display

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -4,6 +4,7 @@
 # main()
 #
 {
-  echo "Compiling version information..."
-  echo UI_VERSION="$(node -p 'require(`./package.json`).version').$(git rev-parse --short HEAD)" > ./.env.production.local
+  UI_VERSION="$(node -p 'require(`./package.json`).version').$(git rev-parse --short HEAD)"
+  echo "Compiling version information... v$UI_VERSION"
+  echo UI_VERSION="$UI_VERSION" > ./.env.production.local
 }

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+
+describe('Version', () => {
+  it('should have a specific version output', () => {
+    const file = './.env.production.local';
+
+    expect(fs.existsSync(file)).toBe(true);
+
+    const fileContents = fs.readFileSync(file, { encoding: 'utf-8' });
+    expect(/^UI_VERSION=\d\.\d\.\d\.[a-z0-9]{7}$/i.test(fileContents.trim())).toBe(true);
+  });
+});

--- a/tests/version.test.js
+++ b/tests/version.test.js
@@ -1,12 +1,10 @@
 const fs = require('fs');
 
 describe('Version', () => {
+  const loadFile = file => (fs.existsSync(file) && fs.readFileSync(file, { encoding: 'utf-8' })) || '';
+
   it('should have a specific version output', () => {
-    const file = './.env.production.local';
-
-    expect(fs.existsSync(file)).toBe(true);
-
-    const fileContents = fs.readFileSync(file, { encoding: 'utf-8' });
+    const fileContents = loadFile('./.env.production.local');
     expect(/^UI_VERSION=\d\.\d\.\d\.[a-z0-9]{7}$/i.test(fileContents.trim())).toBe(true);
   });
 });


### PR DESCRIPTION
## What's included
- fix(build): issues/29 version display
  * display version on creation
  * integration test for version

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
* the unit test checks the format `[string]=[number].[number].[number].[7 character hash]`

## How to test
<!-- Are there directions to test/review? -->
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:integration`
### Or build the version file yourself
1. run `$ yarn build:version`

## Example
Running `$ yarn build:version` should produce output similar to...
  ![Screen Shot 2019-04-04 at 5 02 12 PM](https://user-images.githubusercontent.com/3761375/55588376-964e3a80-56fb-11e9-9054-6af013c8b977.png)


## Updates issue/story
#29 
