### PR TITLE
fix: ds-391 render correct fields to add-cred network

### DIFF
--- a/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
+++ b/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`AddCredentialModal should render a basic component: basic 1`] = `
           "name": "",
           "password": "",
           "ssh_key": "",
+          "ssh_passphrase": "",
           "username": "",
         }
       }
@@ -154,8 +155,6 @@ exports[`CredentialFormFields should render a basic component: basic 1`] = `
         type="password"
       />
     </FormGroup>
-  </React.Fragment>
-  <React.Fragment>
     <FormGroup
       fieldId="become_method"
       label="Become Method"
@@ -269,53 +268,15 @@ exports[`CredentialFormFields should render specific to authType for type networ
         rows={10}
       />
     </FormGroup>
-  </React.Fragment>
-  <React.Fragment>
     <FormGroup
-      fieldId="become_method"
-      label="Become Method"
-    >
-      <SimpleDropdown
-        dropdownItems={
-          [
-            "Select option",
-            "sudo",
-            "su",
-            "pbrun",
-            "pfexec",
-            "doas",
-            "dzdo",
-            "ksu",
-            "runas",
-          ]
-        }
-        isFullWidth={true}
-        label="Select option"
-        onSelect={[Function]}
-        variant="default"
-      />
-    </FormGroup>
-    <FormGroup
-      fieldId="become_user"
-      label="Become User"
+      fieldId="ssh_passphrase"
+      label="SSH passphrase"
     >
       <TextInput
-        id="become_user"
-        name="become_user"
+        id="ssh_passphrase"
+        name="ssh_passphrase"
         onChange={[Function]}
-        placeholder="Enter become user (optional)"
-        type="text"
-      />
-    </FormGroup>
-    <FormGroup
-      fieldId="become_password"
-      label="Become Password"
-    >
-      <TextInput
-        id="become_password"
-        name="become_password"
-        onChange={[Function]}
-        placeholder="Enter become password (optional)"
+        placeholder="Enter SSH passphrase (optional)"
         type="password"
       />
     </FormGroup>
@@ -384,8 +345,6 @@ exports[`CredentialFormFields should render specific to authType for type networ
         type="password"
       />
     </FormGroup>
-  </React.Fragment>
-  <React.Fragment>
     <FormGroup
       fieldId="become_method"
       label="Become Method"
@@ -438,7 +397,7 @@ exports[`CredentialFormFields should render specific to authType for type networ
 </React.Fragment>
 `;
 
-exports[`CredentialFormFields should render specific to authType for type openshift: openshift, SSH Key 1`] = `
+exports[`CredentialFormFields should render specific to authType for type openshift: openshift, "Token" 1`] = `
 <React.Fragment>
   <FormGroup
     fieldId="name"
@@ -466,7 +425,57 @@ exports[`CredentialFormFields should render specific to authType for type opensh
         ]
       }
       isFullWidth={true}
-      label="SSH Key"
+      label="Token"
+      onSelect={[Function]}
+      variant="default"
+    />
+  </FormGroup>
+  <FormGroup
+    fieldId="auth_token"
+    isRequired={true}
+    label="Token"
+  >
+    <TextInput
+      id="credential-token"
+      isRequired={true}
+      name="auth_token"
+      onChange={[Function]}
+      placeholder="Enter Token"
+      type="text"
+    />
+  </FormGroup>
+</React.Fragment>
+`;
+
+exports[`CredentialFormFields should render specific to authType for type openshift: openshift, "Username and Password" 1`] = `
+<React.Fragment>
+  <FormGroup
+    fieldId="name"
+    isRequired={true}
+    label="Name"
+  >
+    <TextInput
+      id="credential-name"
+      isRequired={true}
+      name="name"
+      onChange={[Function]}
+      placeholder="Enter a name for the credential"
+      type="text"
+    />
+  </FormGroup>
+  <FormGroup
+    fieldId="auth_type"
+    label="Authentication Type"
+  >
+    <SimpleDropdown
+      dropdownItems={
+        [
+          "Token",
+          "Username and Password",
+        ]
+      }
+      isFullWidth={true}
+      label="Username and Password"
       onSelect={[Function]}
       variant="default"
     />
@@ -486,17 +495,65 @@ exports[`CredentialFormFields should render specific to authType for type opensh
       />
     </FormGroup>
     <FormGroup
-      fieldId="ssh_key"
+      fieldId="password"
       isRequired={true}
-      label="SSH Key"
+      label="Password"
     >
-      <TextArea
-        id="credential-ssh-key"
+      <TextInput
+        id="credential-password"
         isRequired={true}
-        name="ssh_key"
+        name="password"
         onChange={[Function]}
-        placeholder="Enter SSH Key"
-        rows={10}
+        placeholder="Enter password"
+        type="password"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="become_method"
+      label="Become Method"
+    >
+      <SimpleDropdown
+        dropdownItems={
+          [
+            "Select option",
+            "sudo",
+            "su",
+            "pbrun",
+            "pfexec",
+            "doas",
+            "dzdo",
+            "ksu",
+            "runas",
+          ]
+        }
+        isFullWidth={true}
+        label="Select option"
+        onSelect={[Function]}
+        variant="default"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="become_user"
+      label="Become User"
+    >
+      <TextInput
+        id="become_user"
+        name="become_user"
+        onChange={[Function]}
+        placeholder="Enter become user (optional)"
+        type="text"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="become_password"
+      label="Become Password"
+    >
+      <TextInput
+        id="become_password"
+        name="become_password"
+        onChange={[Function]}
+        placeholder="Enter become password (optional)"
+        type="password"
       />
     </FormGroup>
   </React.Fragment>
@@ -520,6 +577,7 @@ exports[`useCredentialForm should initialize formData correctly: formData 1`] = 
   "name": "",
   "password": "",
   "ssh_key": "",
+  "ssh_passphrase": "",
   "username": "",
 }
 `;

--- a/src/views/credentials/__tests__/addCredentialModal.test.tsx
+++ b/src/views/credentials/__tests__/addCredentialModal.test.tsx
@@ -97,8 +97,13 @@ describe('CredentialFormFields', () => {
   });
 
   it('should render specific to authType for type openshift', async () => {
-    const openshiftSshKey = await shallowComponent(<CredentialFormFields typeValue="openshift" authType="SSH Key" />);
-    expect(openshiftSshKey).toMatchSnapshot('openshift, SSH Key');
+    const openshiftUsernamePassword = await shallowComponent(
+      <CredentialFormFields typeValue="openshift" authType="Username and Password" />
+    );
+    expect(openshiftUsernamePassword).toMatchSnapshot('openshift, "Username and Password"');
+
+    const openshiftToken = await shallowComponent(<CredentialFormFields typeValue="openshift" authType="Token" />);
+    expect(openshiftToken).toMatchSnapshot('openshift, "Token"');
   });
 
   it('should call handlers for setAuthType and handleInputChange', async () => {

--- a/src/views/credentials/addCredentialModal.tsx
+++ b/src/views/credentials/addCredentialModal.tsx
@@ -34,6 +34,7 @@ const useCredentialForm = (credentialType: string | undefined, credential?: Cred
     become_user: '',
     name: '',
     ssh_key: '',
+    ssh_passphrase: '',
     become_password: '',
     authenticationType: '',
     auth_token: '',
@@ -159,39 +160,6 @@ const CredentialFormFields: React.FC<CredentialFormFieldsProps> = ({
             onChange={event => handleInputChange('password', (event.target as HTMLInputElement).value)}
           />
         </FormGroup>
-      </React.Fragment>
-    )}
-
-    {/* SSH Key input */}
-    {authType === 'SSH Key' && (
-      <React.Fragment>
-        <FormGroup label="Username" isRequired fieldId="username">
-          <TextInput
-            value={formData?.username}
-            isRequired
-            placeholder="Enter username"
-            id="credential-username"
-            name="username"
-            onChange={event => handleInputChange('username', (event.target as HTMLInputElement).value)}
-          />
-        </FormGroup>
-        <FormGroup label="SSH Key" isRequired fieldId="ssh_key">
-          <TextArea
-            value={formData?.ssh_key}
-            placeholder="Enter SSH Key"
-            isRequired
-            id="credential-ssh-key"
-            name="ssh_key"
-            onChange={event => handleInputChange('ssh_key', event.target.value)}
-            rows={10}
-          />
-        </FormGroup>
-      </React.Fragment>
-    )}
-
-    {/* Network specific fields */}
-    {typeValue === 'network' && (
-      <React.Fragment>
         <FormGroup label="Become Method" fieldId="become_method">
           <SimpleDropdown
             label={formData?.become_method || 'Select option'}
@@ -219,6 +187,43 @@ const CredentialFormFields: React.FC<CredentialFormFieldsProps> = ({
             id="become_password"
             name="become_password"
             onChange={event => handleInputChange('become_password', (event.target as HTMLInputElement).value)}
+          />
+        </FormGroup>
+      </React.Fragment>
+    )}
+
+    {/* SSH Key input */}
+    {authType === 'SSH Key' && (
+      <React.Fragment>
+        <FormGroup label="Username" isRequired fieldId="username">
+          <TextInput
+            value={formData?.username}
+            isRequired
+            placeholder="Enter username"
+            id="credential-username"
+            name="username"
+            onChange={event => handleInputChange('username', (event.target as HTMLInputElement).value)}
+          />
+        </FormGroup>
+        <FormGroup label="SSH Key" isRequired fieldId="ssh_key">
+          <TextArea
+            value={formData?.ssh_key}
+            placeholder="Enter SSH Key"
+            isRequired
+            id="credential-ssh-key"
+            name="ssh_key"
+            onChange={event => handleInputChange('ssh_key', event.target.value)}
+            rows={10}
+          />
+        </FormGroup>
+        <FormGroup label="SSH passphrase" fieldId="ssh_passphrase">
+          <TextInput
+            value={formData?.ssh_passphrase}
+            placeholder="Enter SSH passphrase (optional)"
+            type="password"
+            id="ssh_passphrase"
+            name="ssh_passphrase"
+            onChange={event => handleInputChange('ssh_passphrase', (event.target as HTMLInputElement).value)}
           />
         </FormGroup>
       </React.Fragment>


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix: ds-391 render correct fields to add-cred network

### Notes
- fix addCredentialModal test for openshift auth type options
- fix correct field rendering for addCredentialModal, network source type 

<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...
![Screenshot from 2024-09-09 14-36-40](https://github.com/user-attachments/assets/dd81e0b4-225e-44cd-9969-1b4ae428027b)
![Screenshot from 2024-09-09 14-36-31](https://github.com/user-attachments/assets/73c4ffc6-8b1b-4d35-abe9-efe8e6ac7851)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-391](https://issues.redhat.com/browse/DISCOVERY-391)
