### PR TITLE
fix(credentials): ds-681 hide token in network

### DIFF
--- a/src/components/createCredentialDialog/__tests__/__snapshots__/createCredentialDialog.test.js.snap
+++ b/src/components/createCredentialDialog/__tests__/__snapshots__/createCredentialDialog.test.js.snap
@@ -2,21 +2,6 @@
 
 exports[`CreateCredentialDialog Component should export select options: options 1`] = `
 {
-  "authenticationTypeOptions": [
-    {
-      "title": [Function],
-      "value": "sshKey",
-    },
-    {
-      "title": [Function],
-      "value": "token",
-    },
-    {
-      "selected": true,
-      "title": [Function],
-      "value": "usernamePassword",
-    },
-  ],
   "becomeMethodTypeOptions": [
     "sudo",
     "su",

--- a/src/components/createCredentialDialog/__tests__/createCredentialDialog.test.js
+++ b/src/components/createCredentialDialog/__tests__/createCredentialDialog.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CreateCredentialDialog, authenticationTypeOptions, becomeMethodTypeOptions } from '../createCredentialDialog';
+import { CreateCredentialDialog, becomeMethodTypeOptions } from '../createCredentialDialog';
 
 describe('CreateCredentialDialog Component', () => {
   it('should render a basic component', async () => {
@@ -17,7 +17,6 @@ describe('CreateCredentialDialog Component', () => {
 
   it('should export select options', () => {
     expect({
-      authenticationTypeOptions,
       becomeMethodTypeOptions
     }).toMatchSnapshot('options');
   });

--- a/src/components/createCredentialDialog/createCredentialDialog.js
+++ b/src/components/createCredentialDialog/createCredentialDialog.js
@@ -30,27 +30,6 @@ import { translate } from '../i18n/i18n';
 const becomeMethodTypeOptions = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas'];
 
 /**
- * Generate authentication type options.
- *
- * @type {{title: Function | React.ReactNode, value: string, selected: boolean}[]}
- */
-const authenticationTypeOptions = [
-  {
-    title: () => translate('form-dialog.label', { context: ['option', 'sshKey'] }),
-    value: 'sshKey'
-  },
-  {
-    title: () => translate('form-dialog.label', { context: ['option', 'token'] }),
-    value: 'token'
-  },
-  {
-    title: () => translate('form-dialog.label', { context: ['option', 'usernamePassword'] }),
-    value: 'usernamePassword',
-    selected: true
-  }
-];
-
-/**
  * ToDo: updating a creds password should immediately reset the entire field
  * When a user attempts to update a cred the password displayed is not decrypted. Existing behavior has the
  * appearance that any user who updates the field but leaves parts of the old password actually submit a combination
@@ -64,7 +43,6 @@ const authenticationTypeOptions = [
  * @fires onSubmit
  * @fires onValidateForm
  * @param {object} props
- * @param {Array} props.authenticationOptions
  * @param {Array} props.becomeMethodOptions
  * @param {Function} props.t
  * @param {Function} props.useCredential
@@ -73,7 +51,6 @@ const authenticationTypeOptions = [
  * @returns {React.ReactNode|null}
  */
 const CreateCredentialDialog = ({
-  authenticationOptions,
   becomeMethodOptions,
   t,
   useCredential: useAliasCredential,
@@ -86,7 +63,17 @@ const CreateCredentialDialog = ({
   const submitCredential = useAliasOnSubmitCredential();
   const isShhKeyfile = credential?.[apiTypes.API_QUERY_TYPES.SSH_KEYFILE] && true;
   const isToken = credential?.[apiTypes.API_QUERY_TYPES.AUTH_TOKEN] && true;
-  const networkAuthenticationOptions = authenticationOptions.filter(item => item.value !== 'token');
+  const networkAuthenticationOptions = [
+    {
+      title: () => translate('form-dialog.label', { context: ['option', 'sshKey'] }),
+      value: 'sshKey'
+    },
+    {
+      title: () => translate('form-dialog.label', { context: ['option', 'usernamePassword'] }),
+      value: 'usernamePassword',
+      selected: true
+    }
+  ];
 
   useEffect(() => {
     if (edit && credentialType === 'network' && isShhKeyfile) {
@@ -495,7 +482,6 @@ const CreateCredentialDialog = ({
 };
 
 CreateCredentialDialog.propTypes = {
-  authenticationOptions: PropTypes.array,
   becomeMethodOptions: PropTypes.array,
   t: PropTypes.func,
   useCredential: PropTypes.func,
@@ -504,7 +490,6 @@ CreateCredentialDialog.propTypes = {
 };
 
 CreateCredentialDialog.defaultProps = {
-  authenticationOptions: authenticationTypeOptions,
   becomeMethodOptions: becomeMethodTypeOptions,
   t: translate,
   useCredential,
@@ -512,9 +497,4 @@ CreateCredentialDialog.defaultProps = {
   useOnUpdateCredential
 };
 
-export {
-  CreateCredentialDialog as default,
-  CreateCredentialDialog,
-  authenticationTypeOptions,
-  becomeMethodTypeOptions
-};
+export { CreateCredentialDialog as default, CreateCredentialDialog, becomeMethodTypeOptions };

--- a/src/components/createCredentialDialog/createCredentialDialog.js
+++ b/src/components/createCredentialDialog/createCredentialDialog.js
@@ -86,6 +86,7 @@ const CreateCredentialDialog = ({
   const submitCredential = useAliasOnSubmitCredential();
   const isShhKeyfile = credential?.[apiTypes.API_QUERY_TYPES.SSH_KEYFILE] && true;
   const isToken = credential?.[apiTypes.API_QUERY_TYPES.AUTH_TOKEN] && true;
+  const networkAuthenticationOptions = authenticationOptions.filter(item => item.value !== 'token');
 
   useEffect(() => {
     if (edit && credentialType === 'network' && isShhKeyfile) {
@@ -238,7 +239,7 @@ const CreateCredentialDialog = ({
             ouiaId="auth_type"
             isInline={false}
             onSelect={onSetAuthType}
-            options={authenticationOptions}
+            options={networkAuthenticationOptions}
             selectedOptions={authType}
           />
         </FormGroup>

--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -1032,10 +1032,6 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "form-dialog.label",
-        "match": "translate('form-dialog.label', { context: ['option', 'token'] })",
-      },
-      {
-        "key": "form-dialog.label",
         "match": "translate('form-dialog.label', { context: ['option', 'usernamePassword'] })",
       },
       {


### PR DESCRIPTION
Don't display "Token" authentication type for Network credential. Not only it doesn't make any sense, such credential can't be created anyway.

Relates to JIRA: DISCOVERY-681
