### PR TITLE
chore(build): post clean up, remove unused css copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "build:deps": "bash ./scripts/dependencies.sh --doctor -u --doctorInstall \"yarn\" --doctorTest \"yarn test:deps\" --reject \"patternfly*, quipudocs, jest*\"",
     "build:docs": "node ./scripts/quipudocs.js",
     "build:js": "react-scripts build",
-    "build:post": "bash ./scripts/post.sh",
+    "build:post": "bash ./scripts/post.sh; bash ./scripts/clean.sh",
     "build:pre": "bash ./scripts/pre.sh",
     "build:brand": "run-s -l 'build:pre -b' 'build:docs -b' test:docs build:js build:post test:integration",
     "release": "> ./CHANGELOG.md && standard-version",

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -5,7 +5,7 @@
 #
 cleanDocs()
 {
-  printf "Cleaning locale resources..."
+  printf "Cleaning document resources..."
 
   (git status > /dev/null 2>&1)
 

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -76,7 +76,6 @@ updateDistribution()
   mkdir -p ./dist/client/assets/css
   cp -R ./node_modules/patternfly/dist/* ./dist/client/assets/rcue
   cp -R ./src/styles/images/* ./dist/client/assets/images
-  cp -R ./src/styles/.css/* ./dist/client/assets/css
   cp -R ./templates/* ./dist/templates
 
   printf "Completed\n"


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): post clean up, remove unused css copy

### Notes
- applies the cleanup convenience script to the build npm script to help with local development
   - `$ yarn build:clean`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install` or `$ yarn`
1. `$ npm test` or `$ yarn test`
### Interactive unit test check
1. update the NPM packages with `$ npm install` or `$ yarn`
1. `$ npm run test:dev` or `$ yarn test:dev`
-->
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm the extra files that normally hang around in the "./public" directory no longer exist

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-8](https://issues.redhat.com/browse/DISCOVERY-8)