### PR TITLE
chore(deps): Updated decode-uri-component to ^0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     "yamljs": "^0.3.0"
   },
   "resolutions": {
-    "**/eslint": "7.19.0"
+    "**/eslint": "7.19.0",
+    "decode-uri-component": "^0.3.0"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5025,10 +5025,10 @@ decimal.js@^10.2.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
   integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
 
-decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+decode-uri-component@^0.2.0, decode-uri-component@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.3.0.tgz#e9719c5cb63e4580f6e84527d2256b60bc0efe64"
+  integrity sha512-DtZDg5Xyj8fhtXChxK7OJksolzQH33uYKxOvhu49tjnNRHfwnxbxTl9g+kZvEJp5w+DMe4DTKAue20A8u8oBHg==
 
 decompress-response@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
chore(deps): Updated decode-uri-component to ^0.3.0

- Updated all indirect references to the decode-uri-component to be at least 0.3.0.
