### PR TITLE
chore(build): do not start with stored data in DB volumes

### DIFF
--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -160,7 +160,7 @@ reviewApi()
     docker stop -t 0 $NAME >/dev/null
   fi
 
-  startDB $DB_NAME true
+  startDB $DB_NAME
 
   if [ -z "$(docker ps | grep $NAME)" ]; then
     printf "\n"
@@ -209,7 +209,7 @@ stageApi()
   fi
 
   if [ ! "$UPDATE" = true ]; then
-    startDB $DB_NAME true
+    startDB $DB_NAME
 
     if [ -z "$(docker ps | grep $NAME)" ]; then
       printf "\n"


### PR DESCRIPTION
The current behavior leads to `quipucords` container giving up to ghost when it tries to connect to the PG DB started with volume to persist data. This workaround just disable this persistence.