### PR TITLE
fix(scans): ds-98 disable expandable sources

### DIFF
--- a/src/components/scans/__tests__/__snapshots__/scans.test.js.snap
+++ b/src/components/scans/__tests__/__snapshots__/scans.test.js.snap
@@ -181,8 +181,6 @@ exports[`Scans Component should handle multiple display states, pending, error, 
                     t(table.label_status, {"context":"cell","count":0}, [object Object],[object Object])
                   </Tooltip>,
                   "dataLabel": "t(table.header, {"context":"sources"})",
-                  "expandedContent": undefined,
-                  "isExpanded": false,
                   "width": 8,
                 },
                 {

--- a/src/components/scans/__tests__/__snapshots__/scansTableCells.test.js.snap
+++ b/src/components/scans/__tests__/__snapshots__/scansTableCells.test.js.snap
@@ -175,7 +175,6 @@ exports[`ScansTableCells should return consistent cell results: basic sourcesCel
   >
     t(table.label_status, {"context":"cell","count":0}, [object Object],[object Object])
   </Tooltip>,
-  "expandedContent": undefined,
 }
 `;
 

--- a/src/components/scans/scanSourceList.js
+++ b/src/components/scans/scanSourceList.js
@@ -8,6 +8,8 @@ import { translate } from '../i18n/i18n';
 
 /**
  * Return a scan jobs listing for "sources".
+ *
+ * @deprecated
  */
 class ScanSourceList extends React.Component {
   static setSourceStatus(source) {

--- a/src/components/scans/scans.js
+++ b/src/components/scans/scans.js
@@ -189,7 +189,6 @@ const Scans = ({
                 },
                 {
                   ...scansTableCells.sourcesCellContent(item, { viewId }),
-                  isExpanded: expandedRows?.[item.id] === 4,
                   width: 8,
                   dataLabel: t('table.header', { context: ['sources'] })
                 },

--- a/src/components/scans/scansTableCells.js
+++ b/src/components/scans/scansTableCells.js
@@ -19,7 +19,6 @@ import { apiTypes } from '../../constants/apiConstants';
 import { translate } from '../i18n/i18n';
 import { helpers } from '../../common';
 import { DropdownSelect, SelectButtonVariant, SelectDirection, SelectPosition } from '../dropdownSelect/dropdownSelect';
-import ScanSourceList from './scanSourceList';
 import ScanJobsList from './scanJobsList';
 
 /**
@@ -198,15 +197,11 @@ const okHostsCellContent = ({ [apiTypes.API_RESPONSE_SCAN_MOST_RECENT]: mostRece
  * @param {string} options.viewId
  * @returns {{expandedContent: (React.ReactNode|undefined), content: React.ReactNode}}
  */
-const sourcesCellContent = (
-  { [apiTypes.API_RESPONSE_SCAN_ID]: id, [apiTypes.API_RESPONSE_SCAN_SOURCES]: sources = [] } = {},
-  { viewId } = {}
-) => {
+const sourcesCellContent = ({ [apiTypes.API_RESPONSE_SCAN_SOURCES]: sources = [] } = {}, { viewId } = {}) => {
   const count = sources?.length;
 
   return {
-    content: statusCell({ count, status: 'sources', viewId }),
-    expandedContent: (count && <ScanSourceList key={`sources-${id}`} id={id} />) || undefined
+    content: statusCell({ count, status: 'sources', viewId })
   };
 };
 


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(scans): ds-98 disable expandable sources

### Notes
- the sources displayed under scans suffers from an sequential id issue, this bypasses the issue by disabling the expansion field
   - we discussed using the same display v2 uses but until it can be determined v2 is pulling the correct information we're taking the direct approach of disabling the field all together 
      - the number of sources that are displayed is an aspect of what v2 uses to show sources
-  we deprecated the old "scanSourceList.js" component as opposed to deleting it simply because it was faster to type the word vs deleting the file, test file, test snapshots, etc. if someone wants us to remove it entirely we can also do that
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. `$ yarn start:stage`
1. confirm that the sources displayed on scans is now disabled, no longer clickable
<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot 2024-05-06 at 2 31 05 PM](https://github.com/quipucords/quipucords-ui/assets/3761375/1f2faf7c-c212-4f34-98aa-94ee732aa692)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-98](https://issues.redhat.com/browse/DISCOVERY-98)
blocked by, requires #350 