### PR TITLE
fix(build): discovery-8 allow repo locale files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,9 @@
     "prettier",
     "react"
   ],
+  "settings": {
+    "import/external-module-folders": ["public"]
+  },
   "extends": [
     "react-app",
     "airbnb",
@@ -21,8 +24,10 @@
     "plugin:jest/recommended"
   ],
   "globals": {
+    "mountHook": "readonly",
     "mountHookComponent": "readonly",
     "mountHookWrapper": "readonly",
+    "shallowHook": "readonly",
     "shallowHookComponent": "readonly",
     "shallowHookWrapper": "readonly"
   },
@@ -37,7 +42,7 @@
     "import/extensions": [
       "error",
       {
-        "json": "never"
+        "json": "always"
       }
     ],
     "import/first": 0,

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "bootstrap": "^5.1.3",
     "classnames": "^2.3.1",
     "detect-browser": "^5.3.0",
+    "glob": "^8.0.3",
     "i18next": "^21.8.10",
     "i18next-xhr-backend": "^2.0.1",
     "js-cookie": "^3.0.1",

--- a/scripts/quipudocs.js
+++ b/scripts/quipudocs.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const { ea, install, locales, user } = require('quipudocs');
+const _merge = require('lodash/merge');
 const installDocFileOutput = './public/docs/install.html';
 const useDocFileOutput = './public/docs/use.html';
 const localesFileOutput = './public/locales/locales.json';
@@ -33,11 +34,23 @@ const buildEa = () => {
     const dir = localesDir;
     const localesJSON = locales;
     const eaJSON = ea;
+    let currentFileOutput = {};
 
-    fs.writeFileSync(fileOutput, JSON.stringify(localesJSON, null, 2));
+    if (fs.existsSync(fileOutput)) {
+      currentFileOutput = JSON.parse(fs.readFileSync(fileOutput, 'utf-8'));
+    }
+
+    fs.writeFileSync(fileOutput, JSON.stringify(_merge(currentFileOutput, localesJSON), null, 2));
 
     Object.keys(eaJSON).forEach(key => {
-      fs.writeFileSync(`${dir}${key}.json`, JSON.stringify(eaJSON[key], null, 2));
+      const langFile = `${dir}${key}.json`;
+      let currentLangFile = {};
+
+      if (fs.existsSync(langFile)) {
+        currentLangFile = JSON.parse(fs.readFileSync(langFile, 'utf-8'));
+      }
+
+      fs.writeFileSync(langFile, JSON.stringify(_merge(currentLangFile, eaJSON[key]), null, 2));
     });
 
     console.info(`Building locale files...Complete`);

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -26,6 +26,12 @@ const aggregatedError = (errors, message, { name = 'AggregateError' } = {}) => {
   return err;
 };
 
+/**
+ * Copy value into "clipboard"
+ *
+ * @param {string|*} text
+ * @returns {boolean}
+ */
 const copyClipboard = text => {
   let successful;
 
@@ -61,8 +67,23 @@ const copyClipboard = text => {
   return successful;
 };
 
+/**
+ * Apply more realistic values numerical values when using the generated data in dev mode.
+ *
+ * @param {number} count
+ * @param {number} modulus
+ * @returns {number}
+ */
 const devModeNormalizeCount = (count, modulus = 100) => Math.abs(count) % modulus;
 
+/**
+ * Allow data to be downloaded.
+ *
+ * @param {string|*} data
+ * @param {string} fileName
+ * @param {string} fileType
+ * @returns {Promise<unknown>}
+ */
 const downloadData = (data = '', fileName = 'download.txt', fileType = 'text/plain') =>
   new Promise((resolve, reject) => {
     try {
@@ -93,15 +114,58 @@ const downloadData = (data = '', fileName = 'download.txt', fileType = 'text/pla
     }
   });
 
+/**
+ * Generate a random'ish ID.
+ *
+ * @param {string} prefix
+ * @returns {string}
+ */
 const generateId = prefix =>
   `${prefix || 'generatedid'}-${(process.env.REACT_APP_ENV !== 'test' && Math.ceil(1e5 * Math.random())) || ''}`;
 
+/**
+ * An empty function.
+ * Typically used as a default prop.
+ */
 const noop = Function.prototype;
 
+/**
+ * An empty promise.
+ * Typically used as a default prop, or during testing.
+ *
+ * @type {Promise<{}>}
+ */
 const noopPromise = Promise.resolve({});
 
-const noopTranslate = (key, value) => value || `t('${key}')`;
+/**
+ * A placeholder for "t", or any translation method.
+ * Associated with the i18n package, and typically used as a default prop.
+ *
+ * @param {string|Array} key
+ * @param {string|object|Array} value
+ * @param {Array} components
+ * @returns {string}
+ */
+const noopTranslate = (key, value, components) => {
+  const updatedKey = (Array.isArray(key) && `[${key}]`) || key;
+  const updatedValue =
+    (typeof value === 'string' && value) ||
+    (Array.isArray(value) && `[${value}]`) ||
+    (Object.keys(value || '').length && JSON.stringify(value)) ||
+    '';
+  const updatedComponents = (components && `${components}`) || '';
 
+  return `t(${updatedKey}${(updatedValue && `, ${updatedValue}`) || ''}${
+    (updatedComponents && `, ${updatedComponents}`) || ''
+  })`;
+};
+
+/**
+ * Return an icon for source type.
+ *
+ * @param {string} sourceType
+ * @returns {{name: string, type: string}}
+ */
 const sourceTypeIcon = sourceType => {
   switch (sourceType) {
     case 'vcenter':
@@ -115,6 +179,12 @@ const sourceTypeIcon = sourceType => {
   }
 };
 
+/**
+ * Return an icon for scanning type.
+ *
+ * @param {string} scanType
+ * @returns {{name: string, type: string}}
+ */
 const scanTypeIcon = scanType => {
   switch (scanType) {
     case 'connect':
@@ -126,6 +196,12 @@ const scanTypeIcon = scanType => {
   }
 };
 
+/**
+ * Return an icon for scanning status.
+ *
+ * @param {string} scanStatus
+ * @returns {{name: string, classNames: *[], type: string}|{name: string, classNames: string[], type: string}}
+ */
 const scanStatusIcon = scanStatus => {
   switch (scanStatus) {
     case 'completed':
@@ -148,10 +224,33 @@ const scanStatusIcon = scanStatus => {
   }
 };
 
+/**
+ * Set a property if the value is NOT undefined using lodash "set".
+ *
+ * @param {object} obj
+ * @param {Array|*} props
+ * @param {*} value
+ * @returns {*}
+ */
 const setPropIfDefined = (obj, props, value) => (obj && value !== undefined ? _set(obj, props, value) : obj);
 
+/**
+ * Set a property if it equates to "truthy" using lodash "set".
+ *
+ * @param {object} obj
+ * @param {Array|*} props
+ * @param {*} value
+ * @returns {*}
+ */
 const setPropIfTruthy = (obj, props, value) => (obj && value ? _set(obj, props, value) : obj);
 
+/**
+ * View lifecycle method helper to determine if props have changed.
+ *
+ * @param {object} nextViewOptions
+ * @param {object} currentViewOptions
+ * @returns {boolean}
+ */
 const viewPropsChanged = (nextViewOptions, currentViewOptions) =>
   nextViewOptions.currentPage !== currentViewOptions.currentPage ||
   nextViewOptions.pageSize !== currentViewOptions.pageSize ||
@@ -159,6 +258,13 @@ const viewPropsChanged = (nextViewOptions, currentViewOptions) =>
   nextViewOptions.sortAscending !== currentViewOptions.sortAscending ||
   nextViewOptions.activeFilters !== currentViewOptions.activeFilters;
 
+/**
+ * Generate a consistent query parameter object for views.
+ *
+ * @param {object} viewOptions
+ * @param {object} queryObj
+ * @returns {object}
+ */
 const createViewQueryObject = (viewOptions, queryObj) => {
   const queryObject = {
     ...queryObj
@@ -182,6 +288,13 @@ const createViewQueryObject = (viewOptions, queryObj) => {
   return queryObject;
 };
 
+/**
+ * A redux helper associated with getting a message from results.
+ *
+ * @param {object} results
+ * @param {*} filter
+ * @returns {{messages: {}, message: null, url, status: number}}
+ */
 const getMessageFromResults = (results, filter = null) => {
   const status = _get(results, 'response.status', results.status);
   const statusResponse = _get(results, 'response.statusText', results.statusText);
@@ -289,6 +402,12 @@ const getMessageFromResults = (results, filter = null) => {
   return messages;
 };
 
+/**
+ * A redux helper associated with returning a http status from results.
+ *
+ * @param {object} results
+ * @returns {number}
+ */
 const getStatusFromResults = results => {
   let status = _get(results, 'response.status', results.status);
 
@@ -299,16 +418,32 @@ const getStatusFromResults = results => {
   return status;
 };
 
+/**
+ * Return a callback for determining a timestamp.
+ *
+ * @returns {Function}
+ */
 const getTimeStampFromResults =
   process.env.REACT_APP_ENV !== 'test'
     ? results => moment(_get(results, 'headers.date', Date.now())).format('YYYYMMDD_HHmmss')
     : () => '20190225_164640';
 
+/**
+ * Return a callback for determine time offset.
+ *
+ * @returns {Function}
+ */
 const getTimeDisplayHowLongAgo =
   process.env.REACT_APP_ENV !== 'test'
     ? timestamp => moment.utc(timestamp).utcOffset(moment().utcOffset()).fromNow()
     : () => 'a day ago';
 
+/**
+ * Is this an IP address.
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
 const isIpAddress = name => {
   const vals = name.split('.');
   if (vals.length === 4) {
@@ -317,25 +452,79 @@ const isIpAddress = name => {
   return false;
 };
 
+/**
+ * Return an IP address value.
+ *
+ * @param {string} name
+ * @returns {*}
+ */
 const ipAddressValue = name => {
   const values = name.split('.');
   return values[0] * 0x1000000 + values[1] * 0x10000 + values[2] * 0x100 + values[3] * 1;
 };
 
+/**
+ * Is dev mode active.
+ * Associated with using the NPM script "start". See dotenv config files for activation.
+ *
+ * @type {boolean}
+ */
 const DEV_MODE = process.env.REACT_APP_ENV === 'development';
 
+/**
+ * Is prod mode active.
+ * Associated with production builds. See dotenv config files for activation.
+ *
+ * @type {boolean}
+ */
 const PROD_MODE = process.env.REACT_APP_ENV === 'production';
 
+/**
+ * Is test mode active.
+ * Associated with running unit tests. See dotenv config files for activation.
+ *
+ * @type {boolean}
+ */
 const TEST_MODE = process.env.REACT_APP_ENV === 'test';
 
+/**
+ * Is UI application name active.
+ * See dotenv config files for updating. See build scripts for how this value is being applied.
+ *
+ * @type {boolean}
+ */
 const UI_BRAND = process.env.REACT_APP_UI_BRAND === 'true';
 
+/**
+ * UI coded name.
+ * See dotenv config files for updating.
+ *
+ * @type {string}
+ */
 const UI_NAME = process.env.REACT_APP_UI_NAME;
 
+/**
+ * UI cased sentence start name.
+ * See dotenv config files for updating.
+ *
+ * @type {string}
+ */
 const UI_SENTENCE_START_NAME = process.env.REACT_APP_UI_SENTENCE_START_NAME;
 
+/**
+ * UI short name.
+ * See dotenv config files for updating.
+ *
+ * @type {string}
+ */
 const UI_SHORT_NAME = process.env.REACT_APP_UI_SHORT_NAME;
 
+/**
+ * UI packaged application version, with generated hash.
+ * See dotenv config files for updating. See build scripts for generated hash.
+ *
+ * @type {string}
+ */
 const UI_VERSION = process.env.REACT_APP_UI_VERSION;
 
 const helpers = {

--- a/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
+++ b/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.js.snap
@@ -25,7 +25,7 @@ exports[`AboutModal Component should contain brand: brand 1`] = `
     >
       <AboutModalVersionItem
         className=""
-        label="UI Version"
+        label="t(about-modal.ui-version, UI Version)"
         versionText="0.0.0.0000000"
       />
     </AboutModalVersions>

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -1,5 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`I18n Component should generate a predictable locale key output snapshot: key output 1`] = `
+Array [
+  Object {
+    "file": "./src/common/helpers.js",
+    "keys": Array [
+      Object {
+        "key": "",
+        "match": "t(\${updatedKey}\${(updatedValue && \`, \${updatedValue}\`)",
+      },
+    ],
+  },
+  Object {
+    "file": "./src/components/aboutModal/aboutModal.js",
+    "keys": Array [
+      Object {
+        "key": "about-modal.username",
+        "match": "t('about-modal.username', 'Username')",
+      },
+      Object {
+        "key": "about-modal.browser-version",
+        "match": "t('about-modal.browser-version', 'Browser Version')",
+      },
+      Object {
+        "key": "about-modal.browser-os",
+        "match": "t('about-modal.browser-os', 'Browser OS')",
+      },
+      Object {
+        "key": "about-modal.server-version",
+        "match": "t('about-modal.server-version', 'Server Version')",
+      },
+      Object {
+        "key": "about-modal.ui-version",
+        "match": "t('about-modal.ui-version', 'UI Version')",
+      },
+    ],
+  },
+]
+`;
+
+exports[`I18n Component should have locale keys that exist in the default language JSON: predictable missing locale keys 1`] = `
+Array [
+  Object {
+    "file": "./src/components/aboutModal/aboutModal.js",
+    "key": "about-modal.username",
+  },
+  Object {
+    "file": "./src/components/aboutModal/aboutModal.js",
+    "key": "about-modal.browser-version",
+  },
+  Object {
+    "file": "./src/components/aboutModal/aboutModal.js",
+    "key": "about-modal.browser-os",
+  },
+  Object {
+    "file": "./src/components/aboutModal/aboutModal.js",
+    "key": "about-modal.server-version",
+  },
+  Object {
+    "file": "./src/components/aboutModal/aboutModal.js",
+    "key": "about-modal.ui-version",
+  },
+]
+`;
+
 exports[`I18n Component should pass children: children 1`] = `"lorem ipsum"`;
 
 exports[`I18n Component should render a basic component: basic 1`] = `

--- a/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18nHelpers.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`I18nHelpers should attempt to perform a string replace: translate 1`] = `
+Object {
+  "emptyContext": "t(lorem.ipsum, {\\"context\\":\\" \\"})",
+  "emptyPartialContext": "t(lorem.ipsum, {\\"context\\":\\"hello_ \\"})",
+  "localeKey": "t(lorem.ipsum)",
+  "multiContext": "t(lorem.ipsum, {\\"context\\":\\"hello_world\\"})",
+  "multiContextWithEmptyValue": "t(lorem.ipsum, {\\"context\\":\\"hello_world\\"})",
+  "multiKey": "t([lorem.ipsum,lorem.fallback])",
+  "placeholder": "t(lorem.ipsum, hello world)",
+}
+`;
+
+exports[`I18nHelpers should attempt to perform translate with a node: translated node 1`] = `"<div>t(lorem.ipsum, {&quot;hello&quot;:&quot;world&quot;}, [object Object])</div>"`;
+
+exports[`I18nHelpers should have specific functions: i18nHelpers 1`] = `
+Object {
+  "EMPTY_CONTEXT": "LOCALE_EMPTY_CONTEXT",
+  "translate": [Function],
+}
+`;

--- a/src/components/i18n/__tests__/i18n.test.js
+++ b/src/components/i18n/__tests__/i18n.test.js
@@ -1,7 +1,55 @@
 import React from 'react';
+import { readFileSync } from 'fs';
+import glob from 'glob';
+import _get from 'lodash/get';
+import enLocales from '../../../../public/locales/en.json';
 import { I18n } from '../i18n';
 
+/**
+ * Get translation keys.
+ *
+ * @param {object} params
+ * @param {string} params.files
+ * @param {Array} params.list
+ * @returns {Array}
+ */
+const getTranslationKeys = ({ files = './src/**/!(*.test|*.spec).@(js|jsx)', list = ['t', 'translate'] }) => {
+  const keys = [];
+  const updatedFiles = glob.sync(files);
+
+  updatedFiles.forEach(file => {
+    const fileContent = readFileSync(file, 'utf-8');
+    const generateRegExp = list.map(f => `\\b${f}\\([\\d\\D]+?\\)`).join('|');
+    const matches = fileContent.match(new RegExp(generateRegExp, 'g'));
+
+    if (matches && matches.length) {
+      const filterKeys = matches
+        .map(match => {
+          const key = match.match(/['`"]([\d\D]+?)['`"][,)]/);
+
+          if (key) {
+            return {
+              key: (!/\${/.test(key) && key[1]) || '',
+              match: match.replace(/\n/g, '').replace(/\s+/g, ' ').trim()
+            };
+          }
+
+          return null;
+        })
+        .filter(key => key !== null);
+
+      if (filterKeys.length) {
+        keys.push({ file, keys: filterKeys });
+      }
+    }
+  });
+
+  return keys;
+};
+
 describe('I18n Component', () => {
+  const getKeys = getTranslationKeys({});
+
   it('should render a basic component', async () => {
     const props = {
       locale: 'es'
@@ -16,5 +64,24 @@ describe('I18n Component', () => {
     const component = await mountHookComponent(<I18n>lorem ipsum</I18n>);
 
     expect(component.html()).toMatchSnapshot('children');
+  });
+
+  it('should generate a predictable locale key output snapshot', () => {
+    expect(getKeys).toMatchSnapshot('key output');
+  });
+
+  it('should have locale keys that exist in the default language JSON', () => {
+    const keys = getKeys;
+    const missingKeys = [];
+
+    keys.forEach(value => {
+      value.keys.forEach(subValue => {
+        if (subValue.key && !_get(enLocales, subValue.key, null)) {
+          missingKeys.push({ file: value.file, key: subValue.key });
+        }
+      });
+    });
+
+    expect(missingKeys).toMatchSnapshot('predictable missing locale keys');
   });
 });

--- a/src/components/i18n/__tests__/i18nHelpers.test.js
+++ b/src/components/i18n/__tests__/i18nHelpers.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { i18nHelpers, EMPTY_CONTEXT, translate } from '../i18nHelpers';
+
+describe('I18nHelpers', () => {
+  it('should have specific functions', () => {
+    expect(i18nHelpers).toMatchSnapshot('i18nHelpers');
+  });
+
+  it('should attempt to perform translate with a node', async () => {
+    const ExampleComponent = () => <div>{translate('lorem.ipsum', { hello: 'world' }, [<span id="test" />])}</div>;
+    ExampleComponent.propTypes = {};
+    ExampleComponent.defaultProps = {};
+
+    const component = await shallowHookComponent(<ExampleComponent />);
+    expect(component.html()).toMatchSnapshot('translated node');
+  });
+
+  it('should attempt to perform a string replace', () => {
+    const emptyContext = translate('lorem.ipsum', { context: EMPTY_CONTEXT });
+    const emptyPartialContext = translate('lorem.ipsum', { context: ['hello', EMPTY_CONTEXT] });
+    const localeKey = translate('lorem.ipsum');
+    const placeholder = translate('lorem.ipsum', 'hello world');
+    const multiContext = translate('lorem.ipsum', { context: ['hello', 'world'] });
+    const multiContextWithEmptyValue = translate('lorem.ipsum', { context: ['hello', undefined, null, '', 'world'] });
+    const multiKey = translate(['lorem.ipsum', undefined, null, '', 'lorem.fallback']);
+
+    expect({
+      emptyContext,
+      emptyPartialContext,
+      localeKey,
+      placeholder,
+      multiContext,
+      multiContextWithEmptyValue,
+      multiKey
+    }).toMatchSnapshot('translate');
+  });
+});

--- a/src/components/i18n/i18n.js
+++ b/src/components/i18n/i18n.js
@@ -4,7 +4,8 @@ import i18next from 'i18next';
 import XHR from 'i18next-xhr-backend';
 import { initReactI18next } from 'react-i18next';
 import { useMount } from 'react-use';
-import { helpers } from '../../common/helpers';
+import { helpers } from '../../common';
+import { EMPTY_CONTEXT, translate } from './i18nHelpers';
 
 const I18n = ({ children, fallbackLng, loadPath, locale }) => {
   const [initialized, setInitialized] = useState(false);
@@ -66,4 +67,4 @@ I18n.defaultProps = {
   locale: null
 };
 
-export { I18n as default, I18n };
+export { I18n as default, I18n, EMPTY_CONTEXT, translate };

--- a/src/components/i18n/i18nHelpers.js
+++ b/src/components/i18n/i18nHelpers.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Trans } from 'react-i18next';
+import i18next from 'i18next';
+import { helpers } from '../../common';
+
+/**
+ * Check for providing an empty context (empty string).
+ *
+ * @type {string}
+ */
+const EMPTY_CONTEXT = 'LOCALE_EMPTY_CONTEXT';
+
+/**
+ * Apply a string towards a key. Optional replacement values and component/nodes.
+ * See, https://react.i18next.com/
+ *
+ * @param {string|Array} translateKey A key reference, or an array of a primary key with fallback keys.
+ * @param {string|object|Array} values A default string if the key can't be found. An object with i18next settings. Or an array of objects (key/value) pairs used to replace string tokes. i.e. "[{ hello: 'world' }]"
+ * @param {Array} components An array of HTML/React nodes used to replace string tokens. i.e. "[<span />, <React.Fragment />]"
+ * @param {object} options
+ * @param {string} options.emptyContextValue Check to allow an empty context value.
+ * @returns {string|React.ReactNode}
+ */
+const translate = (translateKey, values = null, components, { emptyContextValue = EMPTY_CONTEXT } = {}) => {
+  const updatedValues = values;
+  let updatedTranslateKey = translateKey;
+
+  if (Array.isArray(updatedTranslateKey)) {
+    updatedTranslateKey = updatedTranslateKey.filter(value => typeof value === 'string' && value.length > 0);
+  }
+
+  if (Array.isArray(updatedValues?.context)) {
+    updatedValues.context = updatedValues.context
+      .map(value => (value === emptyContextValue && ' ') || value)
+      .filter(value => typeof value === 'string' && value.length > 0)
+      .join('_');
+  } else if (updatedValues?.context === emptyContextValue) {
+    updatedValues.context = ' ';
+  }
+
+  if (helpers.TEST_MODE) {
+    return helpers.noopTranslate(updatedTranslateKey, updatedValues, components);
+  }
+
+  if (components) {
+    return (
+      (i18next.store && <Trans i18nKey={updatedTranslateKey} values={updatedValues} components={components} />) || (
+        <React.Fragment>t({updatedTranslateKey})</React.Fragment>
+      )
+    );
+  }
+
+  return (i18next.store && i18next.t(updatedTranslateKey, updatedValues)) || `t([${updatedTranslateKey}])`;
+};
+
+const i18nHelpers = { EMPTY_CONTEXT, translate };
+
+export { i18nHelpers as default, i18nHelpers, EMPTY_CONTEXT, translate };

--- a/tests/__snapshots__/code.test.js.snap
+++ b/tests/__snapshots__/code.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 Array [
-  "common/helpers.js:57:      console.warn('Copy to clipboard failed.', e.message);",
-  "common/helpers.js:146:      console.error(\`Unknown status: \${scanStatus}\`);",
+  "common/helpers.js:63:      console.warn('Copy to clipboard failed.', e.message);",
+  "common/helpers.js:222:      console.error(\`Unknown status: \${scanStatus}\`);",
   "redux/common/reduxHelpers.js:14:    console.error(\`Error: Property \${prop} does not exist within the passed state.\`, state);",
   "redux/common/reduxHelpers.js:18:    console.warn(\`Warning: Property \${prop} does not exist within the passed initialState.\`, initialState);",
-  "setupTests.js:83:  console.error = (message, ...args) => {",
+  "setupTests.js:151:  console.error = (message, ...args) => {",
 ]
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7157,7 +7157,7 @@ glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.1:
+glob@^8.0.1, glob@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
   integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==


### PR DESCRIPTION
## What's included

#### Bug Fixes
1. **build** discovery-8 allow repo locale files (dcc369a)


### Notes
- Locale strings factors into the PF4 updates. We had considered delaying this set of updates until after PF4, but opted to apply it before/during to avoid additional cycles if/when string additions start popping up
   - we would have preferred to apply strings as `en-US.json` but for now we'll update as `en.json` and test out `en.json` as the fallback language
- Allows the repo to apply locale strings in addition to the existing process of pulling locale strings from the Quipudocs repo.
   - Quipudocs locale strings will always take priority over repo level locale strings

## How to test
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. edit AND commit temporarily an update to the `./public/locales/en.json` file
1. run the build
1. confirm the `./dist/client/locales/en.json` output locale file contains your changes, in addition to the defaults coming from the Quipudocs repository. Quipudocs `./src/ea/en.about-modal.json`. **_NOTE, Quipudocs locale strings will always take priority over repo level locale strings_**


## Example
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-8](https://issues.redhat.com/browse/DISCOVERY-*)