### PR TITLE
chore(build): changelog, version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 0.9.1 (2019-08-14)
+## 0.9.2 (2019-12-11)
+
+
+### Bug Fixes
+
+* **build:** issues/73 correct Django token reference ([#74](https://github.com/quipucords/quipucords-ui/issues/74)) ([06966d4](https://github.com/quipucords/quipucords-ui/commit/06966d4))
+
+
+
+## 0.9.1 (2019-08-20)
 
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quipucords-ui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Quipucords UI",
   "author": "Red Hat",
   "license": "GPL-3.0",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): changelog, version

### Notes
- Tag accordingly with `0.9.2` after merge
- There is a development dependency on commit/tagging updates from Quipudocs. However, the packaging build that leverages Jenkins will pull the latest Quipudocs

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
Ongoing