### PR TITLE
fix(reportsService): issues/52 name report package download

### DIFF
--- a/src/common/__tests__/__snapshots__/helpers.test.js.snap
+++ b/src/common/__tests__/__snapshots__/helpers.test.js.snap
@@ -70,7 +70,6 @@ Object {
   "createViewQueryObject": [Function],
   "devModeNormalizeCount": [Function],
   "downloadData": [Function],
-  "downloadPackage": [Function],
   "generateId": [Function],
   "getMessageFromResults": [Function],
   "getStatusFromResults": [Function],

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -69,27 +69,6 @@ const downloadData = (data = '', fileName = 'download.txt', fileType = 'text/pla
     }
   });
 
-const downloadPackage = (filePath = '') =>
-  new Promise((resolve, reject) => {
-    try {
-      const anchorTag = window.document.createElement('a');
-
-      anchorTag.href = filePath;
-      anchorTag.style.display = 'none';
-
-      window.document.body.appendChild(anchorTag);
-
-      anchorTag.click();
-
-      setTimeout(() => {
-        window.document.body.removeChild(anchorTag);
-        resolve({ filePath });
-      }, 250);
-    } catch (error) {
-      reject(error);
-    }
-  });
-
 const generateId = prefix =>
   `${prefix || 'generatedid'}-${(process.env.REACT_APP_ENV !== 'test' && Math.ceil(1e5 * Math.random())) || ''}`;
 
@@ -337,7 +316,6 @@ const helpers = {
   copyClipboard,
   devModeNormalizeCount,
   downloadData,
-  downloadPackage,
   generateId,
   noop,
   noopPromise,

--- a/src/services/reportsService.js
+++ b/src/services/reportsService.js
@@ -2,19 +2,24 @@ import axios from 'axios';
 import serviceConfig from './config';
 import helpers from '../common/helpers';
 
-/**
- * ToDo: Evaluate naming the download package
- * Since the data is already being handled on the server we do not need to
- * handle the blob/file, simply link to it.
- *
- * Currently when we apply the anchor download attribute in an attempt to rename
- * the gzip it throws a server cert error in staging, i.e. "Failed - Bad certificate"
- * Removing the anchor tag download attribute removes the error, but then all the
- * packages are simply named "download"
- */
 const getReportsDownload = id =>
-  (helpers.TEST_MODE && helpers.noopPromise) ||
-  helpers.downloadPackage(`${process.env.REACT_APP_REPORTS_SERVICE}${id}/`);
+  axios(
+    serviceConfig(
+      {
+        url: `${process.env.REACT_APP_REPORTS_SERVICE}${id}/`,
+        responseType: 'blob'
+      },
+      false
+    )
+  ).then(
+    success =>
+      (helpers.TEST_MODE && success.data) ||
+      helpers.downloadData(
+        success.data,
+        `report_id_${id}_${helpers.getTimeStampFromResults(success)}.tar.gz`,
+        'application/gzip'
+      )
+  );
 
 const mergeReports = (data = {}) =>
   axios(


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(reportsService): issues/52 name report package download
  * reportsService, move to axios, add responseType
  * helpers, remove downloadPackage in favor of downloadData

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- This corrects the naming issue around the report by adding in the `tar.gz`. The current package download generates the name based on the browser, which can be confusing... Chrome labels it `download.gz` and Firefox labels it `[some hash].gz`. To round it out the file doesn't open on RHEL without the `tar` in there, this fix corrects all of that.

## How to test
<!-- Are there directions to test/review? -->
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
### Run the Dev UI
The Dev UI can be used for a quick confirmation on **just the file name** coming through. Trying to unzip it will create an infinite loop of annoyance since the `tar.gz` isn't legit.
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, then
1. `$ yarn start`
1. Next, navigate to the scans page, you should see what appears to be randomized data. Go ahead and hit the download button, if you don't see a download button on scans, refresh the page until you do. Then check your download directory to confirm the file name appears as `report_id_[HUGE RANDOM ID]_[DATE]_[TIME].tar.gz`
### Run the Review UI
To fully test the package name is successfully you'll need to run
1. update the NPM packages with `$ yarn`
1. make sure Docker is running, then
1. `$ yarn start:review` ... this should compile the image, then run the container with the latest changes
1. Next you'll need to generate a successful report. That means setting up a source, running a scan. Then navigate to the scans view, download the package. Within your download directory you should see `report_id_[ID]_[DATE]_[TIME].tar.gz`. The file should expand accordingly and provide you with a directory containing 
    - `report_id_[ID]`
      - `deployments.csv`
      - `deployments.json`
      - `details.csv`
      - `details.json`

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
fixes #52 
