### PR TITLE
test: ds-356 adjust mock i18next to output string

### DIFF
--- a/config/jest.setupTests.js
+++ b/config/jest.setupTests.js
@@ -22,7 +22,7 @@ jest.mock('i18next', () => {
  */
 jest.mock('react-i18next', () => ({
   ...jest.requireActual('react-i18next'),
-  useTranslation: () => ({ t: (...args) => args })
+  useTranslation: () => ({ t: (...args) => `t(${JSON.stringify(args, null, 2)})` })
 }));
 
 /**

--- a/src/hooks/__tests__/__snapshots__/useCredentialApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useCredentialApi.test.ts.snap
@@ -18,29 +18,29 @@ exports[`useDeleteCredentialApi should handle errors while attempting to delete 
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential_error",
-          "count": 1,
-          "message": "Mock error",
-          "name": "lorem ipsum dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential_error",
+    "count": 1,
+    "name": "lorem ipsum dolor sit",
+    "message": "Mock error"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential_error",
-          "count": 2,
-          "message": "Mock error",
-          "name": "lorem ipsum, dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential_error",
+    "count": 2,
+    "name": "lorem ipsum, dolor sit",
+    "message": "Mock error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -51,27 +51,27 @@ exports[`useDeleteCredentialApi should handle success while attempting to delete
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential",
-          "count": 1,
-          "name": "lorem ipsum dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential",
+    "count": 1,
+    "name": "lorem ipsum dolor sit"
+  }
+])",
       "variant": "success",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential",
-          "count": 2,
-          "name": "lorem ipsum, dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential",
+    "count": 2,
+    "name": "lorem ipsum, dolor sit"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -82,57 +82,57 @@ exports[`useDeleteCredentialApi should process an API error response: callbackEr
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential_error",
-          "count": 2,
-          "message": "Lorem ipsum",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Lorem ipsum"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential_error",
-          "count": 2,
-          "message": "Dolor sit",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Dolor sit"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential_error",
-          "count": 2,
-          "message": "Amet",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Amet"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential_error",
-          "count": 2,
-          "message": "Unknown error",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -143,41 +143,41 @@ exports[`useDeleteCredentialApi should process an API success response: callback
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "skipped-credential",
-          "count": 2,
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "skipped-credential",
+    "name": "Lorem, Ipsum",
+    "count": 2
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credentials-skipped-credentials",
-          "count": 1,
-          "deleted_names": "Ipsum",
-          "skipped_names": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credentials-skipped-credentials",
+    "deleted_names": "Ipsum",
+    "skipped_names": "Lorem",
+    "count": 1
+  }
+])",
       "variant": "warning",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-credential",
-          "count": 2,
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-credential",
+    "count": 2,
+    "name": "Lorem, Ipsum"
+  }
+])",
       "variant": "success",
     },
   ],

--- a/src/hooks/__tests__/__snapshots__/useScanApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useScanApi.test.ts.snap
@@ -15,14 +15,14 @@ exports[`useCreateScanApi should handle errors while attempting to create a scan
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_created_error",
-          "message": "Unknown error",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_created_error",
+    "name": "Lorem",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -33,13 +33,12 @@ exports[`useCreateScanApi should handle success while attempting to create a sca
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_created",
-          "name": undefined,
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_created"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -50,14 +49,14 @@ exports[`useCreateScanApi should process an API error response: callbackError 1`
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_created_error",
-          "message": "Dolor sit",
-          "name": "Lorem Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_created_error",
+    "name": "Lorem Ipsum",
+    "message": "Dolor sit"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -68,13 +67,13 @@ exports[`useCreateScanApi should process an API success response: callbackSucces
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_created",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_created",
+    "name": "Lorem"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -99,29 +98,29 @@ exports[`useDeleteScanApi should handle errors while attempting to delete single
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan_error",
-          "count": 1,
-          "message": "Mock error",
-          "name": "lorem ipsum dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan_error",
+    "count": 1,
+    "name": "lorem ipsum dolor sit",
+    "message": "Mock error"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan_error",
-          "count": 2,
-          "message": "Mock error",
-          "name": "lorem ipsum, dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan_error",
+    "count": 2,
+    "name": "lorem ipsum, dolor sit",
+    "message": "Mock error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -132,27 +131,27 @@ exports[`useDeleteScanApi should handle success while attempting to delete singl
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan",
-          "count": 1,
-          "name": "lorem ipsum dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan",
+    "count": 1,
+    "name": "lorem ipsum dolor sit"
+  }
+])",
       "variant": "success",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan",
-          "count": 2,
-          "name": "lorem ipsum, dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan",
+    "count": 2,
+    "name": "lorem ipsum, dolor sit"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -163,57 +162,57 @@ exports[`useDeleteScanApi should process an API error response: callbackError 1`
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan_error",
-          "count": 2,
-          "message": "Lorem ipsum",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Lorem ipsum"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan_error",
-          "count": 2,
-          "message": "Dolor sit",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Dolor sit"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan_error",
-          "count": 2,
-          "message": "Amet",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Amet"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan_error",
-          "count": 2,
-          "message": "Unknown error",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -224,14 +223,14 @@ exports[`useDeleteScanApi should process an API success response: callbackSucces
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-scan",
-          "count": 2,
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-scan",
+    "count": 2,
+    "name": "Lorem, Ipsum"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -253,14 +252,14 @@ exports[`useDownloadReportApi should handle errors while attempting to download 
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "report_download_error",
-          "message": "Unknown error",
-          "name": 123,
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "report_download_error",
+    "name": 123,
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -271,13 +270,13 @@ exports[`useDownloadReportApi should handle success while attempting to download
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "report_downloaded",
-          "name": 123,
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "report_downloaded",
+    "name": 123
+  }
+])",
       "variant": "success",
     },
   ],
@@ -288,14 +287,14 @@ exports[`useDownloadReportApi should process an API error response: callbackErro
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "report_download_error",
-          "message": "Dolor sit",
-          "name": 123,
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "report_download_error",
+    "name": 123,
+    "message": "Dolor sit"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -306,13 +305,13 @@ exports[`useDownloadReportApi should process an API success response: callbackSu
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "report_downloaded",
-          "name": 123,
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "report_downloaded",
+    "name": 123
+  }
+])",
       "variant": "success",
     },
   ],
@@ -331,14 +330,14 @@ exports[`useGetScanJobsApi should handle errors while attempting to retrieve a s
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-jobs_fetch_error",
-          "id": 1,
-          "message": "Unknown error",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-jobs_fetch_error",
+    "id": 1,
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -349,13 +348,12 @@ exports[`useGetScanJobsApi should handle success while attempting to retrieve a 
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-jobs_fetched",
-          "count": undefined,
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-jobs_fetched"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -366,14 +364,14 @@ exports[`useGetScanJobsApi should process an API error response: callbackError 1
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-jobs_fetch_error",
-          "id": 1,
-          "message": "Dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-jobs_fetch_error",
+    "id": 1,
+    "message": "Dolor sit"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -384,13 +382,13 @@ exports[`useGetScanJobsApi should process an API success response: callbackSucce
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-jobs_fetched",
-          "count": 1,
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-jobs_fetched",
+    "count": 1
+  }
+])",
       "variant": "success",
     },
   ],
@@ -409,27 +407,27 @@ exports[`useRunScanApi should handle errors while attempting to run a scan: runS
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_play_error",
-          "message": "Unknown error",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_play_error",
+    "name": "Lorem",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_play_error",
-          "message": "Unknown error",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_play_error",
+    "name": "Lorem",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -440,25 +438,25 @@ exports[`useRunScanApi should handle success while attempting to run a scan: run
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_play",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_play",
+    "name": "Lorem"
+  }
+])",
       "variant": "success",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_play",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_play",
+    "name": "Lorem"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -469,14 +467,14 @@ exports[`useRunScanApi should process an API error response: callbackError 1`] =
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_play_error",
-          "message": "Dolor sit",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_play_error",
+    "name": "Lorem",
+    "message": "Dolor sit"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -487,13 +485,13 @@ exports[`useRunScanApi should process an API success response: callbackSuccess 1
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "scan-report_play",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "scan-report_play",
+    "name": "Lorem"
+  }
+])",
       "variant": "success",
     },
   ],

--- a/src/hooks/__tests__/__snapshots__/useSourceApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useSourceApi.test.ts.snap
@@ -20,14 +20,14 @@ exports[`useAddSourceApi should handle errors while attempting to add a source: 
 [
   [
     {
-      "title": [
-        "toast-notifications.title",
-        {
-          "context": "add-source_hidden_error",
-          "message": "Unknown error",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.title",
+  {
+    "context": "add-source_hidden_error",
+    "name": "Lorem",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -38,13 +38,13 @@ exports[`useAddSourceApi should handle success while attempting to add a source:
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "add-source_hidden",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "add-source_hidden",
+    "name": "Lorem"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -69,29 +69,29 @@ exports[`useDeleteSourceApi should handle errors while attempting to delete sing
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source_error",
-          "count": 1,
-          "message": "Mock error",
-          "name": "lorem ipsum dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source_error",
+    "count": 1,
+    "name": "lorem ipsum dolor sit",
+    "message": "Mock error"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source_error",
-          "count": 2,
-          "message": "Mock error",
-          "name": "lorem ipsum, dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source_error",
+    "count": 2,
+    "name": "lorem ipsum, dolor sit",
+    "message": "Mock error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -102,27 +102,27 @@ exports[`useDeleteSourceApi should handle success while attempting to delete sin
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source",
-          "count": 1,
-          "name": "lorem ipsum dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source",
+    "count": 1,
+    "name": "lorem ipsum dolor sit"
+  }
+])",
       "variant": "success",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source",
-          "count": 2,
-          "name": "lorem ipsum, dolor sit",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source",
+    "count": 2,
+    "name": "lorem ipsum, dolor sit"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -133,57 +133,57 @@ exports[`useDeleteSourceApi should process an API error response: callbackError 
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source_error",
-          "count": 2,
-          "message": "Lorem ipsum",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Lorem ipsum"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source_error",
-          "count": 2,
-          "message": "Dolor sit",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Dolor sit"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source_error",
-          "count": 2,
-          "message": "Amet",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Amet"
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source_error",
-          "count": 2,
-          "message": "Unknown error",
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source_error",
+    "count": 2,
+    "name": "Lorem, Ipsum",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -194,41 +194,41 @@ exports[`useDeleteSourceApi should process an API success response: callbackSucc
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "skipped-source",
-          "count": 2,
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "skipped-source",
+    "name": "Lorem, Ipsum",
+    "count": 2
+  }
+])",
       "variant": "danger",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-sources-skipped-sources",
-          "count": 1,
-          "deleted_names": "Ipsum",
-          "skipped_names": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-sources-skipped-sources",
+    "deleted_names": "Ipsum",
+    "skipped_names": "Lorem",
+    "count": 1
+  }
+])",
       "variant": "warning",
     },
   ],
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "deleted-source",
-          "count": 2,
-          "name": "Lorem, Ipsum",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "deleted-source",
+    "count": 2,
+    "name": "Lorem, Ipsum"
+  }
+])",
       "variant": "success",
     },
   ],
@@ -251,14 +251,14 @@ exports[`useEditSourceApi should handle errors while attempting to edit a source
 [
   [
     {
-      "title": [
-        "toast-notifications.title",
-        {
-          "context": "add-source_hidden_error_edit",
-          "message": "Unknown error",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.title",
+  {
+    "context": "add-source_hidden_error_edit",
+    "name": "Lorem",
+    "message": "Unknown error"
+  }
+])",
       "variant": "danger",
     },
   ],
@@ -269,13 +269,13 @@ exports[`useEditSourceApi should handle success while attempting to edit a sourc
 [
   [
     {
-      "title": [
-        "toast-notifications.description",
-        {
-          "context": "add-source_hidden_edit",
-          "name": "Lorem",
-        },
-      ],
+      "title": "t([
+  "toast-notifications.description",
+  {
+    "context": "add-source_hidden_edit",
+    "name": "Lorem"
+  }
+])",
       "variant": "success",
     },
   ],


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- test: ds-356 adjust mock i18next to output string

### Notes
- needed to avoid TS throwing a type string error when we start testing components. Coincidentally, this starts to revert it back towards the parallel v1.8 version
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back as expected, some failures, missing marks for coverage
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->
<!--
### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start:stage`
1. next...
-->

### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. confirm tests come clean

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-356](https://issues.redhat.com/browse/DISCOVERY-356)
relates #420 