### PR TITLE
refactor(Alert): convert alert in Create Scan Dialog to PF4

### DIFF
--- a/src/components/createScanDialog/__tests__/__snapshots__/createScanDialog.test.js.snap
+++ b/src/components/createScanDialog/__tests__/__snapshots__/createScanDialog.test.js.snap
@@ -16,16 +16,44 @@ Object {
 
 exports[`CreateScanDialog Component should handle multiple error responses: basic error 1`] = `
 <div
-  class="alert alert-danger"
+  aria-label="Danger Alert"
+  class="pf-c-alert pf-m-inline pf-m-danger"
+  data-ouia-component-id="OUIA-Generated-Alert-danger-1"
+  data-ouia-component-type="PF4/Alert"
+  data-ouia-safe="true"
 >
-  <span
-    aria-hidden="true"
-    class="pficon pficon-error-circle-o"
-  />
-  <strong>
+  <div
+    class="pf-c-alert__icon"
+  >
+    <svg
+      aria-hidden="true"
+      fill="currentColor"
+      height="1em"
+      role="img"
+      style="vertical-align: -0.125em;"
+      viewBox="0 0 512 512"
+      width="1em"
+    >
+      <path
+        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+      />
+    </svg>
+  </div>
+  <h4
+    class="pf-c-alert__title"
+  >
+    <span
+      class="pf-u-screen-reader"
+    >
+      Danger alert:
+    </span>
     Error
-  </strong>
-   lorem ipsum
+  </h4>
+  <div
+    class="pf-c-alert__description"
+  >
+    lorem ipsum
+  </div>
 </div>
 `;
 

--- a/src/components/createScanDialog/__tests__/createScanDialog.test.js
+++ b/src/components/createScanDialog/__tests__/createScanDialog.test.js
@@ -52,7 +52,9 @@ describe('CreateScanDialog Component', () => {
     };
 
     const component = mount(<CreateScanDialog {...props} />);
-    expect(component.find('div[className~="alert-danger"]').render()).toMatchSnapshot('basic error');
+    expect(component.find('div[className="pf-c-alert pf-m-inline pf-m-danger"]').render()).toMatchSnapshot(
+      'basic error'
+    );
 
     component.setProps({ submitErrorMessages: { scanName: 'lorem ipsum' } });
     expect(component.find('div[className~="has-error"]').render()).toMatchSnapshot('named error');

--- a/src/components/createScanDialog/__tests__/createScanDialog.test.js
+++ b/src/components/createScanDialog/__tests__/createScanDialog.test.js
@@ -52,9 +52,7 @@ describe('CreateScanDialog Component', () => {
     };
 
     const component = mount(<CreateScanDialog {...props} />);
-    expect(component.find('div[className="pf-c-alert pf-m-inline pf-m-danger"]').render()).toMatchSnapshot(
-      'basic error'
-    );
+    expect(component.find('div[className*="danger"]').render()).toMatchSnapshot('basic error');
 
     component.setProps({ submitErrorMessages: { scanName: 'lorem ipsum' } });
     expect(component.find('div[className~="has-error"]').render()).toMatchSnapshot('named error');

--- a/src/components/createScanDialog/createScanDialog.js
+++ b/src/components/createScanDialog/createScanDialog.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, ButtonVariant, Title } from '@patternfly/react-core';
-import { Alert, FieldLevelHelp, Form, Spinner } from 'patternfly-react';
+import { Alert, AlertVariant, Button, ButtonVariant, Title } from '@patternfly/react-core';
+import { FieldLevelHelp, Form, Spinner } from 'patternfly-react';
 import { Modal } from '../modal/modal';
 import { connect, reduxActions, reduxTypes, store } from '../../redux';
 import { FormState } from '../formState/formState';
@@ -312,8 +312,8 @@ class CreateScanDialog extends React.Component {
 
     if (error && !Object.keys(submitErrorMessages).length) {
       return (
-        <Alert type="error">
-          <strong>Error</strong> {errorMessage}
+        <Alert isInline variant={AlertVariant.danger} title="Error">
+          {errorMessage}
         </Alert>
       );
     }


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
...
Closes https://github.com/quipucords/quipucords-ui/issues/91; converts instance of createScanDialog `Alert` to PF4.

Extends and follows code style of https://github.com/quipucords/quipucords-ui/pull/108/files.

Also updated [createScanDialog.test.js](https://github.com/quipucords/quipucords-ui/compare/dev...jenny-s51:createScanDialog_alert?expand=1#diff-2226e7fecf59cdb8c1ea3ac7e3b60b26ec20a3048d4ebf9567872514c54e9d19) to get the new PF4 alert by its updated classname.

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

### Before
<img width="597" alt="Screen Shot 2022-08-24 at 11 43 50 AM" src="https://user-images.githubusercontent.com/32821331/186467374-e220eed7-2d86-4910-9759-d207f74d73d9.png">

### After
<img width="597" alt="Screen Shot 2022-08-24 at 11 48 25 AM" src="https://user-images.githubusercontent.com/32821331/186467493-f7759963-bab4-43aa-b73e-47e099a63c25.png">


