### PR TITLE
fix(sources): place reset button on right side of others

### DIFF
--- a/src/pages/sources/SourcesListView.tsx
+++ b/src/pages/sources/SourcesListView.tsx
@@ -325,7 +325,6 @@ const SourcesListView: React.FunctionComponent = () => {
         {/* You can render whatever other custom toolbar items you may need here! */}
         <Divider orientation={{ default: 'vertical' }} />
         <ToolbarItem>
-          <RefreshTimeButton lastRefresh={refreshTime?.getTime() ?? 0} onRefresh={onRefresh} />
           <SimpleDropdown
             label="Add Source"
             variant="primary"
@@ -343,6 +342,7 @@ const SourcesListView: React.FunctionComponent = () => {
           >
             {t('table.label', { context: 'scan' })}
           </Button>
+          <RefreshTimeButton lastRefresh={refreshTime?.getTime() ?? 0} onRefresh={onRefresh} />
         </ToolbarItem>
         <ToolbarItem {...paginationToolbarItemProps}>
           <Pagination


### PR DESCRIPTION
this came out of a discussion with natalie wong. the reason being that refresh button can change size as the text changes, which makes the other two buttons jump around when it exists on the left side.