### PR TITLE
refactor(refreshTimeButton): pf4 refreshTimeButton component

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -21,6 +21,9 @@
   "modal": {
     "aria-label-default": "Application modal"
   },
+  "refresh-time-button": {
+    "refreshed_load": "Refreshed "
+  },
   "view": {
     "empty-state_title": "Welcome to {{name}}",
     "empty-state_description_credentials": "Credentials contain authentication information needed to scan a source. A credential includes a username and a password or SSH key. {{name}} uses SSH to connect to servers on the network and uses credentials to access those servers.",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -22,7 +22,8 @@
     "aria-label-default": "Application modal"
   },
   "refresh-time-button": {
-    "refreshed_load": "Refreshed "
+    "refreshed": "Refreshed just now",
+    "refreshed_load": "Refreshed {{refresh}}"
   },
   "view": {
     "empty-state_title": "Welcome to {{name}}",

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -181,6 +181,15 @@ Array [
     ],
   },
   Object {
+    "file": "./src/components/refreshTimeButton/refreshTimeButton.js",
+    "keys": Array [
+      Object {
+        "key": "refresh-time-button.refreshed",
+        "match": "t('refresh-time-button.refreshed', { context: lastRefresh && 'load', refresh: lastRefresh && helpers.getTimeDisplayHowLongAgo(lastRefresh)",
+      },
+    ],
+  },
+  Object {
     "file": "./src/components/scans/scans.js",
     "keys": Array [
       Object {

--- a/src/components/refreshTimeButton/__tests__/__snapshots__/refreshTimeButton.test.js.snap
+++ b/src/components/refreshTimeButton/__tests__/__snapshots__/refreshTimeButton.test.js.snap
@@ -2,17 +2,34 @@
 
 exports[`RefreshTimeButton Component should render 1`] = `
 <button
-  class="refresh-button btn btn-link"
+  aria-disabled="false"
+  class="pf-c-button pf-m-link"
+  data-ouia-component-id="OUIA-Generated-Button-link-1"
+  data-ouia-component-type="PF4/Button"
+  data-ouia-safe="true"
   type="button"
 >
   <span
-    aria-hidden="true"
-    class="fa fa-refresh"
-  />
+    class="pf-c-button__icon pf-m-start"
+  >
+    <svg
+      aria-hidden="true"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 1024 1024"
+      width="1em"
+    >
+      <path
+        d="M515.8,0 C655.3,0 781.6,58.4 873.4,150.2 L968.9,54.7 C989,34.5 1024,48.8 1024,77.3 L1024,352 C1024,369.7 1009.2,384.1 991.5,384 L716.8,384 C688.3,384 674,349.5 694.2,329.3 L783,240.5 C713.5,171.1 617.8,128 512,128 C300.4,128 128,300.2 128,512 C128,723.8 300.2,896.1 511.9,896 C606.9,896 693.9,861.2 761,803.9 C773.7,793.1 792.6,793.8 804.4,805.6 L849.6,850.9 C862.6,864 861.9,885.4 848,897.6 C758,976.3 640.3,1024 511.7,1024 C229.1,1024 0,797 0,510.7 C0,226.2 235,0 515.8,0"
+      />
+    </svg>
+  </span>
   <span
     class="last-refresh-time"
   >
-    Refreshed 0
+    t(refresh-time-button.refreshed, {"context":0,"refresh":0})
   </span>
 </button>
 `;

--- a/src/components/refreshTimeButton/refreshTimeButton.js
+++ b/src/components/refreshTimeButton/refreshTimeButton.js
@@ -50,8 +50,10 @@ class RefreshTimeButton extends React.Component {
     return (
       <Button variant="link" icon={<RebootingIcon />} onClick={onRefresh}>
         <span className="last-refresh-time">
-          {t('refresh-time-button.refreshed', { context: 'load' })}
-          {lastRefresh && helpers.getTimeDisplayHowLongAgo(lastRefresh)}
+          {t('refresh-time-button.refreshed', {
+            context: lastRefresh && 'load',
+            refresh: lastRefresh && helpers.getTimeDisplayHowLongAgo(lastRefresh)
+          })}
         </span>
       </Button>
     );

--- a/src/components/refreshTimeButton/refreshTimeButton.js
+++ b/src/components/refreshTimeButton/refreshTimeButton.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon } from 'patternfly-react';
+import { Button } from '@patternfly/react-core';
+import { RebootingIcon } from '@patternfly/react-icons';
 import { helpers } from '../../common/helpers';
+import { translate } from '../i18n/i18n';
 
 class RefreshTimeButton extends React.Component {
   pollingInterval = null;
@@ -43,13 +45,13 @@ class RefreshTimeButton extends React.Component {
   }
 
   render() {
-    const { lastRefresh, onRefresh } = this.props;
+    const { lastRefresh, onRefresh, t } = this.props;
 
     return (
-      <Button onClick={onRefresh} bsStyle="link" className="refresh-button">
-        <Icon type="fa" name="refresh" />
+      <Button variant="link" icon={<RebootingIcon />} onClick={onRefresh}>
         <span className="last-refresh-time">
-          Refreshed {lastRefresh && helpers.getTimeDisplayHowLongAgo(lastRefresh)}
+          {t('refresh-time-button.refreshed', { context: 'load' })}
+          {lastRefresh && helpers.getTimeDisplayHowLongAgo(lastRefresh)}
         </span>
       </Button>
     );
@@ -58,11 +60,13 @@ class RefreshTimeButton extends React.Component {
 
 RefreshTimeButton.propTypes = {
   lastRefresh: PropTypes.number,
-  onRefresh: PropTypes.func.isRequired
+  onRefresh: PropTypes.func.isRequired,
+  t: PropTypes.func
 };
 
 RefreshTimeButton.defaultProps = {
-  lastRefresh: 0
+  lastRefresh: 0,
+  t: translate
 };
 
 export { RefreshTimeButton as default, RefreshTimeButton };

--- a/src/components/viewToolbar/__tests__/__snapshots__/viewToolbar.test.js.snap
+++ b/src/components/viewToolbar/__tests__/__snapshots__/viewToolbar.test.js.snap
@@ -48,17 +48,34 @@ exports[`ViewPaginationRow Component should render 1`] = `
           class="form-group"
         >
           <button
-            class="refresh-button btn btn-link"
+            aria-disabled="false"
+            class="pf-c-button pf-m-link"
+            data-ouia-component-id="OUIA-Generated-Button-link-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
             type="button"
           >
             <span
-              aria-hidden="true"
-              class="fa fa-refresh"
-            />
+              class="pf-c-button__icon pf-m-start"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 1024 1024"
+                width="1em"
+              >
+                <path
+                  d="M515.8,0 C655.3,0 781.6,58.4 873.4,150.2 L968.9,54.7 C989,34.5 1024,48.8 1024,77.3 L1024,352 C1024,369.7 1009.2,384.1 991.5,384 L716.8,384 C688.3,384 674,349.5 694.2,329.3 L783,240.5 C713.5,171.1 617.8,128 512,128 C300.4,128 128,300.2 128,512 C128,723.8 300.2,896.1 511.9,896 C606.9,896 693.9,861.2 761,803.9 C773.7,793.1 792.6,793.8 804.4,805.6 L849.6,850.9 C862.6,864 861.9,885.4 848,897.6 C758,976.3 640.3,1024 511.7,1024 C229.1,1024 0,797 0,510.7 C0,226.2 235,0 515.8,0"
+                />
+              </svg>
+            </span>
             <span
               class="last-refresh-time"
             >
-              Refreshed 0
+              t(refresh-time-button.refreshed, {"context":0,"refresh":0})
             </span>
           </button>
         </div>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
Closes #102

Refactoring `refreshTimeButton.js` to PF4 component/styling

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
Styling issue. PF-react-core `Button` with `variant="link"` makes button blue. Also, old icon used is font-awesome refresh. However, PF icons does not have refresh so `RebootingIcon` was used. Additionally, there's an alignment styling issue.

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
Before:
<img width="958" alt="Screen Shot 2022-07-06 at 3 40 13 PM" src="https://user-images.githubusercontent.com/58367784/177631428-b0abb078-77d0-449e-a18b-ef6f357c02a2.png">
<img width="958" alt="Screen Shot 2022-07-06 at 3 40 05 PM" src="https://user-images.githubusercontent.com/58367784/177631445-0ff6e0b2-5e4d-4ecc-8085-18060e69045f.png">

After:
<img width="958" alt="Screen Shot 2022-07-06 at 3 39 13 PM" src="https://user-images.githubusercontent.com/58367784/177631492-1a8e230f-9f8c-45bb-be08-2f489f241ee9.png">
<img width="958" alt="Screen Shot 2022-07-06 at 3 39 19 PM" src="https://user-images.githubusercontent.com/58367784/177631503-cf51ab54-6483-4421-9798-428b61ef9615.png">


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
<!-- [DISCOVERY-X](https://issues.redhat.com/browse/DISCOVERY-X) -->
https://issues.redhat.com/browse/DISCOVERY-148