### PR TITLE
fix(credential): ds-391 correct rendered fields

### DIFF
--- a/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
+++ b/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
@@ -155,6 +155,8 @@ exports[`CredentialFormFields should render a basic component: basic 1`] = `
         type="password"
       />
     </FormGroup>
+  </React.Fragment>
+  <React.Fragment>
     <FormGroup
       fieldId="become_method"
       label="Become Method"
@@ -200,6 +202,102 @@ exports[`CredentialFormFields should render a basic component: basic 1`] = `
         name="become_password"
         onChange={[Function]}
         placeholder="Enter become password (optional)"
+        type="password"
+      />
+    </FormGroup>
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`CredentialFormFields should render ansible form appropriately: ansible, "Username and Password" 1`] = `
+<React.Fragment>
+  <FormGroup
+    fieldId="name"
+    isRequired={true}
+    label="Name"
+  >
+    <TextInput
+      id="credential-name"
+      isRequired={true}
+      name="name"
+      onChange={[Function]}
+      placeholder="Enter a name for the credential"
+      type="text"
+    />
+  </FormGroup>
+  <React.Fragment>
+    <FormGroup
+      fieldId="username"
+      isRequired={true}
+      label="Username"
+    >
+      <TextInput
+        id="credential-username"
+        isRequired={true}
+        name="username"
+        onChange={[Function]}
+        placeholder="Enter username"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="password"
+      isRequired={true}
+      label="Password"
+    >
+      <TextInput
+        id="credential-password"
+        isRequired={true}
+        name="password"
+        onChange={[Function]}
+        placeholder="Enter password"
+        type="password"
+      />
+    </FormGroup>
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`CredentialFormFields should render satellite form appropriately: satellite, "Username and Password" 1`] = `
+<React.Fragment>
+  <FormGroup
+    fieldId="name"
+    isRequired={true}
+    label="Name"
+  >
+    <TextInput
+      id="credential-name"
+      isRequired={true}
+      name="name"
+      onChange={[Function]}
+      placeholder="Enter a name for the credential"
+      type="text"
+    />
+  </FormGroup>
+  <React.Fragment>
+    <FormGroup
+      fieldId="username"
+      isRequired={true}
+      label="Username"
+    >
+      <TextInput
+        id="credential-username"
+        isRequired={true}
+        name="username"
+        onChange={[Function]}
+        placeholder="Enter username"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="password"
+      isRequired={true}
+      label="Password"
+    >
+      <TextInput
+        id="credential-password"
+        isRequired={true}
+        name="password"
+        onChange={[Function]}
+        placeholder="Enter password"
         type="password"
       />
     </FormGroup>
@@ -284,6 +382,56 @@ exports[`CredentialFormFields should render specific to authType for type networ
       />
     </FormGroup>
   </React.Fragment>
+  <React.Fragment>
+    <FormGroup
+      fieldId="become_method"
+      label="Become Method"
+    >
+      <SimpleDropdown
+        dropdownItems={
+          [
+            "Select option",
+            "sudo",
+            "su",
+            "pbrun",
+            "pfexec",
+            "doas",
+            "dzdo",
+            "ksu",
+            "runas",
+          ]
+        }
+        isFullWidth={true}
+        label="Select option"
+        onSelect={[Function]}
+        variant="default"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="become_user"
+      label="Become User"
+    >
+      <TextInput
+        id="become_user"
+        name="become_user"
+        onChange={[Function]}
+        placeholder="Enter become user (optional)"
+        type="text"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="become_password"
+      label="Become Password"
+    >
+      <TextInput
+        id="become_password"
+        name="become_password"
+        onChange={[Function]}
+        placeholder="Enter become password (optional)"
+        type="password"
+      />
+    </FormGroup>
+  </React.Fragment>
 </React.Fragment>
 `;
 
@@ -348,6 +496,8 @@ exports[`CredentialFormFields should render specific to authType for type networ
         type="password"
       />
     </FormGroup>
+  </React.Fragment>
+  <React.Fragment>
     <FormGroup
       fieldId="become_method"
       label="Become Method"
@@ -511,51 +661,51 @@ exports[`CredentialFormFields should render specific to authType for type opensh
         type="password"
       />
     </FormGroup>
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`CredentialFormFields should render vcenter form appropriately: vcenter, "Username and Password" 1`] = `
+<React.Fragment>
+  <FormGroup
+    fieldId="name"
+    isRequired={true}
+    label="Name"
+  >
+    <TextInput
+      id="credential-name"
+      isRequired={true}
+      name="name"
+      onChange={[Function]}
+      placeholder="Enter a name for the credential"
+      type="text"
+    />
+  </FormGroup>
+  <React.Fragment>
     <FormGroup
-      fieldId="become_method"
-      label="Become Method"
+      fieldId="username"
+      isRequired={true}
+      label="Username"
     >
-      <SimpleDropdown
-        dropdownItems={
-          [
-            "Select option",
-            "sudo",
-            "su",
-            "pbrun",
-            "pfexec",
-            "doas",
-            "dzdo",
-            "ksu",
-            "runas",
-          ]
-        }
-        isFullWidth={true}
-        label="Select option"
-        onSelect={[Function]}
-        variant="default"
+      <TextInput
+        id="credential-username"
+        isRequired={true}
+        name="username"
+        onChange={[Function]}
+        placeholder="Enter username"
       />
     </FormGroup>
     <FormGroup
-      fieldId="become_user"
-      label="Become User"
+      fieldId="password"
+      isRequired={true}
+      label="Password"
     >
       <TextInput
-        id="become_user"
-        name="become_user"
+        id="credential-password"
+        isRequired={true}
+        name="password"
         onChange={[Function]}
-        placeholder="Enter become user (optional)"
-        type="text"
-      />
-    </FormGroup>
-    <FormGroup
-      fieldId="become_password"
-      label="Become Password"
-    >
-      <TextInput
-        id="become_password"
-        name="become_password"
-        onChange={[Function]}
-        placeholder="Enter become password (optional)"
+        placeholder="Enter password"
         type="password"
       />
     </FormGroup>

--- a/src/views/credentials/__tests__/addCredentialModal.test.tsx
+++ b/src/views/credentials/__tests__/addCredentialModal.test.tsx
@@ -106,6 +106,21 @@ describe('CredentialFormFields', () => {
     expect(openshiftToken).toMatchSnapshot('openshift, "Token"');
   });
 
+  it('should render vcenter form appropriately', async () => {
+    const vcenter = await shallowComponent(<CredentialFormFields typeValue="vcenter" />);
+    expect(vcenter).toMatchSnapshot('vcenter, "Username and Password"');
+  });
+
+  it('should render satellite form appropriately', async () => {
+    const satellite = await shallowComponent(<CredentialFormFields typeValue="satellite" />);
+    expect(satellite).toMatchSnapshot('satellite, "Username and Password"');
+  });
+
+  it('should render ansible form appropriately', async () => {
+    const ansible = await shallowComponent(<CredentialFormFields typeValue="ansible" />);
+    expect(ansible).toMatchSnapshot('ansible, "Username and Password"');
+  });
+
   it('should call handlers for setAuthType and handleInputChange', async () => {
     const mockHandleInputChange = jest.fn();
     const mockSetAuthType = jest.fn();

--- a/src/views/credentials/addCredentialModal.tsx
+++ b/src/views/credentials/addCredentialModal.tsx
@@ -170,35 +170,6 @@ const CredentialFormFields: React.FC<CredentialFormFieldsProps> = ({
             onChange={event => handleInputChange('password', (event.target as HTMLInputElement).value)}
           />
         </FormGroup>
-        <FormGroup label="Become Method" fieldId="become_method">
-          <SimpleDropdown
-            label={formData?.become_method || 'Select option'}
-            variant="default"
-            isFullWidth
-            onSelect={item => handleInputChange('become_method', (item !== 'Select option' && item) || '')}
-            dropdownItems={['Select option', 'sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas']}
-          />
-        </FormGroup>
-        <FormGroup label="Become User" fieldId="become_user">
-          <TextInput
-            value={formData?.become_user}
-            placeholder="Enter become user (optional)"
-            type="text"
-            id="become_user"
-            name="become_user"
-            onChange={event => handleInputChange('become_user', (event.target as HTMLInputElement).value)}
-          />
-        </FormGroup>
-        <FormGroup label="Become Password" fieldId="become_password">
-          <TextInput
-            value={formData?.become_password}
-            placeholder="Enter become password (optional)"
-            type="password"
-            id="become_password"
-            name="become_password"
-            onChange={event => handleInputChange('become_password', (event.target as HTMLInputElement).value)}
-          />
-        </FormGroup>
       </React.Fragment>
     )}
 
@@ -241,9 +212,43 @@ const CredentialFormFields: React.FC<CredentialFormFieldsProps> = ({
         </FormGroup>
       </React.Fragment>
     )}
+
+    {/* Render "Become" fields only if network is selected and authType is Username/Password or SSH Key */}
+    {typeValue === 'network' && (
+      <React.Fragment>
+        <FormGroup label="Become Method" fieldId="become_method">
+          <SimpleDropdown
+            label={formData?.become_method || 'Select option'}
+            variant="default"
+            isFullWidth
+            onSelect={item => handleInputChange('become_method', (item !== 'Select option' && item) || '')}
+            dropdownItems={['Select option', 'sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas']}
+          />
+        </FormGroup>
+        <FormGroup label="Become User" fieldId="become_user">
+          <TextInput
+            value={formData?.become_user}
+            placeholder="Enter become user (optional)"
+            type="text"
+            id="become_user"
+            name="become_user"
+            onChange={event => handleInputChange('become_user', (event.target as HTMLInputElement).value)}
+          />
+        </FormGroup>
+        <FormGroup label="Become Password" fieldId="become_password">
+          <TextInput
+            value={formData?.become_password}
+            placeholder="Enter become password (optional)"
+            type="password"
+            id="become_password"
+            name="become_password"
+            onChange={event => handleInputChange('become_password', (event.target as HTMLInputElement).value)}
+          />
+        </FormGroup>
+      </React.Fragment>
+    )}
   </React.Fragment>
 );
-
 const AddCredentialModal: React.FC<AddCredentialModalProps> = ({
   isOpen,
   credential,


### PR DESCRIPTION
When choosing auth type username and password, some extra fields should only be generated to network source type.
Relates to JIRA: DISCOVERY-391

### Notes
- fix to "[Mirek] Satellite / vCenter / Ansible new credential form have fields for Become Method, Become User and Become Password. I have not tried if they are also available in edit credential form, and I have not verified what happens when you fill them and submit credential to backend"

<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-09-11 14-48-46](https://github.com/user-attachments/assets/69c227d8-6775-47eb-b4d9-02839f79d3aa)
![Screenshot from 2024-09-11 14-48-27](https://github.com/user-attachments/assets/532fc7aa-7eec-4eff-a38e-6aa2087531e4)
![Screenshot from 2024-09-11 14-48-18](https://github.com/user-attachments/assets/706ed795-ce95-44de-823f-694315c26d5f)
![Screenshot from 2024-09-11 14-48-07](https://github.com/user-attachments/assets/fd1c94a3-7606-47a8-a8c7-89a091deb46d)
![Screenshot from 2024-09-11 14-47-53](https://github.com/user-attachments/assets/caf0c110-51c6-4822-bd67-4ba849e14d2e)
![Screenshot from 2024-09-11 14-47-40](https://github.com/user-attachments/assets/9a541ae7-0fe4-4736-880f-c2c47123d715)
![Screenshot from 2024-09-11 14-47-30](https://github.com/user-attachments/assets/ca62e529-6d11-4d2f-a792-d37fccb5670e)
![Screenshot from 2024-09-12 11-17-42](https://github.com/user-attachments/assets/746939c9-1499-453f-b050-d53d41603e5c)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-391](https://issues.redhat.com/browse/DISCOVERY-391)
