### PR TITLE
fix(formGroup): discovery-330 pf id to fieldId

### DIFF
--- a/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepOne.test.js.snap
+++ b/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepOne.test.js.snap
@@ -8,14 +8,13 @@ exports[`AddSourceWizardStepOne Component should render a non-connected componen
   novalidate=""
 >
   <div
-    aria-labelledby="pf-random-id-0-legend"
+    aria-labelledby="sourceType-network-legend"
     class="pf-c-form__group"
-    id="generatedid-"
     role="radiogroup"
   >
     <div
       class="pf-c-form__group-label"
-      id="pf-random-id-0-legend"
+      id="sourceType-network-legend"
     >
       <span
         class="pf-c-form__label"

--- a/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepTwo.test.js.snap
+++ b/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepTwo.test.js.snap
@@ -25,13 +25,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
 >
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="name"
       >
         <span
           class="pf-c-form__label-text"
@@ -60,13 +60,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="hostsMultiple"
       >
         <span
           class="pf-c-form__label-text"
@@ -96,13 +96,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="port"
       >
         <span
           class="pf-c-form__label-text"
@@ -132,13 +132,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="generatedid-"
       >
         <span
           class="pf-c-form__label-text"
@@ -234,7 +234,6 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-control"
@@ -273,13 +272,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
 >
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="name"
       >
         <span
           class="pf-c-form__label-text"
@@ -308,13 +307,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="hostsSingle"
       >
         <span
           class="pf-c-form__label-text"
@@ -343,13 +342,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="generatedid-"
       >
         <span
           class="pf-c-form__label-text"
@@ -446,13 +445,13 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="optionSslProtocol"
       >
         <span
           class="pf-c-form__label-text"
@@ -516,7 +515,6 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-control"
@@ -581,13 +579,13 @@ exports[`AddSourceWizardStepTwo Component should render a non-connected componen
 >
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="name"
       >
         <span
           class="pf-c-form__label-text"
@@ -616,13 +614,13 @@ exports[`AddSourceWizardStepTwo Component should render a non-connected componen
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="hostsMultiple"
       >
         <span
           class="pf-c-form__label-text"
@@ -652,13 +650,13 @@ exports[`AddSourceWizardStepTwo Component should render a non-connected componen
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="port"
       >
         <span
           class="pf-c-form__label-text"
@@ -688,13 +686,13 @@ exports[`AddSourceWizardStepTwo Component should render a non-connected componen
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-label"
     >
       <label
         class="pf-c-form__label"
+        for="generatedid-"
       >
         <span
           class="pf-c-form__label-text"
@@ -790,7 +788,6 @@ exports[`AddSourceWizardStepTwo Component should render a non-connected componen
   </div>
   <div
     class="pf-c-form__group"
-    id="generatedid-"
   >
     <div
       class="pf-c-form__group-control"

--- a/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepTwo.test.js.snap
+++ b/src/components/addSourceWizard/__tests__/__snapshots__/addSourceWizardStepTwo.test.js.snap
@@ -138,7 +138,7 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
     >
       <label
         class="pf-c-form__label"
-        for="generatedid-"
+        for="addCredentials"
       >
         <span
           class="pf-c-form__label-text"
@@ -208,6 +208,7 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
           data-ouia-component-id="OUIA-Generated-Button-control-2"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
+          id="addCredentials"
           title="t(form-dialog.label, {"context":"add-credential"})"
           type="button"
         >
@@ -348,7 +349,7 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
     >
       <label
         class="pf-c-form__label"
-        for="generatedid-"
+        for="addCredentials"
       >
         <span
           class="pf-c-form__label-text"
@@ -419,6 +420,7 @@ exports[`AddSourceWizardStepTwo Component should display different forms for sou
           data-ouia-component-id="OUIA-Generated-Button-control-3"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
+          id="addCredentials"
           title="t(form-dialog.label, {"context":"add-credential"})"
           type="button"
         >
@@ -692,7 +694,7 @@ exports[`AddSourceWizardStepTwo Component should render a non-connected componen
     >
       <label
         class="pf-c-form__label"
-        for="generatedid-"
+        for="addCredentials"
       >
         <span
           class="pf-c-form__label-text"
@@ -762,6 +764,7 @@ exports[`AddSourceWizardStepTwo Component should render a non-connected componen
           data-ouia-component-id="OUIA-Generated-Button-control-1"
           data-ouia-component-type="PF4/Button"
           data-ouia-safe="true"
+          id="addCredentials"
           title="t(form-dialog.label, {"context":"add-credential"})"
           type="button"
         >

--- a/src/components/addSourceWizard/addSourceWizardStepTwo.js
+++ b/src/components/addSourceWizard/addSourceWizardStepTwo.js
@@ -378,6 +378,7 @@ class AddSourceWizardStepTwo extends React.Component {
 
     return (
       <FormGroup
+        fieldId="addCredentials"
         label={t('form-dialog.label', { context: 'credential' })}
         error={(touched.credentials && errors.credentials) || stepTwoErrorMessages.credentials}
         errorMessage={stepTwoErrorMessages.credentials || t('form-dialog.label', { context: ['credential', 'error'] })}
@@ -402,6 +403,7 @@ class AddSourceWizardStepTwo extends React.Component {
             key={`dropdown-update-${sourceCredentials.length}`}
           />
           <Button
+            id="addCredentials"
             variant={ButtonVariant.control}
             aria-label={t('form-dialog.label', { context: 'add-credential' })}
             icon={<PlusIcon />}

--- a/src/components/createScanDialog/__tests__/__snapshots__/createScanDialog.test.js.snap
+++ b/src/components/createScanDialog/__tests__/__snapshots__/createScanDialog.test.js.snap
@@ -61,7 +61,7 @@ exports[`CreateScanDialog Component should handle multiple error responses: name
 <div
   aria-live="polite"
   class="pf-c-form__helper-text pf-m-error"
-  id="undefined-helper"
+  id="scanName-helper"
 >
   lorem ipsum
 </div>
@@ -237,13 +237,13 @@ exports[`CreateScanDialog Component should render a non-connected component: non
         >
           <div
             class="pf-c-form__group"
-            id="generatedid-"
           >
             <div
               class="pf-c-form__group-label"
             >
               <label
                 class="pf-c-form__label"
+                for="scanName"
               >
                 <span
                   class="pf-c-form__label-text"
@@ -273,13 +273,13 @@ exports[`CreateScanDialog Component should render a non-connected component: non
           </div>
           <div
             class="pf-c-form__group"
-            id="generatedid-"
           >
             <div
               class="pf-c-form__group-label"
             >
               <label
                 class="pf-c-form__label"
+                for="displayScanSources"
               >
                 <span
                   class="pf-c-form__label-text"
@@ -306,13 +306,13 @@ exports[`CreateScanDialog Component should render a non-connected component: non
           </div>
           <div
             class="pf-c-form__group"
-            id="scanConcurrency"
           >
             <div
               class="pf-c-form__group-label"
             >
               <label
                 class="pf-c-form__label"
+                for="scanConcurrency"
               >
                 <span
                   class="pf-c-form__label-text"
@@ -399,13 +399,13 @@ exports[`CreateScanDialog Component should render a non-connected component: non
           </div>
           <div
             class="pf-c-form__group"
-            id="generatedid-"
           >
             <div
               class="pf-c-form__group-label"
             >
               <label
                 class="pf-c-form__label"
+                for="jbossEap"
               >
                 <span
                   class="pf-c-form__label-text"
@@ -545,13 +545,13 @@ exports[`CreateScanDialog Component should render a non-connected component: non
           </div>
           <div
             class="pf-c-form__group"
-            id="generatedid-"
           >
             <div
               class="pf-c-form__group-label"
             >
               <label
                 class="pf-c-form__label"
+                for="displayScanDirectories"
               >
                 <span
                   class="pf-c-form__label-text"

--- a/src/components/form/__tests__/__snapshots__/formGroup.test.js.snap
+++ b/src/components/form/__tests__/__snapshots__/formGroup.test.js.snap
@@ -3,7 +3,6 @@
 exports[`FormGroup Component should handle multiple error message types: boolean error message 1`] = `
 <div
   class="pf-c-form__group"
-  id="test"
 >
   <div
     class="pf-c-form__group-control"
@@ -17,7 +16,7 @@ exports[`FormGroup Component should handle multiple error message types: boolean
     <div
       aria-live="polite"
       class="pf-c-form__helper-text pf-m-error"
-      id="undefined-helper"
+      id="test-helper"
     >
       Error
     </div>
@@ -28,7 +27,6 @@ exports[`FormGroup Component should handle multiple error message types: boolean
 exports[`FormGroup Component should handle multiple error message types: node error message 1`] = `
 <div
   class="pf-c-form__group"
-  id="test"
 >
   <div
     class="pf-c-form__group-control"
@@ -49,7 +47,6 @@ exports[`FormGroup Component should handle multiple error message types: node er
 exports[`FormGroup Component should handle multiple error message types: string error message 1`] = `
 <div
   class="pf-c-form__group"
-  id="test"
 >
   <div
     class="pf-c-form__group-control"
@@ -63,7 +60,7 @@ exports[`FormGroup Component should handle multiple error message types: string 
     <div
       aria-live="polite"
       class="pf-c-form__helper-text pf-m-error"
-      id="undefined-helper"
+      id="test-helper"
     >
       lorem ipsum
     </div>
@@ -74,13 +71,13 @@ exports[`FormGroup Component should handle multiple error message types: string 
 exports[`FormGroup Component should render a basic component: basic formgroup 1`] = `
 <div
   class="pf-c-form__group"
-  id="test"
 >
   <div
     class="pf-c-form__group-label"
   >
     <label
       class="pf-c-form__label"
+      for="test"
     >
       <span
         class="pf-c-form__label-text"
@@ -106,6 +103,7 @@ exports[`FormGroup Component should render a basic component: basic formgroup 1`
 exports[`FormGroup Component should render a basic component: basic label 1`] = `
 <label
   class="pf-c-form__label"
+  for="test"
 >
   <span
     class="pf-c-form__label-text"

--- a/src/components/form/formGroup.js
+++ b/src/components/form/formGroup.js
@@ -3,6 +3,12 @@ import PropTypes from 'prop-types';
 import { FormGroup as PfFormGroup, ValidatedOptions } from '@patternfly/react-core';
 import helpers from '../../common/helpers';
 
+// FixMe: PF FormGroup fails to apply a label tag when role="radiogroup" is used
+/**
+ * FixMe: PF FormGroup requires hard coding a field ID even when single children are wrapped.
+ * This is potentially a breaking change that requires more than a few updates to prior
+ * implementations.
+ */
 /**
  * A wrapper for Patternfly FormGroup.
  *
@@ -11,16 +17,33 @@ import helpers from '../../common/helpers';
  * @param {string|boolean} props.error
  * @param {React.ReactNode|boolean} props.errorMessage
  * @param {React.ReactNode} props.helperText
- * @param {string} props.id
+ * @param {string} props.id Field ID reference
+ * @param {string} props.fieldId Field ID reference
  * @param {object} props.props
  * @returns {React.ReactNode}
  */
-const FormGroup = ({ children, error, errorMessage, helperText, id, ...props }) => {
-  const setId = id || helpers.generateId();
+const FormGroup = ({ children, error, errorMessage, helperText, id, fieldId, ...props }) => {
+  // Dynamically apply field id for single and multiple children when specific components are used
+  let firstChildId;
+
+  if (
+    React.Children.count(children) === 1 &&
+    (/(textArea|input|radio|checkbox|select)$/i.test(children?.type) ||
+      /(textArea|input|radio|checkbox|select)$/i.test(children?.type?.name))
+  ) {
+    firstChildId = children?.props?.id || children?.props?.name;
+  } else if (
+    React.Children.count(children) > 1 &&
+    (/(radio|checkbox)$/i.test(children?.[0]?.type) || /(radio|checkbox)$/i.test(children?.[0]?.type?.name))
+  ) {
+    firstChildId = children?.[0]?.props?.id || children?.[0]?.props?.name;
+  }
+
+  const setId = id || fieldId || firstChildId || helpers.generateId();
 
   return (
     <PfFormGroup
-      id={setId}
+      fieldId={setId}
       validated={error ? ValidatedOptions.error : ValidatedOptions.default}
       // FixMe: Applies consistent behavior to helperText regardless of it being an element or string
       helperText={helperText && <div className="pf-c-form__helper-text">{helperText}</div>}
@@ -41,26 +64,28 @@ const FormGroup = ({ children, error, errorMessage, helperText, id, ...props }) 
  * Prop types
  *
  * @type {{children: React.ReactNode, errorMessage: React.ReactNode|boolean, id: string, error: string|boolean,
- *     helperText: React.ReactNode}}
+ *     helperText: React.ReactNode, fieldId: string}}
  */
 FormGroup.propTypes = {
   children: PropTypes.node.isRequired,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   errorMessage: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
   helperText: PropTypes.node,
-  id: PropTypes.string
+  id: PropTypes.string,
+  fieldId: PropTypes.string
 };
 
 /**
  * Default props
  *
- * @type {{errorMessage: null, id: null, error: null, helperText: null}}
+ * @type {{errorMessage: null, id: null, error: null, helperText: null, fieldId: null}}
  */
 FormGroup.defaultProps = {
   error: null,
   errorMessage: null,
   helperText: null,
-  id: null
+  id: null,
+  fieldId: null
 };
 
 export { FormGroup as default, FormGroup };


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- fix(formGroup): discovery-330 pf id to fieldId

### Notes
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- moves from using `id` to `fieldId` attribute for formGroup component
- patches formGroup to apply labels dynamically for known child components
   - still the existing issue of not correctly applying labels when used against dropdownSelect 

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back without error
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. confirm form fields still have a "label" (or span/div in some cases) that displays copy next to a form field
   - this will not work against the Dropdown/Select component, this is expected and maintains existing behavior


### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back without error

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-330](https://issues.redhat.com/browse/DISCOVERY-330) 
related #216 