### PR TITLE
chore(deps): bump actions/cache from 3 to 4

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
       - name: Node.js modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: modules-cache
         with:
           path: ${{ github.workspace }}/node_modules

--- a/.github/workflows/yarn_audit.yml
+++ b/.github/workflows/yarn_audit.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
       - name: Node.js modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: modules-cache
         with:
           path: ${{ github.workspace }}/node_modules


### PR DESCRIPTION
This change ports the update introduced by https://github.com/quipucords/quipucords-ui/pull/308 from `main` to `v2-rewrite`.

Bumps [actions/cache](https://github.com/actions/cache) from 3 to 4.
- [Release notes](https://github.com/actions/cache/releases)
- [Changelog](https://github.com/actions/cache/blob/main/RELEASES.md)
- [Commits](https://github.com/actions/cache/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/cache dependency-type: direct:production update-type: version-update:semver-major ...