### PR TITLE
fix(sources): discovery-154, activate scans button

### DIFF
--- a/src/components/sources/sources.js
+++ b/src/components/sources/sources.js
@@ -93,7 +93,7 @@ const Sources = ({
       <Button onClick={onShowAddSourceWizard}>{t('table.label', { context: 'add' })}</Button>{' '}
       <Button
         variant={ButtonVariant.secondary}
-        isDisabled={Object.values(selectedRows).filter(val => val !== null).length === 0}
+        isDisabled={Object.values(selectedRows).filter(val => val !== null).length <= 1}
         onClick={onScanSources}
       >
         {t('table.label', { context: 'scan' })}


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- fix(sources): discovery-154, activate scans button

### Notes
- makes it so 2 or more selections activate the scan button in the upper right toolbar, currently it's set for 1 or more
- makes it consistent with the merge reports dialog on scans, and the credentials toolbar delete button 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. navigate to sources and confirm it now takes 2 or more selections to activate the toolbar `scans` button

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screen Shot 2022-09-15 at 6 55 17 PM](https://user-images.githubusercontent.com/3761375/190522922-9f36620f-b7cf-40ed-9bd5-1ce6aed70483.png)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-154](https://issues.redhat.com/browse/DISCOVERY-154)
