### PR TITLE
cleanup(proptypes): remove propTypes.string where propTypes.node is used

### DIFF
--- a/src/components/poll/poll.js
+++ b/src/components/poll/poll.js
@@ -45,7 +45,7 @@ class Poll extends React.Component {
 }
 
 Poll.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  children: PropTypes.node.isRequired,
   itemId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   itemIdCheck: PropTypes.bool.isRequired,
   interval: PropTypes.number,

--- a/src/components/scans/scanDownload.js
+++ b/src/components/scans/scanDownload.js
@@ -57,7 +57,7 @@ class ScanDownload extends React.Component {
 }
 
 ScanDownload.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  children: PropTypes.node,
   tooltip: PropTypes.string,
   downloadId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   downloadName: PropTypes.string,


### PR DESCRIPTION
required:
we need to move `poll.js` and `scanDownload.js` into their own PR pointed at the `dev` branch

reason:
because we're doing feature branching with `forms` and the related fields as a standalone aspect we have to be diligent in trying to avoid potential merge conflicts, and focused on the feature itself, forms. Both `poll.js` and `scanDownload.js` are  outside of that feature scope and can be updated on the primary development branch. Additionally, `poll.js` is most likely going to be removed in the future ... part of the `scans` table refactors

_Originally posted by @cdcabrera in https://github.com/quipucords/quipucords-ui/pull/150#discussion_r963758310_