### PR TITLE
chore(deps): Upgrade react-table-batteries to 1.0.3 and fix usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,11 +105,12 @@
     "webpack-merge": "^5.9.0"
   },
   "dependencies": {
-    "@mturley-latest/react-table-batteries": "^1.0.2",
+    "@mturley-latest/react-table-batteries": "^1.0.3",
     "@patternfly/react-core": "^5.0.0",
     "@patternfly/react-icons": "^5.0.0",
     "@patternfly/react-styles": "^5.0.0",
     "@patternfly/react-table": "^5.1.1",
+    "@tanstack/react-query": "^5.8.4",
     "axios": "^1.6.1",
     "detect-browser": "^5.3.0",
     "i18next": "^23.4.4",
@@ -119,7 +120,6 @@
     "react-axe": "^3.5.4",
     "react-dom": "^18",
     "react-i18next": "^13.1.2",
-    "@tanstack/react-query": "^5.8.4",
     "react-redux": "^8.1.2",
     "react-router-dom": "6.4.0",
     "sirv-cli": "^2.0.2"

--- a/src/common/queryHelpers.ts
+++ b/src/common/queryHelpers.ts
@@ -1,0 +1,83 @@
+import { TableState } from '@mturley-latest/react-table-batteries';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import helpers from 'src/common';
+
+export const getServiceQueryUrl = <
+  TItem,
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
+>({
+  tableState: {
+    filter: { filterValues },
+    sort: { activeSort, initialSort },
+    pagination: { pageNumber, itemsPerPage }
+  },
+  baseUrl,
+  columnOrderMap
+}: {
+  tableState: TableState<TItem, TColumnKey, TSortableColumnKey>;
+  baseUrl?: string;
+  columnOrderMap?: Record<TSortableColumnKey, string>;
+}) => {
+  const filterParams = filterValues
+    ? Object.keys(filterValues)
+        .map(key => `${key}=${filterValues[key]}`)
+        .join('&')
+    : null;
+
+  const ordering = `${(activeSort?.direction ?? initialSort?.direction) === 'desc' ? '-' : ''}${
+    activeSort?.columnKey
+      ? columnOrderMap?.[activeSort.columnKey] || activeSort.columnKey
+      : initialSort?.columnKey
+  }`;
+
+  const query =
+    `${baseUrl}` +
+    `?` +
+    `ordering=${ordering}` +
+    `&` +
+    `page=${pageNumber}` +
+    `&` +
+    `page-size=${itemsPerPage}${filterParams ? `&${filterParams}` : ''}`;
+
+  return query;
+};
+
+export type ServiceQueryResult<TItem> = { count: number; results: TItem[] };
+
+export const useServiceQuery = <
+  TItem,
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
+>({
+  queryKey,
+  baseUrl,
+  columnOrderMap,
+  tableState,
+  setRefreshTime
+}: {
+  queryKey: string[];
+  baseUrl?: string;
+  columnOrderMap?: Record<TSortableColumnKey, string>;
+  tableState: TableState<TItem, TColumnKey, TSortableColumnKey>;
+  setRefreshTime?: (date: Date) => void;
+}) =>
+  useQuery<ServiceQueryResult<TItem>>({
+    queryKey: [...queryKey, tableState.cacheKey],
+    refetchOnWindowFocus: !helpers.DEV_MODE,
+    queryFn: async () => {
+      try {
+        const query = getServiceQueryUrl({ tableState, baseUrl, columnOrderMap });
+        console.log(`Query: `, query);
+        const response = await axios.get<ServiceQueryResult<TItem>>(query, {
+          headers: { Authorization: `Token ${localStorage.getItem('authToken')}` }
+        });
+        setRefreshTime?.(new Date());
+        return response.data;
+      } catch (error) {
+        console.error(error);
+        throw error; // You can choose to throw the error or return a default value here
+      }
+    }
+  });

--- a/src/pages/credentials/useCredentialsQuery.ts
+++ b/src/pages/credentials/useCredentialsQuery.ts
@@ -1,0 +1,22 @@
+import { TableState } from '@mturley-latest/react-table-batteries';
+import { useServiceQuery } from 'src/common/queryHelpers';
+import { CredentialType } from 'src/types';
+
+export const CREDS_LIST_QUERY = 'credentialsList';
+
+export const useCredentialsQuery = <
+  TColumnKey extends string,
+  TSortableColumnKey extends TColumnKey
+>({
+  tableState,
+  setRefreshTime
+}: {
+  tableState: TableState<CredentialType, TColumnKey, TSortableColumnKey>;
+  setRefreshTime: (date: Date) => void;
+}) =>
+  useServiceQuery<CredentialType, TColumnKey, TSortableColumnKey>({
+    queryKey: [CREDS_LIST_QUERY],
+    baseUrl: process.env.REACT_APP_CREDENTIALS_SERVICE,
+    tableState,
+    setRefreshTime
+  });

--- a/src/pages/sources/useSourcesQuery.ts
+++ b/src/pages/sources/useSourcesQuery.ts
@@ -1,0 +1,35 @@
+import { TableState } from '@mturley-latest/react-table-batteries';
+import { useServiceQuery } from 'src/common/queryHelpers';
+import { SourceType } from 'src/types';
+
+export const SOURCES_LIST_QUERY = 'sourcesList';
+
+type SourcesColumnKey =
+  | 'name'
+  | 'connection'
+  | 'type'
+  | 'actions'
+  | 'credentials'
+  | 'unreachableSystems'
+  | 'scan';
+
+type SourcesSortableColumnKey = 'name' | 'connection' | 'type';
+
+export const useSourcesQuery = ({
+  tableState,
+  setRefreshTime
+}: {
+  tableState: TableState<SourceType, SourcesColumnKey, SourcesSortableColumnKey>;
+  setRefreshTime: (date: Date) => void;
+}) =>
+  useServiceQuery<SourceType, SourcesColumnKey, SourcesSortableColumnKey>({
+    queryKey: [SOURCES_LIST_QUERY],
+    baseUrl: process.env.REACT_APP_SOURCES_SERVICE,
+    columnOrderMap: {
+      name: 'name',
+      connection: 'most_recent_connect_scan__start_time',
+      type: 'source_type'
+    },
+    tableState,
+    setRefreshTime
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,13 +664,14 @@
     tinycolor2 "^1.6.0"
     yup "^0.32.9"
 
-"@mturley-latest/react-table-batteries@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@mturley-latest/react-table-batteries/-/react-table-batteries-1.0.2.tgz"
-  integrity sha512-f+Z7//5XX2CG06z5Bsdr8wINKpcWqUcN/UD4+8/3NSTwVGCDFCSGBvH7nQEUBQjNKB7+fsuABs1mAjwD8TG6yQ==
+"@mturley-latest/react-table-batteries@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@mturley-latest/react-table-batteries/-/react-table-batteries-1.0.3.tgz#7aa5d70d92fb92f12f54b329bb58698f3c40da74"
+  integrity sha512-pIgHbCoN4e6dYbxdkFF9D0FVaIYIWQNI68du1zCEtTTBe4Dej0hDsNpRLhkpNsg2lcn/i6Fww7OwLEvezscCHg==
   dependencies:
     "@migtools/lib-ui" "^10.0.1"
     "@patternfly/react-core" "^5.1.1"
+    use-deep-compare "^1.1.0"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -3048,7 +3049,7 @@ depd@~1.1.2:
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
-dequal@^2.0.3:
+dequal@2.0.3, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -8909,6 +8910,13 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-deep-compare@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-deep-compare/-/use-deep-compare-1.2.0.tgz#0ffb05c4972d0588ae8d6ed10a09042acffb2c16"
+  integrity sha512-AemF4mbYpuCjOl0jIzeZA7kql3/94BPmfHA96wChnvNvFBjrYe8GVGDsb79wNMBCEQpQhnsUiblNNXqc2eoyjQ==
+  dependencies:
+    dequal "2.0.3"
 
 use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
The 1.0.3 version of `@mturley-latest/react-table-batteries` includes breaking changes to get it close to the final API that will be present when it moves to PatternFly. This PR upgrades and changes the usage here to match. It also factors out `queryHelpers.ts` to prevent some repetitive code. We wrap the `useQuery` calls in custom hooks that rely on `tableState.cacheKey` to invalidate the cache rather than a `useEffect`.

cc @gitdallas