### PR TITLE
api service raw draft suggestion

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import getUniqueId from '../../src/common/helpers';
+
+class ApiService {
+  protected baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  protected async delete(url: string, successMessage: string, errorMessage: string, setPendingDelete: () => void, queryKey: any[]) {
+    try {
+      await axios.delete(url);
+      addAlert(successMessage, 'success', getUniqueId());
+      // Other common logic
+    } catch (error) {
+      console.error(error);
+      // Error handling logic
+    } finally {
+      setPendingDelete();
+    }
+  }
+
+  // Other common methods like get, post, put, etc.
+}
+
+export default ApiService;

--- a/src/services/credentialService.ts
+++ b/src/services/credentialService.ts
@@ -1,0 +1,16 @@
+import ApiService from './ApiService';
+
+class CredentialService extends ApiService {
+  constructor(baseUrl: string) {
+    super(baseUrl);
+  }
+
+  deleteCredential(credential: CredentialType, setPendingDelete: () => void, queryKey: any[]) {
+    const url = `${this.baseUrl}/api/v1/credentials/${credential.id}/`;
+    const successMessage = `Credential deleted successfully`;
+    const errorMessage = `Error removing credential`;
+    this.delete(url, successMessage, errorMessage, setPendingDelete, queryKey);
+  }
+
+  // Other credential-specific methods
+}

--- a/src/services/sourceService.ts
+++ b/src/services/sourceService.ts
@@ -1,0 +1,16 @@
+import ApiService from './ApiService';
+
+class SourceService extends ApiService {
+  constructor(baseUrl: string) {
+    super(baseUrl);
+  }
+
+  deleteSource(source: SourceType, setPendingDelete: () => void, queryKey: any[]) {
+    const url = `${this.baseUrl}/api/v1/sources/${source.id}/`;
+    const successMessage = `Source "${source.name}" deleted successfully`;
+   const errorMessage = `Error removing source "${source.name}"`;
+    this.delete(url, successMessage, errorMessage, setPendingDelete, queryKey);
+  }
+
+  // Other source-specific methods
+}


### PR DESCRIPTION
We repeat the "same" operations across  sources, credentials, delete pages. 
I was thinking in a way to abstract those the same way it was done on https://github.com/quipucords/quipucords-ui/tree/main/src/services,. 
what do u think ? Is there a better way to do this ?