### PR TITLE
[DISCOVERY-536] - Serve content over https

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -57,3 +57,6 @@ yarn-error.log*
 api-debug*
 
 .vscode
+
+# local files
+var/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ yarn-error.log*
 api-debug*
 
 .vscode
+
+# local files
+var/

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
 
+set -e
+
 # on podman, host.containers.internal resolves to the host. this is equivalent to
 # host.docker.internal for docker.
 export QUIPUCORDS_API_URL="${QUIPUCORDS_API_URL:-https://host.containers.internal:9443}"
+CERTS_PATH="/opt/app-root/certs"
+
+# verify if user provided certificates exist or create a self signed certificate.
+mkdir -p ${CERTS_PATH}
+if ([ -f "${CERTS_PATH}/server.key" ] && [ -f "${CERTS_PATH}/server.crt" ]); then
+    echo "Using user provided certificates..."
+    openssl rsa -in "${CERTS_PATH}/server.key" -check
+    openssl x509 -in "${CERTS_PATH}/server.crt" -text -noout
+elif [ ! -f "${CERTS_PATH}/server.key" ] && [ ! -f "${CERTS_PATH}/server.crt" ]; then
+    echo "No certificates provided. Creating them..."
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout "${CERTS_PATH}/server.key" \
+        -out "${CERTS_PATH}/server.crt" \
+        -subj "/C=US/ST=Raleigh/L=Raleigh/O=IT/OU=IT Department/CN=example.com"
+else
+    echo "Either key or certificate is missing."
+    echo "Please provide both named as server.key and server.crt."
+    echo "Tip: this container expects these files at ${CERTS_PATH}/"
+    exit 1
+fi
 
 envsubst "\$QUIPUCORDS_API_URL" < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 nginx -g "daemon off;"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,7 +1,6 @@
 # configuration shamelessly copied from https://github.com/sclorg/nginx-container/blob/master/examples/1.22/test-app/nginx.conf
 # For more information on configuration, see:
 #   * Official English Documentation: http://nginx.org/en/docs/
-#   * Official Russian Documentation: http://nginx.org/ru/docs/
 
 worker_processes auto;
 error_log /var/log/nginx/error.log notice;
@@ -30,10 +29,24 @@ http {
     default_type        application/octet-stream;
 
     server {
-        listen       8080 default_server;
-        listen       [::]:8080 default_server;
+        listen       8079 default_server;
+        listen       [::]:8079 default_server;
+        server_name  _;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen       8080 ssl http2;
+        listen       [::]:8080 ssl http2;
         server_name  _;
         root         /opt/app-root/src;
+
+        ssl_certificate "/opt/app-root/certs/server.crt";
+        ssl_certificate_key "/opt/app-root/certs/server.key";
+        ssl_session_cache shared:SSL:1m;
+        ssl_session_timeout  10m;
+        ssl_ciphers PROFILE=SYSTEM;
+        ssl_prefer_server_ciphers on;
 
         location / {
             try_files $uri /index.html;
@@ -45,30 +58,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_pass_header X-CSRFToken;
         }
-    }
-
-# Settings for a TLS enabled server.
-#
-#    server {
-#        listen       443 ssl http2;
-#        listen       [::]:443 ssl http2;
-#        server_name  _;
-#        root         /opt/app-root/src;
-#
-#        ssl_certificate "/etc/pki/nginx/server.crt";
-#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
-#        ssl_session_cache shared:SSL:1m;
-#        ssl_session_timeout  10m;
-#        ssl_ciphers PROFILE=SYSTEM;
-#        ssl_prefer_server_ciphers on;
-#
-#        # Load configuration files for the default server block.
-#        include /opt/app-root/etc/nginx.default.d/*.conf;
-#
-#        location = /404.html {
-#        }
-#
-#    }
+   }
 
 }
 


### PR DESCRIPTION
## What's included
Content is now served over https.
Also alow users to provide their own certificates when using a folder mounted to /opt/app-root/certs/.
Otherwise, certificates are generated on-the-fly to avoid the
anti-pattern currently in use in Quipucords server codebase 
(DISCOVERY-361).
...

<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
```
podman build -t qpc-ui .
podman run -it -p 8080:8080 --replace --name qpc-ui qpc-ui
```
head to https://localhost:8080. content should now be served over https.

to test passing customer provided certificates, add ` -v <path/to/certs>:/opt/app-root/certs:z` to
`podman run` command.

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-536](https://issues.redhat.com/browse/DISCOVERY-536)
