### PR TITLE
fix: fix broken apiStage.sh script

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -58,6 +58,7 @@ http {
         location /ui-v1/ {
             rewrite /ui-v1/(.*) /$1 break;
             proxy_pass ${QUIPUCORDS_SERVER_URL};
+            proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -65,6 +66,7 @@ http {
         }
         location /api/ {
             proxy_pass ${QUIPUCORDS_SERVER_URL};
+            proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/scripts/apiStage.sh
+++ b/scripts/apiStage.sh
@@ -74,8 +74,8 @@ stageApi()
     local MOUNT_ARGS=$([[ "$OSTYPE" == "darwin"* ]] && echo "" || echo ":z")
 
     $PODMAN run -itd --rm \
-      -e QPC_SERVER_PASSWORD=$PASSWORD \
-      -e QPC_DBMS=sqlite \
+      -e QUIPUCORDS_SERVER_PASSWORD=$PASSWORD \
+      -e QUIPUCORDS_DBMS=sqlite \
       -p $PORT:443 \
       -v "${HOME}"/.local/share/discovery/log/:/var/log"$MOUNT_ARGS" \
       -v "${HOME}"/.local/share/discovery/data/:/var/data"$MOUNT_ARGS" \

--- a/scripts/apiStage.sh
+++ b/scripts/apiStage.sh
@@ -88,7 +88,7 @@ stageApi() {
       -e QUIPUCORDS_SERVER_PASSWORD=$PASSWORD \
       -e QUIPUCORDS_DBMS=sqlite \
       -e REDIS_HOST=qpc-redis \
-      -p $PORT:443 \
+      -p $PORT:8000 \
       -v "${HOME}"/.local/share/discovery/log/:/var/log"$MOUNT_ARGS" \
       -v "${HOME}"/.local/share/discovery/data/:/var/data"$MOUNT_ARGS" \
       -v "${HOME}"/.local/share/discovery/sshkeys/:/sshkeys"$MOUNT_ARGS" \
@@ -101,7 +101,7 @@ stageApi() {
 
   if [ ! -z "$($PODMAN ps | grep $NAME)" ]; then
     echo "  Container: $($PODMAN ps | grep $NAME | cut -c 1-80)"
-    echo "  QPC container running: https://${HOST}:${PORT}/"
+    echo "  QPC container running: http://${HOST}:${PORT}/"
     printf "  To stop: $ ${GREEN}$PODMAN stop ${NAME}${NOCOLOR}\n"
   fi
 
@@ -117,7 +117,7 @@ stageApi() {
   NOCOLOR="\e[39m"
 
   HOST="127.0.0.1"
-  PORT=9443
+  PORT=8000
   PASSWORD="1_2_3_4_5_"
   CONTAINER="quay.io/quipucords/quipucords:latest"
   PODMAN=""


### PR DESCRIPTION
## What's included

Fix the `apiStage.sh` script as requested at standup on 2024-08-29.

Disclaimer: I do not use or maintain this script. In its current state in this branch, it nominally works on my machine (containers start, and I am able to access the running service in my local browser at http://127.0.0.1:8000), but that's as far as I will test or support this script.

    fix: add missing "proxy_set_header X-Forwarded-Proto $scheme"

    See: https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1724871007554689

    fix: use correct env vars when starting quipucords server container

    See: https://github.com/quipucords/quipucords/pull/2726

    fix: start redis before starting quipucords server

    Modern versions of quipucords require redis.

    I do not use this script, and I do not support it.
    I consider this script to be a hack, and I absolve myself of any responsibility.
    Proper installations of quipucords should use quipucords-installer.
    Use this script at your own risk.

    fix: quipucords serves port 8000 not 443

    See: https://github.com/quipucords/quipucords/pull/2729