### PR TITLE
fix(viewToolbar): dsc-682 add missing types to filter

### DIFF
--- a/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
+++ b/src/components/i18n/__tests__/__snapshots__/i18n.test.js.snap
@@ -41,11 +41,19 @@ exports[`I18n Component should generate a predictable locale key output snapshot
       },
       {
         "key": "form-dialog.label",
+        "match": "translate('form-dialog.label', { context: ['option', 'rhacs'] })",
+      },
+      {
+        "key": "form-dialog.label",
         "match": "translate('form-dialog.label', { context: ['option', 'satellite'] })",
       },
       {
         "key": "form-dialog.label",
         "match": "translate('form-dialog.label', { context: ['option', 'vcenter'] })",
+      },
+      {
+        "key": "form-dialog.label",
+        "match": "translate('form-dialog.label', { context: ['option', 'ansible'] })",
       },
       {
         "key": "toolbar.label",

--- a/src/components/viewToolbar/__tests__/__snapshots__/viewToolbarSelect.test.js.snap
+++ b/src/components/viewToolbar/__tests__/__snapshots__/viewToolbarSelect.test.js.snap
@@ -18,11 +18,19 @@ exports[`ViewToolbarSelect Component should export select variants and related o
       },
       {
         "title": [Function],
+        "value": "rhacs",
+      },
+      {
+        "title": [Function],
         "value": "satellite",
       },
       {
         "title": [Function],
         "value": "vcenter",
+      },
+      {
+        "title": [Function],
+        "value": "ansible",
       },
     ],
     "source_type": [
@@ -36,11 +44,19 @@ exports[`ViewToolbarSelect Component should export select variants and related o
       },
       {
         "title": [Function],
+        "value": "rhacs",
+      },
+      {
+        "title": [Function],
         "value": "satellite",
       },
       {
         "title": [Function],
         "value": "vcenter",
+      },
+      {
+        "title": [Function],
+        "value": "ansible",
       },
     ],
   },
@@ -112,11 +128,19 @@ exports[`ViewToolbarSelect Component should render a basic component: basic 1`] 
       },
       {
         "title": [Function],
+        "value": "rhacs",
+      },
+      {
+        "title": [Function],
         "value": "satellite",
       },
       {
         "title": [Function],
         "value": "vcenter",
+      },
+      {
+        "title": [Function],
+        "value": "ansible",
       },
     ]
   }

--- a/src/components/viewToolbar/viewToolbarSelect.js
+++ b/src/components/viewToolbar/viewToolbarSelect.js
@@ -14,8 +14,10 @@ import { translate } from '../i18n/i18n';
 const credentialSourceTypeFieldOptions = [
   { title: () => translate('form-dialog.label', { context: ['option', 'network'] }), value: 'network' },
   { title: () => translate('form-dialog.label', { context: ['option', 'openshift'] }), value: 'openshift' },
+  { title: () => translate('form-dialog.label', { context: ['option', 'rhacs'] }), value: 'rhacs' },
   { title: () => translate('form-dialog.label', { context: ['option', 'satellite'] }), value: 'satellite' },
-  { title: () => translate('form-dialog.label', { context: ['option', 'vcenter'] }), value: 'vcenter' }
+  { title: () => translate('form-dialog.label', { context: ['option', 'vcenter'] }), value: 'vcenter' },
+  { title: () => translate('form-dialog.label', { context: ['option', 'ansible'] }), value: 'ansible' }
 ];
 
 /**


### PR DESCRIPTION
Credential type and Source type filter items were missing RHACS and Ansible. We must have forgot to add them back when we introduced these source types. Add these items now.

Relates to JIRA: DISCOVERY-682