### PR TITLE
refactor(Alert): convert alert to PF4 in credential dialog

### DIFF
--- a/src/components/createCredentialDialog/createCredentialDialog.js
+++ b/src/components/createCredentialDialog/createCredentialDialog.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, ButtonVariant, Title } from '@patternfly/react-core';
-import { Alert, Form, Grid } from 'patternfly-react';
+import { Alert, Button, ButtonVariant, Title } from '@patternfly/react-core';
+import { Form, Grid } from 'patternfly-react';
 import { Modal } from '../modal/modal';
 import { connect, reduxActions, reduxTypes, store } from '../../redux';
 import { helpers } from '../../common/helpers';
@@ -77,7 +77,8 @@ class CreateCredentialDialog extends React.Component {
 
   state = { ...this.initialState };
 
-  UNSAFE_componentWillReceiveProps(nextProps) { //eslint-disable-line
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { edit, fulfilled, getCredentials, show, viewOptions } = this.props;
 
     if (!show && nextProps.show) {
@@ -389,8 +390,8 @@ class CreateCredentialDialog extends React.Component {
 
     if (error) {
       return (
-        <Alert type="error" onDismiss={this.onErrorDismissed}>
-          <strong>Error</strong> {errorMessage}
+        <Alert isInline variant="danger" title="Error">
+          {errorMessage}
         </Alert>
       );
     }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
...
Converts the instance of `Alert` in createCredentialDialog.js to use new PF4 component/styling.

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
Towards #91 

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->
1. Change line 389 of https://github.com/quipucords/quipucords-ui/compare/dev...jenny-s51:credentialDialogConvertAlert?expand=1#diff-c9e674b4dc402e05f627561a03fa45b3e001693235edd669a9df547cb160522bL387 to `if (!error) {`
2. Go to Credentials -> Add and click on each type 


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...
Before:
<img width="495" alt="Screen Shot 2022-06-30 at 11 27 49 AM" src="https://user-images.githubusercontent.com/32821331/176739452-6aa8c5fe-5b95-477f-8be8-f83af49511ce.png">
<img width="453" alt="Screen Shot 2022-06-30 at 11 27 57 AM" src="https://user-images.githubusercontent.com/32821331/176739455-d59dc812-3c08-4f85-a2c7-57a69aa4bfa3.png">
<img width="462" alt="Screen Shot 2022-06-30 at 11 28 04 AM" src="https://user-images.githubusercontent.com/32821331/176739458-f0129295-5d21-4795-8c02-bf38d6f41242.png">


After:
<img width="447" alt="Screen Shot 2022-06-30 at 11 29 06 AM" src="https://user-images.githubusercontent.com/32821331/176739500-53e82daa-ed9c-4c60-bade-116b0e1221e2.png">
<img width="496" alt="Screen Shot 2022-06-30 at 11 29 12 AM" src="https://user-images.githubusercontent.com/32821331/176739503-3cb16a89-9f41-4584-9f12-de852f938a64.png">
<img width="463" alt="Screen Shot 2022-06-30 at 11 29 17 AM" src="https://user-images.githubusercontent.com/32821331/176739505-73e993f7-b118-40ad-a2a9-6b14c4d6ee07.png">


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
<!-- [DISCOVERY-X](https://issues.redhat.com/browse/DISCOVERY-X) -->
https://issues.redhat.com/browse/DISCOVERY-148