### PR TITLE
chore(build): nodejs 14 to 16

### DIFF
--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ on:
       - "*"
   pull_request:
 env:
-  COV_NODE_VERSION: 14
+  COV_NODE_VERSION: 16
   UPSTREAM_TAR: quipucords-ui-dist.tar
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Web user interface for [Quipucords](https://github.com/quipucords/quipucords), b
 
 ## Requirements
 Before developing, the basic requirements:
-   * Your system needs to be running [NodeJS version 14+ and NPM](https://nodejs.org/)
+   * Your system needs to be running [NodeJS version 16+ and NPM](https://nodejs.org/)
    * [Docker](https://docs.docker.com/engine/install/)
    * And [Yarn 1.22+](https://yarnpkg.com) for dependency and script management.
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/quipucords/quipucords-ui/issues"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- chore(build): nodejs 14 to 16

### Notes
- wrap up task for the 2022 refactors from Nov/Dec
- looks like there are issues with moving to NodeJS 18, so skipping those checks for now until the build gets updated... aka we either migrate to the next React Scripts, or straight Webpack (which might actually be easier now)
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. confirm the interface engine on package.json enforces the NodeJS 16 version check


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm the build completes 


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-110](https://issues.redhat.com/browse/DISCOVERY-110)
Ongoing
