### PR TITLE
fix(credentials): ds-205 disable edit for encrypted fields

### DIFF
--- a/src/components/createCredentialDialog/createCredentialDialog.js
+++ b/src/components/createCredentialDialog/createCredentialDialog.js
@@ -166,6 +166,10 @@ const CreateCredentialDialog = ({
 
     // clean for submitting an edited cred
     if (edit) {
+      delete updatedValues[apiTypes.API_QUERY_TYPES.AUTH_TOKEN];
+      delete updatedValues[apiTypes.API_QUERY_TYPES.SSH_PASSPHRASE];
+      delete updatedValues[apiTypes.API_QUERY_TYPES.BECOME_PASSWORD];
+      delete updatedValues[apiTypes.API_QUERY_TYPES.PASSWORD];
       delete updatedValues[apiTypes.API_QUERY_TYPES.CREATED_AT];
       delete updatedValues[apiTypes.API_QUERY_TYPES.CREDENTIAL_TYPE];
       delete updatedValues[apiTypes.API_QUERY_TYPES.UPDATED_AT];
@@ -303,6 +307,7 @@ const CreateCredentialDialog = ({
               label={t('form-dialog.label', { context: ['ssh-passphrase', 'create-credential'] })}
             >
               <TextInput
+                isDisabled={edit}
                 ouiaId="ssh_passphrase"
                 name={apiTypes.API_QUERY_TYPES.SSH_PASSPHRASE}
                 type="password"
@@ -323,6 +328,7 @@ const CreateCredentialDialog = ({
             errorMessage={t('form-dialog.label', { context: ['token', 'create-credential', 'error'] })}
           >
             <TextInput
+              isDisabled={edit}
               ouiaId="auth_token"
               name={apiTypes.API_QUERY_TYPES.AUTH_TOKEN}
               value={values[apiTypes.API_QUERY_TYPES.AUTH_TOKEN]}
@@ -347,6 +353,7 @@ const CreateCredentialDialog = ({
             errorMessage={t('form-dialog.label', { context: ['password', 'error'] })}
           >
             <TextInput
+              isDisabled={edit}
               ouiaId="password"
               name={apiTypes.API_QUERY_TYPES.PASSWORD}
               type="password"
@@ -404,6 +411,7 @@ const CreateCredentialDialog = ({
         </FormGroup>
         <FormGroup key="become_password" label={t('form-dialog.label', { context: ['become-password'] })}>
           <TextInput
+            isDisabled={edit}
             ouiaId="become_password"
             name={apiTypes.API_QUERY_TYPES.BECOME_PASSWORD}
             type="password"

--- a/src/services/credentialsService.js
+++ b/src/services/credentialsService.js
@@ -24,7 +24,7 @@ const getCredentials = (id = '', params = {}) =>
 
 const updateCredential = (id, data = {}) =>
   serviceCall({
-    method: 'put',
+    method: 'patch',
     url: `${process.env.REACT_APP_CREDENTIALS_SERVICE}${id}/`,
     data
   });


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(credentials): ds-205 disable edit for encrypted fields

### Notes
- Moves the credential "update" service from `put` to `patch`
- We opted for the most simplistic solution on this one... 
   - Technically the all asterisk values are still returning from the API as before, it's just NOW, before submission of the updated cred the values are removed
- Disables edits for the following encrypted fields. If additional fields are required we can add them in...
   - auth_token
   - ssh_passphrase
   - become_password
   - password 
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ yarn`
1. `$ yarn test:dev`
-->

### Local run check
1. update the NPM packages with `$ yarn`
1. make sure `podman` is running
1. `$ yarn start:stage`
1. add a credential with an encrypted field type
   - after adding the credential, edit it, submit it and confirm the field has NOT been updated with `*`asterisk characters . You will most likely need access to the same tests @ruda performed to determine this. We used form submission on edited credentials as our verification 

<!--
### Check the build
1. update the NPM packages with `$ yarn`
1. `$ yarn build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-205](https://issues.redhat.com/browse/DISCOVERY-205)
blocked by #350 #365 