### PR TITLE
chore: add 'yarn audit' GitHub workflow

### DIFF
--- a/.github/workflows/yarn_audit.yml
+++ b/.github/workflows/yarn_audit.yml
@@ -1,0 +1,32 @@
+name: Yarn Audit
+on:
+  push:
+    branches: [ main, v2-refactor ]
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  Integration-checks:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - name: Node.js modules cache
+        uses: actions/cache@v3
+        id: modules-cache
+        with:
+          path: ${{ github.workspace }}/node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-modules
+      - name: yarn audit
+        run: yarn audit
+


### PR DESCRIPTION
## What's included
This adds a GitHub workflow to run `yarn audit` to check if dependencies have critical vulnerabilities.