### PR TITLE
feat: exclusively serve the current "new" UI

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -10,7 +10,7 @@ CERTS_PATH="/opt/app-root/certs"
 # verify if user provided certificates exist or create a self signed certificate.
 mkdir -p ${CERTS_PATH}
 
-if ([ -f "${CERTS_PATH}/server.key" ] && [ -f "${CERTS_PATH}/server.crt" ]); then
+if [ -f "${CERTS_PATH}/server.key" ] && [ -f "${CERTS_PATH}/server.crt" ]; then
     echo "Using user provided certificates..."
     openssl rsa -in "${CERTS_PATH}/server.key" -check
     openssl x509 -in "${CERTS_PATH}/server.crt" -text -noout
@@ -27,9 +27,9 @@ else
     exit 1
 fi
 
-envsubst "\$QUIPUCORDS_APP_PORT,\$QUIPUCORDS_APP_ENABLE_V2UI,\$QUIPUCORDS_SERVER_URL" \
-    < /etc/nginx/nginx.conf.template \
-    > /etc/nginx/nginx.conf
+envsubst "\$QUIPUCORDS_APP_PORT,\$QUIPUCORDS_SERVER_URL" \
+    </etc/nginx/nginx.conf.template \
+    >/etc/nginx/nginx.conf
 
 mkdir -p /var/log/nginx
 nginx -g "daemon off;"

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -32,7 +32,7 @@ http {
         listen       8079 default_server;
         listen       [::]:8079 default_server;
         server_name  _;
-        return 301 https://$host$request_uri;
+        return 301   https://$host$request_uri;
     }
 
     server {
@@ -49,20 +49,7 @@ http {
         ssl_prefer_server_ciphers on;
 
         location / {
-            set $enable_v2ui "${QUIPUCORDS_APP_ENABLE_V2UI}";
-            if ($enable_v2ui = "0") {
-               rewrite (.*) /ui-v1$1 last;
-            }
             try_files $uri /index.html;
-        }
-        location /ui-v1/ {
-            rewrite /ui-v1/(.*) /$1 break;
-            proxy_pass ${QUIPUCORDS_SERVER_URL};
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass_header X-CSRFToken;
         }
         location /api/ {
             proxy_pass ${QUIPUCORDS_SERVER_URL};


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-356

## What's included
Actually serve the new login UI from the UI container. Stop serving any of the old login UI or old UI in general.

## How to test
- build the container image (`make build-container`) and tag it appropriately.
- set your new container image name/tag in an installer overrides file. For example…
  ```
  cat ~/.config/quipucords-installer-overrides/quipucords-app.container
  [Container]
  Image=localhost/quipucords-ui:latest
  ```
- run the installer with your overrides directory, and start the containers. For example…
  ```
  quipucords-installer --override-conf-dir ~/.config/quipucords-installer-overrides install
  systemctl --user start quipucords-app
  ```
- go to https://localhost:9443 in your browser
- observe all new UI.

## Updates issue/story
https://issues.redhat.com/browse/DISCOVERY-356