### PR TITLE
refactor(simpleDropdown): ds-742 simplify props, test updates

### DIFF
--- a/src/components/simpleDropdown/__tests__/__snapshots__/simpleDropdown.test.tsx.snap
+++ b/src/components/simpleDropdown/__tests__/__snapshots__/simpleDropdown.test.tsx.snap
@@ -1,55 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders proper dom snapshot 1`] = `
-<DocumentFragment>
-  <button
-    aria-expanded="false"
-    aria-label="Dropdown menu"
-    class="pf-v5-c-menu-toggle pf-m-full-width"
-    type="button"
-  >
-    <span
-      class="pf-v5-c-menu-toggle__text"
-    >
-      dropdown label
-    </span>
-    <span
-      class="pf-v5-c-menu-toggle__controls"
-    >
-      <span
-        class="pf-v5-c-menu-toggle__toggle-icon"
-      >
-        <svg
-          aria-hidden="true"
-          class="pf-v5-svg"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          viewBox="0 0 320 512"
-          width="1em"
-        >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          />
-        </svg>
-      </span>
-    </span>
-  </button>
-</DocumentFragment>
-`;
-
-exports[`snapshot after toggle is clicked 1`] = `
+exports[`SimpleDropdown should display items and allow selecting after toggle is clicked: expanded 1`] = `
 <DocumentFragment>
   <button
     aria-expanded="true"
     aria-label="Dropdown menu"
-    class="pf-v5-c-menu-toggle pf-m-expanded pf-m-full-width"
+    class="pf-v5-c-menu-toggle pf-m-expanded"
     type="button"
   >
     <span
       class="pf-v5-c-menu-toggle__text"
     >
-      dropdown label
+      Lorem ipsum
     </span>
     <span
       class="pf-v5-c-menu-toggle__controls"
@@ -75,7 +37,7 @@ exports[`snapshot after toggle is clicked 1`] = `
   </button>
   <div
     class="pf-v5-c-menu"
-    data-ouia-component-id="OUIA-Generated-Dropdown-4"
+    data-ouia-component-id="OUIA-Generated-Dropdown-2"
     data-ouia-component-type="PF5/Dropdown"
     data-ouia-safe="true"
     data-popper-escaped="true"
@@ -109,7 +71,7 @@ exports[`snapshot after toggle is clicked 1`] = `
               <span
                 class="pf-v5-c-menu__item-text"
               >
-                SSLv23
+                dolor
               </span>
             </span>
           </button>
@@ -133,79 +95,7 @@ exports[`snapshot after toggle is clicked 1`] = `
               <span
                 class="pf-v5-c-menu__item-text"
               >
-                TLSv1
-              </span>
-            </span>
-          </button>
-        </li>
-        <li
-          class="pf-v5-c-menu__list-item"
-          data-ouia-component-id="OUIA-Generated-DropdownItem-3"
-          data-ouia-component-type="PF5/DropdownItem"
-          data-ouia-safe="true"
-          role="none"
-        >
-          <button
-            class="pf-v5-c-menu__item"
-            role="menuitem"
-            tabindex="-1"
-            type="button"
-          >
-            <span
-              class="pf-v5-c-menu__item-main"
-            >
-              <span
-                class="pf-v5-c-menu__item-text"
-              >
-                TLSv1.1
-              </span>
-            </span>
-          </button>
-        </li>
-        <li
-          class="pf-v5-c-menu__list-item"
-          data-ouia-component-id="OUIA-Generated-DropdownItem-4"
-          data-ouia-component-type="PF5/DropdownItem"
-          data-ouia-safe="true"
-          role="none"
-        >
-          <button
-            class="pf-v5-c-menu__item"
-            role="menuitem"
-            tabindex="-1"
-            type="button"
-          >
-            <span
-              class="pf-v5-c-menu__item-main"
-            >
-              <span
-                class="pf-v5-c-menu__item-text"
-              >
-                TLSv1.2
-              </span>
-            </span>
-          </button>
-        </li>
-        <li
-          class="pf-v5-c-menu__list-item"
-          data-ouia-component-id="OUIA-Generated-DropdownItem-5"
-          data-ouia-component-type="PF5/DropdownItem"
-          data-ouia-safe="true"
-          role="none"
-        >
-          <button
-            class="pf-v5-c-menu__item"
-            role="menuitem"
-            tabindex="-1"
-            type="button"
-          >
-            <span
-              class="pf-v5-c-menu__item-main"
-            >
-              <span
-                class="pf-v5-c-menu__item-text"
-              >
-                Disable SSL
+                sit
               </span>
             </span>
           </button>
@@ -214,4 +104,31 @@ exports[`snapshot after toggle is clicked 1`] = `
     </div>
   </div>
 </DocumentFragment>
+`;
+
+exports[`SimpleDropdown should display items and allow selecting after toggle is clicked: select 1`] = `
+[
+  [
+    "dolor",
+  ],
+]
+`;
+
+exports[`SimpleDropdown should have a dropdown label: label 1`] = `
+<span
+  class="pf-v5-c-menu-toggle__text"
+>
+  lorem ipsum
+</span>
+`;
+
+exports[`SimpleDropdown should render a basic component: basic 1`] = `
+<Dropdown
+  isOpen={false}
+  onOpenChange={[Function]}
+  onSelect={[Function]}
+  toggle={[Function]}
+>
+  <DropdownList />
+</Dropdown>
 `;

--- a/src/components/simpleDropdown/__tests__/simpleDropdown.test.tsx
+++ b/src/components/simpleDropdown/__tests__/simpleDropdown.test.tsx
@@ -1,181 +1,42 @@
 import React from 'react';
-import { DropdownItem } from '@patternfly/react-core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
-import '@testing-library/jest-dom';
+import { shallowComponent } from '../../../../config/jest.setupTests';
 import { SimpleDropdown } from '../simpleDropdown';
 
-const exampleItems = ['SSLv23', 'TLSv1', 'TLSv1.1', 'TLSv1.2', 'Disable SSL'];
-
-test('renders proper dom snapshot', () => {
-  const setSslProtocol = jest.fn();
-  const { asFragment } = render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
-  expect(asFragment()).toMatchSnapshot();
-});
-
-test('dropdown label is visible', () => {
-  const setSslProtocol = jest.fn();
-  render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
-  expect(screen.getByText('dropdown label')).toBeVisible();
-});
-
-test('options will not show before toggle is clicked', async () => {
-  const setSslProtocol = jest.fn();
-  render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
-  exampleItems.forEach(i => {
-    expect(screen.queryByText(i)).toBeNull();
+describe('SimpleDropdown', () => {
+  it('should render a basic component', async () => {
+    const props = {
+      label: 'lorem ipsum'
+    };
+    const component = await shallowComponent(<SimpleDropdown {...props} />);
+    expect(component).toMatchSnapshot('basic');
   });
-});
 
-test('snapshot after toggle is clicked', async () => {
-  const user = userEvent.setup();
-  const setSslProtocol = jest.fn();
-  const { asFragment } = render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
-  const toggleButton = screen.getByText('dropdown label');
-  await act(() => user.click(toggleButton));
-  expect(asFragment()).toMatchSnapshot();
-});
-
-test('options will show after toggle is clicked', async () => {
-  const user = userEvent.setup();
-  const setSslProtocol = jest.fn();
-  render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
-  const toggleButton = screen.getByText('dropdown label');
-  await act(() => user.click(toggleButton));
-  exampleItems.forEach(i => {
-    expect(screen.getByText(i)).toBeVisible();
+  it('should have a dropdown label', async () => {
+    const props = {
+      label: 'lorem ipsum'
+    };
+    const component = await shallowComponent(<SimpleDropdown {...props} />);
+    expect(component.querySelector('button > span')).toMatchSnapshot('label');
   });
-});
 
-test('menu will go away after toggle is clicked twice', async () => {
-  const user = userEvent.setup();
-  const setSslProtocol = jest.fn();
-  render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
+  it('should display items and allow selecting after toggle is clicked', async () => {
+    const user = userEvent.setup();
+    const onMockSelect = jest.fn();
 
-  const toggleButton = screen.getByText('dropdown label');
+    const props = {
+      label: 'Lorem ipsum',
+      onSelect: onMockSelect,
+      dropdownItems: ['dolor', 'sit']
+    };
 
-  await act(() => user.click(toggleButton));
-  await act(() => user.click(toggleButton));
-  await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
-});
+    const { asFragment } = render(<SimpleDropdown {...props} />);
 
-test('menu will go away after option selected', async () => {
-  const user = userEvent.setup();
-  const setSslProtocol = jest.fn();
-  render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
-  const toggleButton = screen.getByText('dropdown label');
-  await act(() => user.click(toggleButton));
+    await user.click(screen.getByText(props.label));
+    expect(asFragment()).toMatchSnapshot('expanded');
 
-  const option = screen.getByText(exampleItems[2]);
-  await act(() => user.click(option));
-
-  await waitFor(
-    () => {
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-    },
-    { timeout: 1000 }
-  );
-});
-
-test('onclick callback should get called when clicked', async () => {
-  const user = userEvent.setup();
-  const setSslProtocol = jest.fn();
-  render(
-    <SimpleDropdown
-      isFullWidth
-      label="dropdown label"
-      variant={'default'}
-      dropdownItems={exampleItems.map(s => (
-        <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-          {s}
-        </DropdownItem>
-      ))}
-    />
-  );
-  expect(setSslProtocol).toHaveBeenCalledTimes(0);
-  const toggleButton = screen.getByText('dropdown label');
-  await act(() => user.click(toggleButton));
-
-  const option = screen.getByText(exampleItems[2]);
-  await act(() => user.click(option));
-  expect(setSslProtocol).toHaveBeenCalledTimes(1);
-  expect(setSslProtocol).toHaveBeenCalledWith(exampleItems[2]);
+    await user.click(screen.getByText('dolor'));
+    expect(onMockSelect.mock.calls).toMatchSnapshot('select');
+  });
 });

--- a/src/components/simpleDropdown/simpleDropdown.tsx
+++ b/src/components/simpleDropdown/simpleDropdown.tsx
@@ -6,22 +6,29 @@
  * @module simpleDropdown
  */
 import React, { useState } from 'react';
-import { Dropdown, DropdownList, MenuToggle, type MenuToggleElement } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  type MenuToggleElement,
+  type MenuToggleProps
+} from '@patternfly/react-core';
 
-export interface ISimpleDropdownProps {
+interface SimpleDropdownProps {
   label: string;
-  dropdownItems?: React.ReactNode[];
+  dropdownItems?: string[];
   ariaLabel?: string;
-  onSelect?: () => void;
-  variant: 'default' | 'plain' | 'primary' | 'secondary';
+  onSelect?: (item: string) => void;
+  variant?: MenuToggleProps['variant'];
   isFullWidth?: boolean;
 }
 
-export const SimpleDropdown: React.FC<ISimpleDropdownProps> = ({
+const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
   label,
   dropdownItems,
-  ariaLabel,
-  onSelect,
+  ariaLabel = 'Dropdown menu',
+  onSelect = Function.prototype,
   variant,
   isFullWidth
 }) => {
@@ -33,7 +40,6 @@ export const SimpleDropdown: React.FC<ISimpleDropdownProps> = ({
       onOpenChange={isOpen => setIsOpen(isOpen)}
       onSelect={() => {
         setIsOpen(false);
-        onSelect && onSelect();
       }}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <MenuToggle
@@ -42,14 +48,23 @@ export const SimpleDropdown: React.FC<ISimpleDropdownProps> = ({
           isExpanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
           variant={variant}
-          aria-label={ariaLabel || 'Dropdown menu'}
+          aria-label={ariaLabel}
           isDisabled={!dropdownItems || dropdownItems.length === 0}
         >
           {label}
         </MenuToggle>
       )}
     >
-      <DropdownList>{dropdownItems}</DropdownList>
+      <DropdownList>
+        {Array.isArray(dropdownItems) &&
+          dropdownItems.map(item => (
+            <DropdownItem key={item} onClick={() => onSelect(item)}>
+              {item}
+            </DropdownItem>
+          ))}
+      </DropdownList>
     </Dropdown>
   );
 };
+
+export { SimpleDropdown as default, SimpleDropdown, type SimpleDropdownProps };

--- a/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
+++ b/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
@@ -116,22 +116,13 @@ exports[`CredentialFormFields should render a basic component: basic 1`] = `
     <SimpleDropdown
       dropdownItems={
         [
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            Username and Password
-          </DropdownItem>,
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            SSH Key
-          </DropdownItem>,
+          "Username and Password",
+          "SSH Key",
         ]
       }
       isFullWidth={true}
       label="Username and Password"
+      onSelect={[Function]}
       variant="default"
     />
   </FormGroup>
@@ -172,64 +163,20 @@ exports[`CredentialFormFields should render a basic component: basic 1`] = `
       <SimpleDropdown
         dropdownItems={
           [
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              Select option
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              sudo
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              su
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              pbrun
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              pfexec
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              doas
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              dzdo
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              ksu
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              runas
-            </DropdownItem>,
+            "Select option",
+            "sudo",
+            "su",
+            "pbrun",
+            "pfexec",
+            "doas",
+            "dzdo",
+            "ksu",
+            "runas",
           ]
         }
         isFullWidth={true}
         label="Select option"
+        onSelect={[Function]}
         variant="default"
       />
     </FormGroup>
@@ -284,22 +231,13 @@ exports[`CredentialFormFields should render specific to authType for type networ
     <SimpleDropdown
       dropdownItems={
         [
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            Username and Password
-          </DropdownItem>,
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            SSH Key
-          </DropdownItem>,
+          "Username and Password",
+          "SSH Key",
         ]
       }
       isFullWidth={true}
       label="SSH Key"
+      onSelect={[Function]}
       variant="default"
     />
   </FormGroup>
@@ -340,64 +278,20 @@ exports[`CredentialFormFields should render specific to authType for type networ
       <SimpleDropdown
         dropdownItems={
           [
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              Select option
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              sudo
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              su
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              pbrun
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              pfexec
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              doas
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              dzdo
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              ksu
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              runas
-            </DropdownItem>,
+            "Select option",
+            "sudo",
+            "su",
+            "pbrun",
+            "pfexec",
+            "doas",
+            "dzdo",
+            "ksu",
+            "runas",
           ]
         }
         isFullWidth={true}
         label="Select option"
+        onSelect={[Function]}
         variant="default"
       />
     </FormGroup>
@@ -452,22 +346,13 @@ exports[`CredentialFormFields should render specific to authType for type networ
     <SimpleDropdown
       dropdownItems={
         [
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            Username and Password
-          </DropdownItem>,
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            SSH Key
-          </DropdownItem>,
+          "Username and Password",
+          "SSH Key",
         ]
       }
       isFullWidth={true}
       label="Username and Password"
+      onSelect={[Function]}
       variant="default"
     />
   </FormGroup>
@@ -508,64 +393,20 @@ exports[`CredentialFormFields should render specific to authType for type networ
       <SimpleDropdown
         dropdownItems={
           [
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              Select option
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              sudo
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              su
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              pbrun
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              pfexec
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              doas
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              dzdo
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              ksu
-            </DropdownItem>,
-            <DropdownItem
-              component="button"
-              onClick={[Function]}
-            >
-              runas
-            </DropdownItem>,
+            "Select option",
+            "sudo",
+            "su",
+            "pbrun",
+            "pfexec",
+            "doas",
+            "dzdo",
+            "ksu",
+            "runas",
           ]
         }
         isFullWidth={true}
         label="Select option"
+        onSelect={[Function]}
         variant="default"
       />
     </FormGroup>
@@ -620,22 +461,13 @@ exports[`CredentialFormFields should render specific to authType for type opensh
     <SimpleDropdown
       dropdownItems={
         [
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            Token
-          </DropdownItem>,
-          <DropdownItem
-            component="button"
-            onClick={[Function]}
-          >
-            Username and Password
-          </DropdownItem>,
+          "Token",
+          "Username and Password",
         ]
       }
       isFullWidth={true}
       label="SSH Key"
+      onSelect={[Function]}
       variant="default"
     />
   </FormGroup>

--- a/src/views/credentials/addCredentialModal.tsx
+++ b/src/views/credentials/addCredentialModal.tsx
@@ -4,17 +4,7 @@
  * @module AddCredentialModal
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  ActionGroup,
-  Button,
-  DropdownItem,
-  Form,
-  FormGroup,
-  Modal,
-  ModalVariant,
-  TextArea,
-  TextInput
-} from '@patternfly/react-core';
+import { ActionGroup, Button, Form, FormGroup, Modal, ModalVariant, TextArea, TextInput } from '@patternfly/react-core';
 import { SimpleDropdown } from '../../components/simpleDropdown/simpleDropdown';
 import { type CredentialType } from '../../types/types';
 
@@ -122,18 +112,9 @@ const CredentialFormFields: React.FC<CredentialFormFieldsProps> = ({
           label={authType}
           variant="default"
           isFullWidth
+          onSelect={item => setAuthType(item)}
           dropdownItems={
-            typeValue === 'network'
-              ? ['Username and Password', 'SSH Key'].map(s => (
-                  <DropdownItem key={s} component="button" onClick={() => setAuthType(s)}>
-                    {s}
-                  </DropdownItem>
-                ))
-              : ['Token', 'Username and Password'].map(s => (
-                  <DropdownItem key={s} component="button" onClick={() => setAuthType(s)}>
-                    {s}
-                  </DropdownItem>
-                ))
+            (typeValue === 'network' && ['Username and Password', 'SSH Key']) || ['Token', 'Username and Password']
           }
         />
       </FormGroup>
@@ -216,20 +197,8 @@ const CredentialFormFields: React.FC<CredentialFormFieldsProps> = ({
             label={formData?.become_method || 'Select option'}
             variant="default"
             isFullWidth
-            dropdownItems={[
-              <DropdownItem key="none" component="button" onClick={() => handleInputChange('become_method', '')}>
-                Select option
-              </DropdownItem>,
-              ...['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas'].map(method => (
-                <DropdownItem
-                  key={method}
-                  component="button"
-                  onClick={() => handleInputChange('become_method', method)}
-                >
-                  {method}
-                </DropdownItem>
-              ))
-            ]}
+            onSelect={item => handleInputChange('become_method', (item !== 'Select option' && item) || '')}
+            dropdownItems={['Select option', 'sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas']}
           />
         </FormGroup>
         <FormGroup label="Become User" fieldId="become_user">

--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -21,7 +21,6 @@ import {
   AlertVariant,
   Button,
   ButtonVariant,
-  DropdownItem,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -185,6 +184,7 @@ const CredentialsListView: React.FunctionComponent = () => {
     <SimpleDropdown
       label={t('view.empty-state_label_credentials')}
       variant="primary"
+      onSelect={item => setAddCredentialModal(item)}
       dropdownItems={[
         t('dataSource.network'),
         t('dataSource.openshift'),
@@ -192,11 +192,7 @@ const CredentialsListView: React.FunctionComponent = () => {
         t('dataSource.satellite'),
         t('dataSource.vcenter'),
         t('dataSource.ansible')
-      ].map(type => (
-        <DropdownItem key={type} onClick={() => setAddCredentialModal(type)}>
-          {type}
-        </DropdownItem>
-      ))}
+      ]}
     />
   );
 

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -11,7 +11,6 @@ import {
   ActionGroup,
   Button,
   Checkbox,
-  DropdownItem,
   Form,
   FormContextProvider,
   FormGroup,
@@ -190,11 +189,8 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ isOpen, source, sourceT
                     isFullWidth
                     label={sslProtocol}
                     variant={'default'}
-                    dropdownItems={['SSLv23', 'TLSv1', 'TLSv1.1', 'TLSv1.2', 'Disable SSL'].map(s => (
-                      <DropdownItem key={s} onClick={() => setSslProtocol(s)}>
-                        {s}
-                      </DropdownItem>
-                    ))}
+                    onSelect={item => setSslProtocol(item)}
+                    dropdownItems={['SSLv23', 'TLSv1', 'TLSv1.1', 'TLSv1.2', 'Disable SSL']}
                   />
                 </FormGroup>
                 <FormGroup label="" fieldId="ssl_verify">

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -21,7 +21,6 @@ import {
   AlertVariant,
   Button,
   ButtonVariant,
-  DropdownItem,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -243,6 +242,7 @@ const SourcesListView: React.FunctionComponent = () => {
     <SimpleDropdown
       label={t('view.empty-state_label_sources')}
       variant="primary"
+      onSelect={item => setAddSourceModal(item)}
       dropdownItems={[
         t('dataSource.network'),
         t('dataSource.openshift'),
@@ -250,11 +250,7 @@ const SourcesListView: React.FunctionComponent = () => {
         t('dataSource.satellite'),
         t('dataSource.vcenter'),
         t('dataSource.ansible')
-      ].map(type => (
-        <DropdownItem key={type} onClick={() => setAddSourceModal(type)}>
-          {type}
-        </DropdownItem>
-      ))}
+      ]}
     />
   );
 

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -28,6 +28,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "views/scans/showScansModal.tsx:70:      console.log({ aValue, bValue });",
-  "views/sources/addSourceModal.tsx:55:      .catch(err => console.error(err));",
+  "views/sources/addSourceModal.tsx:54:      .catch(err => console.error(err));",
 ]
 `;


### PR DESCRIPTION

## What's included
<!-- Summary of changes/additions -->
- refactor(simpleDropdown): ds-742 simplify props, test updates

### Notes
- extends simpledropdown so you no longer have to drop a list of components as options
- squash the act warnings that were popping up in the test framework for this component
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back as expected
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm the simple dropdown component displays as expected in
   - viewSourcesList.tsx in the toolbar, "add a source"
   - viewCredentialsList.tsx in the toolbar, "add a cred"
   - and addSourceModal add a "Connection type"

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-742](https://issues.redhat.com/browse/DISCOVERY-742) 
