### PR TITLE
refactor(sources): discovery-148 pf4 empty-state

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -28,6 +28,7 @@
   "view": {
     "empty-state_description_credentials": "Credentials contain authentication information needed to scan a source. A credential includes a username and a password or SSH key. {{name}} uses SSH to connect to servers on the network and uses credentials to access those servers.",
     "empty-state_description_scans": "Select a Source to scan from the Sources page.",
+    "empty-state_description_sources": "Begin by adding one or more sources. A source contains a collection of network information, including systems management solution information, IP addresses, or host names, in addition to SSH ports and credentials.",
     "empty-state_filter_description": "The active filters are hiding all items.",
     "empty-state_filter_title": "No Results Match the Filter Criteria",
     "empty-state_label_clear": "Clear Filters",
@@ -39,10 +40,12 @@
     "error_credentials": "Credentials error",
     "error_scan-jobs": "Scan jobs error",
     "error_scans": "Scans error",
+    "error_sources": "Sources error",
     "error-message_authentication": "{{message}} Please <0>login</0> to continue.",
     "error-message_credentials": "Error retrieving credentials: {{message}}",
     "error-message_scan-jobs": "Error retrieving scan jobs: {{message}}",
     "error-message_scans": "Error retrieving scans: {{message}}",
+    "error-message_sources": "Error retrieving sources: {{message}}",
     "loading": "Loading...",
     "loading_authentication": "Logging in...",
     "loading_credentials": "Loading credentials..."

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -276,6 +276,43 @@ Array [
         "key": "view.loading",
         "match": "t('view.loading', { context: 'sources' })",
       },
+      Object {
+        "key": "view.empty-state",
+        "match": "t('view.empty-state', { context: ['filter', 'title'] })",
+      },
+      Object {
+        "key": "view.empty-state",
+        "match": "t('view.empty-state', { context: ['filter', 'description'] })",
+      },
+      Object {
+        "key": "view.empty-state",
+        "match": "t('view.empty-state', { context: ['label', 'clear'] })",
+      },
+      Object {
+        "key": "view.error",
+        "match": "t('view.error', { context: 'sources' })",
+      },
+      Object {
+        "key": "view.error-message",
+        "match": "t('view.error-message', { context: ['sources'], message: errorMessage })",
+      },
+    ],
+  },
+  Object {
+    "file": "./src/components/sources/sourcesEmptyState.js",
+    "keys": Array [
+      Object {
+        "key": "view.empty-state",
+        "match": "t('view.empty-state', { context: ['title'], name: uiShortName })",
+      },
+      Object {
+        "key": "view.empty-state",
+        "match": "t('view.empty-state', { context: ['description', 'sources'] })",
+      },
+      Object {
+        "key": "view.empty-state",
+        "match": "t('view.empty-state', { context: ['label', 'source'] })",
+      },
     ],
   },
 ]
@@ -410,6 +447,38 @@ Array [
   Object {
     "file": "./src/components/scans/scanSourceList.js",
     "key": "view.error-message",
+  },
+  Object {
+    "file": "./src/components/sources/sources.js",
+    "key": "view.empty-state",
+  },
+  Object {
+    "file": "./src/components/sources/sources.js",
+    "key": "view.empty-state",
+  },
+  Object {
+    "file": "./src/components/sources/sources.js",
+    "key": "view.empty-state",
+  },
+  Object {
+    "file": "./src/components/sources/sources.js",
+    "key": "view.error",
+  },
+  Object {
+    "file": "./src/components/sources/sources.js",
+    "key": "view.error-message",
+  },
+  Object {
+    "file": "./src/components/sources/sourcesEmptyState.js",
+    "key": "view.empty-state",
+  },
+  Object {
+    "file": "./src/components/sources/sourcesEmptyState.js",
+    "key": "view.empty-state",
+  },
+  Object {
+    "file": "./src/components/sources/sourcesEmptyState.js",
+    "key": "view.empty-state",
   },
 ]
 `;

--- a/src/components/scans/__tests__/__snapshots__/scansEmptyState.test.js.snap
+++ b/src/components/scans/__tests__/__snapshots__/scansEmptyState.test.js.snap
@@ -8,45 +8,58 @@ exports[`ScansEmptyState Component should render a connected component: connecte
 
 exports[`ScansEmptyState Component should render a non-connected component: non-connected do not exist 1`] = `
 <div
-  class="fadein container-fluid"
+  class="container-fluid"
 >
   <div
     class="row"
   >
     <div
-      class="blank-slate-pf full-page-blank-slate"
+      class="pf-c-empty-state pf-m-lg quipucords-empty-state"
     >
       <div
-        class="blank-slate-pf-icon"
+        class="pf-c-empty-state__content"
       >
-        <span
+        <svg
           aria-hidden="true"
-          class="pficon pficon-add-circle-o"
-        />
-      </div>
-      <h4
-        class="h1 blank-slate-pf-title"
-      >
-        Welcome to Quipucords
-      </h4>
-      <p
-        class="blank-slate-pf-info"
-      >
-        Begin by adding one or more sources. A source contains a collection of network information, 
-        <br />
-        including systems management solution information, IP addresses, or host names, in addition to 
-        <br />
-        SSH ports and credentials.
-      </p>
-      <div
-        class="blank-slate-pf-main-action"
-      >
-        <button
-          class="btn btn-lg btn-primary"
-          type="button"
+          class="pf-c-empty-state__icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 1024 1024"
+          width="1em"
         >
-          Add Source
-        </button>
+          <path
+            d="M576,303 C576,294.715729 569.284271,288 561,288 L463,288 C454.715729,288 448,294.715729 448,303 L448,448 L303,448 C294.715729,448 288,454.715729 288,463 L288,561 C288,569.284271 294.715729,576 303,576 L448,576 L448,720.9 C447.983373,729.207373 454.6927,735.961429 463,736 L561,736 C569.3073,735.961429 576.016627,729.207373 576,720.9 L576,576 L721,576 C724.969024,576.026638 728.784638,574.468589 731.600595,571.671405 C734.416553,568.87422 736.000031,565.069113 736.000031,561.1 L736.000031,463.1 C736.016627,454.792627 729.3073,448.038571 721,448 L576,448 L576,303 Z M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 Z M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0 Z"
+          />
+        </svg>
+        <h1
+          class="pf-c-title pf-m-2xl"
+          data-ouia-component-id="OUIA-Generated-Title-2"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe="true"
+        >
+          t(view.empty-state, {"context":"title","name":"Quipucords"})
+        </h1>
+        <div
+          class="pf-c-empty-state__body"
+        >
+          t(view.empty-state, {"context":"description_sources"})
+        </div>
+        <div
+          class="pf-c-empty-state__primary"
+        >
+          <button
+            aria-disabled="false"
+            class="pf-c-button pf-m-primary"
+            data-ouia-component-id="OUIA-Generated-Button-primary-2"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            t(view.empty-state, {"context":"label_source"})
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/sources/__tests__/__snapshots__/sources.test.js.snap
+++ b/src/components/sources/__tests__/__snapshots__/sources.test.js.snap
@@ -4,69 +4,150 @@ exports[`Sources Component should render a connected component with default prop
 
 exports[`Sources Component should render a non-connected component error: error 1`] = `
 <div
-  class="blank-slate-pf"
+  class="pf-c-empty-state quipucords-empty-state__alert"
 >
   <div
-    class="alert alert-danger"
+    class="pf-c-empty-state__content"
   >
-    <span
-      aria-hidden="true"
-      class="pficon pficon-error-circle-o"
-    />
-    <span>
-      Error retrieving sources: 
-    </span>
+    <div
+      aria-label="Danger Alert"
+      class="pf-c-alert pf-m-danger"
+      data-ouia-component-id="OUIA-Generated-Alert-danger-1"
+      data-ouia-component-type="PF4/Alert"
+      data-ouia-safe="true"
+    >
+      <div
+        class="pf-c-alert__icon"
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 512 512"
+          width="1em"
+        >
+          <path
+            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+          />
+        </svg>
+      </div>
+      <h4
+        class="pf-c-alert__title"
+      >
+        <span
+          class="pf-u-screen-reader"
+        >
+          Danger alert:
+        </span>
+        t(view.error, {"context":"sources"})
+      </h4>
+      <div
+        class="pf-c-alert__description"
+      >
+        t(view.error-message, {"context":"sources","message":null})
+      </div>
+    </div>
   </div>
 </div>
 `;
 
 exports[`Sources Component should render a non-connected component pending: pending 1`] = `
 <div
-  class="quipucords-view-container"
-/>
+  class="pf-c-backdrop"
+>
+  <div
+    class="pf-l-bullseye"
+  >
+    <div
+      aria-describedby="pf-modal-part-2"
+      aria-label="t(modal.aria-label-default)"
+      aria-labelledby="pf-modal-part-0"
+      aria-modal="true"
+      class="pf-c-modal-box pf-m-align-top pf-m-md"
+      data-ouia-component-id="OUIA-Generated-Modal-medium-1"
+      data-ouia-component-type="PF4/ModalContent"
+      data-ouia-safe="true"
+      id="pf-modal-part-0"
+      role="dialog"
+      style="--pf-c-modal-box--m-align-top--spacer: 5%;"
+    >
+      <div
+        aria-live="polite"
+        class="pf-c-modal-box__body"
+        id="pf-modal-part-2"
+      >
+        <div>
+          <div
+            class="blank-slate-pf-icon spinner spinner-lg"
+          />
+          <div
+            class="text-center"
+          >
+            t(view.loading, {"context":"sources"})
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Sources Component should render a non-connected component with empty state: empty state 1`] = `
 <div
-  class="fadein container-fluid"
+  class="container-fluid"
 >
   <div
     class="row"
   >
     <div
-      class="blank-slate-pf full-page-blank-slate"
+      class="pf-c-empty-state pf-m-lg quipucords-empty-state"
     >
       <div
-        class="blank-slate-pf-icon"
+        class="pf-c-empty-state__content"
       >
-        <span
+        <svg
           aria-hidden="true"
-          class="pficon pficon-add-circle-o"
-        />
-      </div>
-      <h4
-        class="h1 blank-slate-pf-title"
-      >
-        Welcome to Quipucords
-      </h4>
-      <p
-        class="blank-slate-pf-info"
-      >
-        Begin by adding one or more sources. A source contains a collection of network information, 
-        <br />
-        including systems management solution information, IP addresses, or host names, in addition to 
-        <br />
-        SSH ports and credentials.
-      </p>
-      <div
-        class="blank-slate-pf-main-action"
-      >
-        <button
-          class="btn btn-lg btn-primary"
-          type="button"
+          class="pf-c-empty-state__icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 1024 1024"
+          width="1em"
         >
-          Add Source
-        </button>
+          <path
+            d="M576,303 C576,294.715729 569.284271,288 561,288 L463,288 C454.715729,288 448,294.715729 448,303 L448,448 L303,448 C294.715729,448 288,454.715729 288,463 L288,561 C288,569.284271 294.715729,576 303,576 L448,576 L448,720.9 C447.983373,729.207373 454.6927,735.961429 463,736 L561,736 C569.3073,735.961429 576.016627,729.207373 576,720.9 L576,576 L721,576 C724.969024,576.026638 728.784638,574.468589 731.600595,571.671405 C734.416553,568.87422 736.000031,565.069113 736.000031,561.1 L736.000031,463.1 C736.016627,454.792627 729.3073,448.038571 721,448 L576,448 L576,303 Z M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 Z M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0 Z"
+          />
+        </svg>
+        <h1
+          class="pf-c-title pf-m-2xl"
+          data-ouia-component-id="OUIA-Generated-Title-1"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe="true"
+        >
+          t(view.empty-state, {"context":"title","name":"Quipucords"})
+        </h1>
+        <div
+          class="pf-c-empty-state__body"
+        >
+          t(view.empty-state, {"context":"description_sources"})
+        </div>
+        <div
+          class="pf-c-empty-state__primary"
+        >
+          <button
+            aria-disabled="false"
+            class="pf-c-button pf-m-primary"
+            data-ouia-component-id="OUIA-Generated-Button-primary-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            t(view.empty-state, {"context":"label_source"})
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/sources/__tests__/__snapshots__/sourcesEmptyState.test.js.snap
+++ b/src/components/sources/__tests__/__snapshots__/sourcesEmptyState.test.js.snap
@@ -2,45 +2,58 @@
 
 exports[`SourcesEmptyState Component should render a basic component 1`] = `
 <div
-  class="fadein container-fluid"
+  class="container-fluid"
 >
   <div
     class="row"
   >
     <div
-      class="blank-slate-pf full-page-blank-slate"
+      class="pf-c-empty-state pf-m-lg quipucords-empty-state"
     >
       <div
-        class="blank-slate-pf-icon"
+        class="pf-c-empty-state__content"
       >
-        <span
+        <svg
           aria-hidden="true"
-          class="pficon pficon-add-circle-o"
-        />
-      </div>
-      <h4
-        class="h1 blank-slate-pf-title"
-      >
-        Welcome to Quipucords
-      </h4>
-      <p
-        class="blank-slate-pf-info"
-      >
-        Begin by adding one or more sources. A source contains a collection of network information, 
-        <br />
-        including systems management solution information, IP addresses, or host names, in addition to 
-        <br />
-        SSH ports and credentials.
-      </p>
-      <div
-        class="blank-slate-pf-main-action"
-      >
-        <button
-          class="btn btn-lg btn-primary"
-          type="button"
+          class="pf-c-empty-state__icon"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 1024 1024"
+          width="1em"
         >
-          Add Source
-        </button>
+          <path
+            d="M576,303 C576,294.715729 569.284271,288 561,288 L463,288 C454.715729,288 448,294.715729 448,303 L448,448 L303,448 C294.715729,448 288,454.715729 288,463 L288,561 C288,569.284271 294.715729,576 303,576 L448,576 L448,720.9 C447.983373,729.207373 454.6927,735.961429 463,736 L561,736 C569.3073,735.961429 576.016627,729.207373 576,720.9 L576,576 L721,576 C724.969024,576.026638 728.784638,574.468589 731.600595,571.671405 C734.416553,568.87422 736.000031,565.069113 736.000031,561.1 L736.000031,463.1 C736.016627,454.792627 729.3073,448.038571 721,448 L576,448 L576,303 Z M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 Z M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0 Z"
+          />
+        </svg>
+        <h1
+          class="pf-c-title pf-m-2xl"
+          data-ouia-component-id="OUIA-Generated-Title-1"
+          data-ouia-component-type="PF4/Title"
+          data-ouia-safe="true"
+        >
+          t(view.empty-state, {"context":"title","name":"Quipucords"})
+        </h1>
+        <div
+          class="pf-c-empty-state__body"
+        >
+          t(view.empty-state, {"context":"description_sources"})
+        </div>
+        <div
+          class="pf-c-empty-state__primary"
+        >
+          <button
+            aria-disabled="false"
+            class="pf-c-button pf-m-primary"
+            data-ouia-component-id="OUIA-Generated-Button-primary-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            t(view.empty-state, {"context":"label_source"})
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -48,14 +61,16 @@ exports[`SourcesEmptyState Component should render a basic component 1`] = `
 `;
 
 exports[`SourcesEmptyState Component should render the application name: application name 1`] = `
-<EmptyStateTitle
-  className=""
+<Title
+  headingLevel="h1"
 >
-  <h4
-    className="h1 blank-slate-pf-title"
+  <h1
+    className="pf-c-title pf-m-2xl"
+    data-ouia-component-id="OUIA-Generated-Title-2"
+    data-ouia-component-type="PF4/Title"
+    data-ouia-safe={true}
   >
-    Welcome to 
-    Ipsum
-  </h4>
-</EmptyStateTitle>
+    t(view.empty-state, {"context":"title","name":"Ipsum"})
+  </h1>
+</Title>
 `;

--- a/src/components/sources/__tests__/sourcesEmptyState.test.js
+++ b/src/components/sources/__tests__/sourcesEmptyState.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { EmptyState } from 'patternfly-react';
+import { Title } from '@patternfly/react-core';
 import SourcesEmptyState from '../sourcesEmptyState';
 
 describe('SourcesEmptyState Component', () => {
@@ -17,6 +17,6 @@ describe('SourcesEmptyState Component', () => {
     };
 
     const component = mount(<SourcesEmptyState {...props} />);
-    expect(component.find(EmptyState.Title)).toMatchSnapshot('application name');
+    expect(component.find(Title)).toMatchSnapshot('application name');
   });
 });

--- a/src/components/sources/sources.js
+++ b/src/components/sources/sources.js
@@ -2,7 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _isEqual from 'lodash/isEqual';
 import _size from 'lodash/size';
-import { Alert, Button, EmptyState, ListView, Spinner } from 'patternfly-react';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  EmptyStateVariant,
+  Title,
+  TitleSizes
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { Button as ButtonPf3, ListView, Spinner } from 'patternfly-react';
 import { Modal, ModalVariant } from '../modal/modal';
 import { connect, reduxActions, reduxTypes, store } from '../../redux';
 import helpers from '../../common/helpers';
@@ -14,6 +28,9 @@ import { SourceFilterFields, SourceSortFields } from './sourceConstants';
 import { apiTypes } from '../../constants/apiConstants';
 import { translate } from '../i18n/i18n';
 
+/**
+ * A sources view.
+ */
 class Sources extends React.Component {
   componentDidMount() {
     const { getSources, viewOptions } = this.props;
@@ -65,15 +82,15 @@ class Sources extends React.Component {
 
     return (
       <div className="form-group">
-        <Button bsStyle="primary" onClick={this.onShowAddSourceWizard}>
+        <ButtonPf3 bsStyle="primary" onClick={this.onShowAddSourceWizard}>
           Add
-        </Button>
-        <Button
+        </ButtonPf3>
+        <ButtonPf3
           disabled={!viewOptions.selectedItems || viewOptions.selectedItems.length === 0}
           onClick={this.onScanSources}
         >
           Scan
-        </Button>
+        </ButtonPf3>
       </div>
     );
   }
@@ -94,7 +111,7 @@ class Sources extends React.Component {
   }
 
   renderSourcesList(sources) {
-    const { lastRefresh } = this.props;
+    const { lastRefresh, t } = this.props;
 
     if (sources.length) {
       return (
@@ -107,34 +124,36 @@ class Sources extends React.Component {
     }
 
     return (
-      <EmptyState className="list-view-blank-slate">
-        <EmptyState.Title>No Results Match the Filter Criteria</EmptyState.Title>
-        <EmptyState.Info>The active filters are hiding all items.</EmptyState.Info>
-        <EmptyState.Action>
-          <Button bsStyle="link" onClick={this.onClearFilters}>
-            Clear Filters
+      <EmptyState className="quipucords-empty-state" variant={EmptyStateVariant.large}>
+        <EmptyStateIcon icon={SearchIcon} />
+        <Title size={TitleSizes.lg} headingLevel="h1">
+          {t('view.empty-state', { context: ['filter', 'title'] })}
+        </Title>
+        <EmptyStateBody>{t('view.empty-state', { context: ['filter', 'description'] })}</EmptyStateBody>
+        <EmptyStatePrimary>
+          <Button variant={ButtonVariant.link} onClick={this.onClearFilters}>
+            {t('view.empty-state', { context: ['label', 'clear'] })}
           </Button>
-        </EmptyState.Action>
+        </EmptyStatePrimary>
       </EmptyState>
     );
   }
 
   render() {
-    const { error, errorMessage, lastRefresh, pending, sources, viewOptions } = this.props;
+    const { error, errorMessage, lastRefresh, pending, sources, t, viewOptions } = this.props;
+
+    if (pending && !sources.length) {
+      return this.renderPendingMessage();
+    }
 
     if (error) {
       return (
-        <EmptyState>
-          <Alert type="error">
-            <span>Error retrieving sources: {errorMessage}</span>
+        <EmptyState className="quipucords-empty-state__alert">
+          <Alert variant={AlertVariant.danger} title={t('view.error', { context: 'sources' })}>
+            {t('view.error-message', { context: ['sources'], message: errorMessage })}
           </Alert>
-          {this.renderPendingMessage()}
         </EmptyState>
       );
-    }
-
-    if (pending && !sources.length) {
-      return <div className="quipucords-view-container">{this.renderPendingMessage()}</div>;
     }
 
     if (sources.length || _size(viewOptions.activeFilters)) {
@@ -163,6 +182,12 @@ class Sources extends React.Component {
   }
 }
 
+/**
+ * Prop types
+ *
+ * @type {{sources: Array, t: Function, lastRefresh: number, pending: boolean, errorMessage: string,
+ *     getSources: Function, error: boolean, updateSources: boolean, viewOptions: object}}
+ */
 Sources.propTypes = {
   error: PropTypes.bool,
   errorMessage: PropTypes.string,
@@ -175,6 +200,12 @@ Sources.propTypes = {
   viewOptions: PropTypes.object
 };
 
+/**
+ * Default props
+ *
+ * @type {{sources: *[], t: Function, lastRefresh: number, pending: boolean, errorMessage: null,
+ *     getSources: Function, error: boolean, updateSources: boolean, viewOptions: {}}}
+ */
 Sources.defaultProps = {
   error: false,
   errorMessage: null,

--- a/src/components/sources/sourcesEmptyState.js
+++ b/src/components/sources/sourcesEmptyState.js
@@ -1,37 +1,63 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, EmptyState, Grid, Row } from 'patternfly-react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  EmptyStateVariant,
+  Title
+} from '@patternfly/react-core';
+import { AddCircleOIcon } from '@patternfly/react-icons';
+import { Grid, Row } from 'patternfly-react';
 import helpers from '../../common/helpers';
+import { translate } from '../i18n/i18n';
 
-const SourcesEmptyState = ({ onAddSource, uiShortName }) => (
-  <Grid fluid className="fadein">
+/**
+ * Return a sources empty state.
+ *
+ * @param {object} props
+ * @param {Function} props.onAddSource
+ * @param {Function} props.t
+ * @param {string} props.uiShortName
+ * @returns {React.ReactNode}
+ */
+const SourcesEmptyState = ({ onAddSource, t, uiShortName }) => (
+  <Grid fluid>
     <Row>
-      <EmptyState className="full-page-blank-slate">
-        <EmptyState.Icon />
-        <EmptyState.Title>Welcome to {uiShortName}</EmptyState.Title>
-        <EmptyState.Info>
-          Begin by adding one or more sources. A source contains a collection of network information, <br />
-          including systems management solution information, IP addresses, or host names, in addition to <br />
-          SSH ports and credentials.
-        </EmptyState.Info>
-        <EmptyState.Action>
-          <Button bsStyle="primary" bsSize="large" onClick={onAddSource}>
-            Add Source
-          </Button>
-        </EmptyState.Action>
+      <EmptyState className="quipucords-empty-state" variant={EmptyStateVariant.large}>
+        <EmptyStateIcon icon={AddCircleOIcon} />
+        <Title headingLevel="h1">{t('view.empty-state', { context: ['title'], name: uiShortName })}</Title>
+        <EmptyStateBody>{t('view.empty-state', { context: ['description', 'sources'] })}</EmptyStateBody>
+        <EmptyStatePrimary>
+          <Button onClick={onAddSource}>{t('view.empty-state', { context: ['label', 'source'] })}</Button>
+        </EmptyStatePrimary>
       </EmptyState>
     </Row>
   </Grid>
 );
 
+/**
+ * Prop types
+ *
+ * @type {{uiShortName: string, t: Function, onAddSource: Function}}
+ */
 SourcesEmptyState.propTypes = {
   onAddSource: PropTypes.func,
-  uiShortName: PropTypes.string
+  uiShortName: PropTypes.string,
+  t: PropTypes.func
 };
 
+/**
+ * Default props
+ *
+ * @type {{uiShortName: string, t: translate, onAddSource: Function}}
+ */
 SourcesEmptyState.defaultProps = {
   onAddSource: helpers.noop,
-  uiShortName: helpers.UI_SHORT_NAME
+  uiShortName: helpers.UI_SHORT_NAME,
+  t: translate
 };
 
 export { SourcesEmptyState as default, SourcesEmptyState };


### PR DESCRIPTION
## What's included

#### Code Refactoring
1. **sources** discovery-148 pf4 empty-state


<!-- ### Notes -->

## How to test
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. navigate to the sources view, with zero sources the initial welcome message should display
1. next add a source, then filter it so NO sources display, and confirm the empty state filter with magnifying glass displays
1. recreating the error we handled by modifying the Redux state layer... open the `./src/components/sources/sources.js` file and add the two lines for `, error: true, errorMessage: 'Lorem ipsum'`
   ```
    const mapStateToProps = state => ({
      ...state.sources.view,
      viewOptions: state.viewOptions[reduxTypes.view.SOURCES_VIEW],
      error: true,
      errorMessage: 'Lorem ipsum'
    });
   ```
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
### BEFORE
![Screen Shot 2022-07-12 at 4 26 23 PM](https://user-images.githubusercontent.com/3761375/178589044-632a9a3f-0350-4cd3-93c6-02a2d26bf7be.png)
![Screen Shot 2022-07-12 at 4 25 55 PM](https://user-images.githubusercontent.com/3761375/178589058-c5ffc890-739b-4077-b022-a07c938038b7.png)
![Screen Shot 2022-07-12 at 4 26 44 PM](https://user-images.githubusercontent.com/3761375/178589073-f36c49a6-f1f1-4bba-97f7-495eecdbe895.png)
### AFTER


![Screen Shot 2022-07-12 at 4 22 10 PM](https://user-images.githubusercontent.com/3761375/178588055-4950224c-2604-4ade-ab5d-d2cb2ce24560.png)
![Screen Shot 2022-07-12 at 4 20 00 PM](https://user-images.githubusercontent.com/3761375/178588063-09bc8611-ea76-4913-a356-4e14745647f4.png)
![Screen Shot 2022-07-12 at 4 23 02 PM](https://user-images.githubusercontent.com/3761375/178588072-0e2ab17a-7537-49ea-acda-9ebd856d31c4.png)


## Updates issue/story
[DISCOVERY-148](https://issues.redhat.com/browse/DISCOVERY-148)
#99 
