### PR TITLE
fix(SourceWizard): discovery-178 sslCert default option

### DIFF
--- a/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepTwo.test.js.snap
+++ b/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepTwo.test.js.snap
@@ -527,6 +527,7 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
         <input
           aria-invalid="false"
           aria-label="checkbox input"
+          checked=""
           class="pf-c-check__input"
           data-ouia-component-id="OUIA-Generated-Checkbox-3"
           data-ouia-component-type="PF4/Checkbox"

--- a/src/components/addSourceWizard/addSourceWizardStepTwo.js
+++ b/src/components/addSourceWizard/addSourceWizardStepTwo.js
@@ -465,7 +465,7 @@ class AddSourceWizardStepTwo extends React.Component {
             <FormGroup error={stepTwoErrorMessages.options} errorMessage={stepTwoErrorMessages.options}>
               <Checkbox
                 name="optionSslCert"
-                checked={checked.optionSslCert || false}
+                checked={checked.optionSslCert}
                 isDisabled={checked.optionDisableSsl}
                 onChange={handleOnEvent}
               >
@@ -576,7 +576,7 @@ AddSourceWizardStepTwo.defaultProps = {
   hostsSingle: '',
   id: null,
   name: '',
-  optionSslCert: null,
+  optionSslCert: true,
   optionSslProtocol: 'SSLv23',
   optionDisableSsl: null,
   optionParamiko: null,


### PR DESCRIPTION
## What's included
Change the default option for Source/optionSslCert to `true`.

## Updates issue/story
[DISCOVERY-178](https://issues.redhat.com/browse/DISCOVERY-178)
