### PR TITLE
chore(refact): Disable the scan Merge Reports functionality.

### DIFF
--- a/src/components/scans/__tests__/__snapshots__/scans.test.js.snap
+++ b/src/components/scans/__tests__/__snapshots__/scans.test.js.snap
@@ -34,6 +34,11 @@ exports[`Scans Component should handle multiple display states, pending, error, 
             <Button
               isDisabled={true}
               onClick={[Function]}
+              style={
+                {
+                  "display": "none",
+                }
+              }
               variant="primary"
             >
               t(table.label, {"context":"merge-reports"})
@@ -415,6 +420,11 @@ exports[`Scans Component should return an empty state when there are no scans: e
             <Button
               isDisabled={true}
               onClick={[Function]}
+              style={
+                {
+                  "display": "none",
+                }
+              }
               variant="primary"
             >
               t(table.label, {"context":"merge-reports"})

--- a/src/components/scans/scans.js
+++ b/src/components/scans/scans.js
@@ -1,3 +1,7 @@
+/**
+ * Fixme: Temporarily disabling the merge reports button due to broken behavior.
+ * For a full explanation see, DISCOVERY-423
+ */
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -111,6 +115,7 @@ const Scans = ({
   const renderToolbarActions = () => (
     <Tooltip content={t('table.tooltip', { context: ['merge-reports'] })}>
       <Button
+        style={{ display: 'none' }}
         variant={ButtonVariant.primary}
         isDisabled={Object.values(selectedRows).filter(val => val !== null).length <= 1}
         onClick={onMergeReports}


### PR DESCRIPTION
The functionality has been broken for a while in the UI, and needs to be updated to leverage the async version of the API. For now we won't expose the Merge report Button and leave this as a CLI only functionality until the UI can be properly updated.

Current feature:

![Screenshot 2023-09-25 at 5 32 39 PM](https://github.com/quipucords/quipucords-ui/assets/5797328/ae027d61-0226-41f7-83f9-a738aeb727d9)

![Screenshot 2023-09-25 at 5 32 56 PM](https://github.com/quipucords/quipucords-ui/assets/5797328/b8b7f451-a68d-41fd-8f24-37846b6464c4)


After the disabling the feature (Merge reports button is hidden):


![Screenshot 2023-09-25 at 5 31 27 PM](https://github.com/quipucords/quipucords-ui/assets/5797328/c45f21c0-95d6-47e9-aa34-b1eec09dda2d)
