### PR TITLE
refactor(buttons): convert buttons on Sources screen to PF4

### DIFF
--- a/src/components/sources/__tests__/__snapshots__/sourceListItem.test.js.snap
+++ b/src/components/sources/__tests__/__snapshots__/sourceListItem.test.js.snap
@@ -33,34 +33,62 @@ exports[`SourceListItem Component should render a non-connected component: non-c
   <div
     class="list-view-pf-actions"
   >
-    <span>
-      <button
-        class="btn btn-link"
-        type="button"
+    <button
+      aria-disabled="false"
+      aria-label="Edit"
+      class="pf-c-button pf-m-plain quipucords-view__row-button"
+      data-ouia-component-id="OUIA-Generated-Button-plain-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe="true"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 512 512"
+        width="1em"
       >
-        <span
-          aria-hidden="true"
-          aria-label="Edit"
-          class="pficon pficon-edit"
+        <path
+          d="M497.9 142.1l-46.1 46.1c-4.7 4.7-12.3 4.7-17 0l-111-111c-4.7-4.7-4.7-12.3 0-17l46.1-46.1c18.7-18.7 49.1-18.7 67.9 0l60.1 60.1c18.8 18.7 18.8 49.1 0 67.9zM284.2 99.8L21.6 362.4.4 483.9c-2.9 16.4 11.4 30.6 27.8 27.8l121.5-21.3 262.6-262.6c4.7-4.7 4.7-12.3 0-17l-111-111c-4.8-4.7-12.4-4.7-17.1 0zM124.1 339.9c-5.5-5.5-5.5-14.3 0-19.8l154-154c5.5-5.5 14.3-5.5 19.8 0s5.5 14.3 0 19.8l-154 154c-5.5 5.5-14.3 5.5-19.8 0zM88 424h48v36.3l-64.5 11.3-31.1-31.1L51.7 376H88v48z"
         />
-      </button>
-      <button
-        class="btn btn-link"
-        type="button"
+      </svg>
+    </button>
+    <button
+      aria-disabled="false"
+      aria-label="Delete"
+      class="pf-c-button pf-m-plain quipucords-view__row-button"
+      data-ouia-component-id="OUIA-Generated-Button-plain-2"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe="true"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style="vertical-align: -0.125em;"
+        viewBox="0 0 448 512"
+        width="1em"
       >
-        <span
-          aria-hidden="true"
-          aria-label="Delete"
-          class="pficon pficon-delete"
+        <path
+          d="M432 32H312l-9.4-18.7A24 24 0 0 0 281.1 0H166.8a23.72 23.72 0 0 0-21.4 13.3L136 32H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16zM53.2 467a48 48 0 0 0 47.9 45h245.8a48 48 0 0 0 47.9-45L416 128H32z"
         />
-      </button>
-      <button
-        class="btn btn-default"
-        type="button"
-      >
-        Scan
-      </button>
-    </span>
+      </svg>
+    </button>
+    <button
+      aria-disabled="false"
+      class="pf-c-button pf-m-secondary"
+      data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe="true"
+      type="button"
+    >
+      Scan
+    </button>
   </div>
   <div
     class="list-view-pf-main-info"

--- a/src/components/sources/__tests__/__snapshots__/sources.test.js.snap
+++ b/src/components/sources/__tests__/__snapshots__/sources.test.js.snap
@@ -151,30 +151,21 @@ exports[`Sources Component should render a non-connected component: non-connecte
 >
   <ViewToolbar
     actions={
-      <div
-        className="form-group"
-      >
+      <React.Fragment>
         <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="primary"
-          disabled={false}
           onClick={[Function]}
         >
           Add
         </Button>
+         
         <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="default"
-          disabled={true}
+          isDisabled={true}
           onClick={[Function]}
+          variant="secondary"
         >
           Scan
         </Button>
-      </div>
+      </React.Fragment>
     }
     activeFilters={Array []}
     filterFields={

--- a/src/components/sources/sourceListItem.js
+++ b/src/components/sources/sourceListItem.js
@@ -141,7 +141,7 @@ class SourceListItem extends React.Component {
 
     return (
       <React.Fragment>
-        <ToolTip content="Edit">
+        <ToolTip key="tooltip-edit" content="Edit">
           <Button
             className="quipucords-view__row-button"
             onClick={() => this.onEdit(item)}
@@ -151,7 +151,7 @@ class SourceListItem extends React.Component {
             <PencilAltIcon />
           </Button>
         </ToolTip>
-        <ToolTip content="Delete">
+        <ToolTip key="tooltip-delete" content="Delete">
           <Button
             className="quipucords-view__row-button"
             onClick={() => this.onDelete(item)}
@@ -161,7 +161,7 @@ class SourceListItem extends React.Component {
             <TrashIcon />
           </Button>
         </ToolTip>
-        <Button variant={ButtonVariant.secondary} onClick={() => this.onScan(item)}>
+        <Button key="button-scan" variant={ButtonVariant.secondary} onClick={() => this.onScan(item)}>
           Scan
         </Button>
       </React.Fragment>

--- a/src/components/sources/sourceListItem.js
+++ b/src/components/sources/sourceListItem.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { Button, Checkbox, Grid, Icon, ListView } from 'patternfly-react';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { PencilAltIcon, TrashIcon } from '@patternfly/react-icons';
+import { Checkbox, Grid, Icon, ListView } from 'patternfly-react';
 import _get from 'lodash/get';
 import _size from 'lodash/size';
 import { connect, reduxActions, reduxTypes, store } from '../../redux';
@@ -138,19 +140,31 @@ class SourceListItem extends React.Component {
     const { item } = this.props;
 
     return (
-      <span>
+      <React.Fragment>
         <ToolTip content="Edit">
-          <Button onClick={() => this.onEdit(item)} bsStyle="link">
-            <Icon type="pf" name="edit" aria-label="Edit" />
+          <Button
+            className="quipucords-view__row-button"
+            onClick={() => this.onEdit(item)}
+            aria-label="Edit"
+            variant={ButtonVariant.plain}
+          >
+            <PencilAltIcon />
           </Button>
         </ToolTip>
         <ToolTip content="Delete">
-          <Button onClick={() => this.onDelete(item)} bsStyle="link">
-            <Icon type="pf" name="delete" aria-label="Delete" />
+          <Button
+            className="quipucords-view__row-button"
+            onClick={() => this.onDelete(item)}
+            aria-label="Delete"
+            variant={ButtonVariant.plain}
+          >
+            <TrashIcon />
           </Button>
         </ToolTip>
-        <Button onClick={() => this.onScan(item)}>Scan</Button>
-      </span>
+        <Button variant={ButtonVariant.secondary} onClick={() => this.onScan(item)}>
+          Scan
+        </Button>
+      </React.Fragment>
     );
   }
 
@@ -311,7 +325,7 @@ class SourceListItem extends React.Component {
         itemDescription = (
           <ListView.DescriptionText>
             <ToolTip isPopover content={itemHostsPopover} placement="left">
-              <Button bsStyle="link" className="quipucords-sources-network-button">
+              <Button variant={ButtonVariant.link} isInline>
                 Network Range
               </Button>
             </ToolTip>

--- a/src/components/sources/sources.js
+++ b/src/components/sources/sources.js
@@ -16,7 +16,7 @@ import {
   TitleSizes
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { Button as ButtonPf3, ListView, Spinner } from 'patternfly-react';
+import { ListView, Spinner } from 'patternfly-react';
 import { Modal, ModalVariant } from '../modal/modal';
 import { connect, reduxActions, reduxTypes, store } from '../../redux';
 import helpers from '../../common/helpers';
@@ -81,17 +81,16 @@ class Sources extends React.Component {
     const { viewOptions } = this.props;
 
     return (
-      <div className="form-group">
-        <ButtonPf3 bsStyle="primary" onClick={this.onShowAddSourceWizard}>
-          Add
-        </ButtonPf3>
-        <ButtonPf3
-          disabled={!viewOptions.selectedItems || viewOptions.selectedItems.length === 0}
+      <React.Fragment>
+        <Button onClick={this.onShowAddSourceWizard}>Add</Button>{' '}
+        <Button
+          variant={ButtonVariant.secondary}
+          isDisabled={!viewOptions.selectedItems || viewOptions.selectedItems.length === 0}
           onClick={this.onScanSources}
         >
           Scan
-        </ButtonPf3>
-      </div>
+        </Button>
+      </React.Fragment>
     );
   }
 

--- a/src/styles/app/_views.scss
+++ b/src/styles/app/_views.scss
@@ -58,7 +58,7 @@
   .list-view-pf-actions {
     margin-left: 0;
     text-align: right;
-    width: 150px;
+    min-width: 150px;
 
     .btn-link {
       color: var(--pf-global--palette--black-700);
@@ -222,10 +222,6 @@
   }
 }
 
-.quipucords-sources-network-button {
-  padding-left: 0;
-}
-
 .blank-slate-pf.full-page-blank-slate {
   border: none;
 }
@@ -280,4 +276,8 @@
 
 .quipucords-view__pagination {
   padding-bottom: 0 !important;
+}
+
+.quipucords-view__row-button {
+  margin-left: inherit !important;
 }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
Towards #134, ~closes #135~

**Before:**
<img width="1728" alt="sources_buttons_before" src="https://user-images.githubusercontent.com/32821331/182471363-a0b0f44c-4455-4e39-8bee-5299b664db1d.png">

**After:**
<img width="1728" alt="Screen Shot 2022-08-02 at 4 46 02 PM" src="https://user-images.githubusercontent.com/32821331/182471070-50e9da94-629f-457b-a6a6-e1b9928182d8.png">