### PR TITLE
fix(server): discovery-198 replace assets paths

### DIFF
--- a/templates/registration/logged_out.html
+++ b/templates/registration/logged_out.html
@@ -4,9 +4,9 @@
 {% load static %}
 
 {% block includes %}
-  <link rel="stylesheet" href="{% static '/assets/rcue/css/rcue.css' %}">
-  <link rel="stylesheet" href="{% static '/assets/rcue/css/rcue-additions.css' %}">
-  <link rel="stylesheet" href="{% static '/assets/css/index.css' %}">
+  <link rel="stylesheet" href="{% static 'assets/rcue/css/rcue.css' %}">
+  <link rel="stylesheet" href="{% static 'assets/rcue/css/rcue-additions.css' %}">
+  <link rel="stylesheet" href="{% static 'assets/css/index.css' %}">
 {% endblock %}
 
 {% block pagetitle %}
@@ -14,11 +14,11 @@
 {% endblock %}
 
 {% block pagelogo %}
-<img src="{% static '/assets/images/logo{{UI_BRAND_LABEL}}.svg' %}" alt="logo" style="height: 40px;" />
+<img src="{% static 'assets/images/logo{{UI_BRAND_LABEL}}.svg' %}" alt="logo" style="height: 40px;" />
 {% endblock %}
 
 {% block title %}
-<img class="login-title-img{{UI_BRAND_LABEL}}" src="{% static '/assets/images/title{{UI_BRAND_LABEL}}.svg' %}" alt="{% trans "{{UI_NAME}}" %}" />
+<img class="login-title-img{{UI_BRAND_LABEL}}" src="{% static 'assets/images/title{{UI_BRAND_LABEL}}.svg' %}" alt="{% trans "{{UI_NAME}}" %}" />
 {% endblock %}
 
 {% block content %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -4,9 +4,9 @@
 {% load static %}
 
 {% block includes %}
-  <link rel="stylesheet" href="{% static '/assets/rcue/css/rcue.css' %}">
-  <link rel="stylesheet" href="{% static '/assets/rcue/css/rcue-additions.css' %}">
-  <link rel="stylesheet" href="{% static '/assets/css/index.css' %}">
+  <link rel="stylesheet" href="{% static 'assets/rcue/css/rcue.css' %}">
+  <link rel="stylesheet" href="{% static 'assets/rcue/css/rcue-additions.css' %}">
+  <link rel="stylesheet" href="{% static 'assets/css/index.css' %}">
 {% endblock %}
 
 {% block pagetitle %}
@@ -14,11 +14,11 @@
 {% endblock %}
 
 {% block pagelogo %}
-<img src="{% static '/assets/images/logo{{UI_BRAND_LABEL}}.svg' %}" alt="logo" style="height: 40px;"/>
+<img src="{% static 'assets/images/logo{{UI_BRAND_LABEL}}.svg' %}" alt="logo" style="height: 40px;"/>
 {% endblock %}
 
 {% block title %}
-<img class="login-title-img{{UI_BRAND_LABEL}}"  src="{% static '/assets/images/title{{UI_BRAND_LABEL}}.svg' %}" alt="{% trans "{{UI_NAME}}" %}">
+<img class="login-title-img{{UI_BRAND_LABEL}}"  src="{% static 'assets/images/title{{UI_BRAND_LABEL}}.svg' %}" alt="{% trans "{{UI_NAME}}" %}">
 {% endblock %}
 
 {% block content %}

--- a/tests/__snapshots__/templates.test.js.snap
+++ b/tests/__snapshots__/templates.test.js.snap
@@ -99,9 +99,9 @@ exports[`Templates should contain templates with a specific output: login 1`] = 
 {% load static %}
 
 {% block includes %}
-  <link rel=\\"stylesheet\\" href=\\"{% static '/assets/rcue/css/rcue.css' %}\\">
-  <link rel=\\"stylesheet\\" href=\\"{% static '/assets/rcue/css/rcue-additions.css' %}\\">
-  <link rel=\\"stylesheet\\" href=\\"{% static '/assets/css/index.css' %}\\">
+  <link rel=\\"stylesheet\\" href=\\"{% static 'assets/rcue/css/rcue.css' %}\\">
+  <link rel=\\"stylesheet\\" href=\\"{% static 'assets/rcue/css/rcue-additions.css' %}\\">
+  <link rel=\\"stylesheet\\" href=\\"{% static 'assets/css/index.css' %}\\">
 {% endblock %}
 
 {% block pagetitle %}
@@ -109,11 +109,11 @@ exports[`Templates should contain templates with a specific output: login 1`] = 
 {% endblock %}
 
 {% block pagelogo %}
-<img src=\\"{% static '/assets/images/logo{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"logo\\" style=\\"height: 40px;\\"/>
+<img src=\\"{% static 'assets/images/logo{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"logo\\" style=\\"height: 40px;\\"/>
 {% endblock %}
 
 {% block title %}
-<img class=\\"login-title-img{{UI_BRAND_LABEL}}\\"  src=\\"{% static '/assets/images/title{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"{% trans \\"{{UI_NAME}}\\" %}\\">
+<img class=\\"login-title-img{{UI_BRAND_LABEL}}\\"  src=\\"{% static 'assets/images/title{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"{% trans \\"{{UI_NAME}}\\" %}\\">
 {% endblock %}
 
 {% block content %}
@@ -176,9 +176,9 @@ exports[`Templates should contain templates with a specific output: logout 1`] =
 {% load static %}
 
 {% block includes %}
-  <link rel=\\"stylesheet\\" href=\\"{% static '/assets/rcue/css/rcue.css' %}\\">
-  <link rel=\\"stylesheet\\" href=\\"{% static '/assets/rcue/css/rcue-additions.css' %}\\">
-  <link rel=\\"stylesheet\\" href=\\"{% static '/assets/css/index.css' %}\\">
+  <link rel=\\"stylesheet\\" href=\\"{% static 'assets/rcue/css/rcue.css' %}\\">
+  <link rel=\\"stylesheet\\" href=\\"{% static 'assets/rcue/css/rcue-additions.css' %}\\">
+  <link rel=\\"stylesheet\\" href=\\"{% static 'assets/css/index.css' %}\\">
 {% endblock %}
 
 {% block pagetitle %}
@@ -186,11 +186,11 @@ exports[`Templates should contain templates with a specific output: logout 1`] =
 {% endblock %}
 
 {% block pagelogo %}
-<img src=\\"{% static '/assets/images/logo{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"logo\\" style=\\"height: 40px;\\" />
+<img src=\\"{% static 'assets/images/logo{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"logo\\" style=\\"height: 40px;\\" />
 {% endblock %}
 
 {% block title %}
-<img class=\\"login-title-img{{UI_BRAND_LABEL}}\\" src=\\"{% static '/assets/images/title{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"{% trans \\"{{UI_NAME}}\\" %}\\" />
+<img class=\\"login-title-img{{UI_BRAND_LABEL}}\\" src=\\"{% static 'assets/images/title{{UI_BRAND_LABEL}}.svg' %}\\" alt=\\"{% trans \\"{{UI_NAME}}\\" %}\\" />
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
For some reason quipucords server is able to find staticfiles under `/assets` in development mode, but not in production mode.

Related to DISCOVERY-189.
## What's included
Altered the path for staticfiles on django templates

### Notes
It's impossible to log in with DEBUG mode disabled without these changes (quipucords/quipucords#2194)

## How to test
On quipucords (server - version proposed on quipucords/quipucords#2194), run
1. `make build-ui`
2. `./quipucords/manage.py collectstatic --settings quipucords.settings --no-input`
3. Run the container with /app mapped to quipucords folder with DJANGO_DEBUG env var set to false
4. Open the GUI in a browser. UI elements should be loaded and login/logout should work.
5. Repeat step 3 with DJANGO_DEBUG env var set to true, then repeat step 4

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
[DISCOVERY-198](https://issues.redhat.com/browse/DISCOVERY-198)
