### PR TITLE
fix(creds): sorting by name and type

### DIFF
--- a/src/pages/credentials/CredentialsListView.tsx
+++ b/src/pages/credentials/CredentialsListView.tsx
@@ -111,7 +111,7 @@ const CredentialsListView: React.FunctionComponent = () => {
     },
     sort: {
       isEnabled: true,
-      sortableColumns: ['name', 'type', 'auth_type', 'sources', 'updated'],
+      sortableColumns: ['name', 'type'],
       initialSort: { columnKey: 'name', direction: 'asc' }
     },
     pagination: { isEnabled: true },

--- a/src/pages/credentials/useCredentialsQuery.ts
+++ b/src/pages/credentials/useCredentialsQuery.ts
@@ -4,19 +4,31 @@ import { CredentialType } from 'src/types';
 
 export const CREDS_LIST_QUERY = 'credentialsList';
 
-export const useCredentialsQuery = <
-  TColumnKey extends string,
-  TSortableColumnKey extends TColumnKey
->({
+type CredentialsColumnKey =
+| 'name'
+| 'type'
+| 'auth_type'
+| 'sources'
+| 'updated'
+| 'actions'
+
+type CredentialsSortableColumnKey = 'name' | 'type';
+
+
+export const useCredentialsQuery = ({
   tableState,
   setRefreshTime
 }: {
-  tableState: TableState<CredentialType, TColumnKey, TSortableColumnKey>;
+  tableState: TableState<CredentialType, CredentialsColumnKey, CredentialsSortableColumnKey>;
   setRefreshTime: (date: Date) => void;
 }) =>
-  useServiceQuery<CredentialType, TColumnKey, TSortableColumnKey>({
+  useServiceQuery<CredentialType, CredentialsColumnKey, CredentialsSortableColumnKey>({
     queryKey: [CREDS_LIST_QUERY],
     baseUrl: process.env.REACT_APP_CREDENTIALS_SERVICE,
+    columnOrderMap: {
+      name: 'name',
+      type: 'cred_type'
+    },
     tableState,
     setRefreshTime
   });


### PR DESCRIPTION
Fix credentials table to sort by anem and credential type. In YIchen's sketches there's also the possibility to filter using other columns, but currently tose were not implemented in the backend.