### PR TITLE
ci: ds-647 adjust gh workflow job names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
   REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 
 jobs:
-  build:
+  Build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/commit_lint.yml
+++ b/.github/workflows/commit_lint.yml
@@ -5,7 +5,7 @@ env:
   BRANCH: ${{ github.base_ref }}
 
 jobs:
-  Checks:
+  Commits:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ env:
   UPSTREAM_TAR: quipucords-ui-dist.tar
 
 jobs:
-  Checks:
+  Integration:
     runs-on: ubuntu-latest
     permissions:
       # required for releasing artifacts

--- a/.github/workflows/package_audit.yml
+++ b/.github/workflows/package_audit.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  Checks:
+  Audit:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- ci: ds-647 adjust gh workflow job names

### Notes
- we had attempted to align the gh workflow job names so they were consistent unfortunately we highlighted that this causes issues with GH actions itself... apparently someone may be using them as identifiers internally causing issues across multiple facets of the `Checks`  =(
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
- Confirm that all checks are running
   - Commit lint
   - Integration testing 20.x, 18.x
   - Build Container Image
   - NPM Audit
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start:stage`
1. next...
-->
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-647](https://issues.redhat.com/browse/DISCOVERY-647)
