### PR TITLE
refactor(testing): jest, pass act, avoid readonly props

### DIFF
--- a/config/jest.setupTests.js
+++ b/config/jest.setupTests.js
@@ -118,15 +118,17 @@ global.renderComponent = (testComponent, options = {}) => {
       if (element) {
         Object.entries(element).forEach(([key, value]) => {
           if (typeof value === 'function') {
-            updatedElement[key] = (...args) => {
-              let output;
-              act(() => {
-                output = value.call(element, ...args);
-              });
-              return output;
-            };
-          } else {
-            updatedElement[key] = value;
+            try {
+              updatedElement[key] = (...args) => {
+                let output;
+                act(() => {
+                  output = value.call(element, ...args);
+                });
+                return output;
+              };
+            } catch (e) {
+              //
+            }
           }
         });
 
@@ -148,6 +150,7 @@ global.renderComponent = (testComponent, options = {}) => {
   };
 
   const updatedContainer = container;
+  updatedContainer.act = act;
   updatedContainer.screen = global.screenRender;
   updatedContainer.instance = elementInstance;
   updatedContainer.find = selector => container?.querySelector(selector);
@@ -216,20 +219,22 @@ global.renderHook = async (useHook = Function.prototype, options = {}) => {
   if (result && updatedOptions.includeInstanceContext === true) {
     Object.entries(result).forEach(([key, value]) => {
       if (typeof value === 'function') {
-        updatedResult[key] = (...args) => {
-          let output;
-          act(() => {
-            output = value.call(result, ...args);
-          });
-          return output;
-        };
-      } else {
-        updatedResult[key] = value;
+        try {
+          updatedResult[key] = (...args) => {
+            let output;
+            act(() => {
+              output = value.call(result, ...args);
+            });
+            return output;
+          };
+        } catch (e) {
+          //
+        }
       }
     });
   }
 
-  return { unmount, result: updatedResult };
+  return { unmount, result: updatedResult, act };
 };
 
 /**


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- refactor(testing): jest, pass act, avoid readonly props

### Notes
- expands the jest handlers and passes `act` back in the event an unknown or `read only` property is encountered apply the instance context convenience methods 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. next...
-->

### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. confirm tests come back clean


## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
<!-- [DISCOVERY-X](https://issues.redhat.com/browse/DISCOVERY-X) -->
ongoing 
related to https://github.com/RedHatInsights/curiosity-frontend/pull/1144