### PR TITLE
fix: ds-356 axios response interceptors

### DIFF
--- a/src/hooks/__tests__/__snapshots__/useLoginApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useLoginApi.test.ts.snap
@@ -8,9 +8,7 @@ exports[`useGetSetAuthApi should attempt a call to get a token: getToken 1`] = `
 ]
 `;
 
-exports[`useGetSetAuthApi should process an interceptor error: interceptorError 1`] = `undefined`;
-
-exports[`useGetSetAuthApi should process an interceptor success: interceptorSuccess 1`] = `
+exports[`useGetSetAuthApi should process an interceptor request success: interceptorRequestSuccess 1`] = `
 {
   "headers": {
     "Authorization": "Token Dolor sit",
@@ -19,7 +17,7 @@ exports[`useGetSetAuthApi should process an interceptor success: interceptorSucc
 }
 `;
 
-exports[`useGetSetAuthApi should process an interceptor success: interceptorSuccess, token service 1`] = `
+exports[`useGetSetAuthApi should process an interceptor request success: interceptorRequestSuccess, token service 1`] = `
 {
   "headers": {
     "Authorization": "",
@@ -27,6 +25,12 @@ exports[`useGetSetAuthApi should process an interceptor success: interceptorSucc
   "url": "/api/v1/token/",
 }
 `;
+
+exports[`useGetSetAuthApi should process an interceptor response success: interceptorResponseSuccess 1`] = `undefined`;
+
+exports[`useGetSetAuthApi should process interceptor request errors: interceptorRequestError 1`] = `undefined`;
+
+exports[`useGetSetAuthApi should process interceptor response errors: interceptorResponseError 1`] = `undefined`;
 
 exports[`useLoginApi should attempt an api call to login: apiCall 1`] = `
 [

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -15,7 +15,7 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useLoginApi.ts:58:          console.error(error);",
   "hooks/useLoginApi.ts:99:        console.error(error);",
   "hooks/useLoginApi.ts:137:        console.error(error);",
-  "hooks/useLoginApi.ts:165:        console.error('Invalid token, unable to parse format');",
+  "hooks/useLoginApi.ts:166:        console.error('Invalid token, unable to parse format');",
   "hooks/useScanApi.ts:67:          console.error(error);",
   "hooks/useScanApi.ts:140:          console.error(error);",
   "hooks/useScanApi.ts:186:        console.log(missingScansMsg);",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix: ds-356 axios response interceptors

### Notes
- assumed patch for token deletion, or random, 401s. this is an incremental change
- alerting users to 4xx level errors for login, similar to v1.8 is outside of this patch and possibly requires altering the current view component layout
- patching 4xx level errors with a login display message is outside of this patch
- patching 5xx level errors with a display message possibly requires alteration of current view base `get`s and is ignored with this patch
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm linting and tests come back as expected
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start:stage` or your equivalent use of tooling for previous determination of errors
1. attempt to generate a 401 for any one API call
   - expected result is bringing up the login screen on interaction with the UI
1. attempt to let the login token expire
   - expected result is bringing up the login screen on interaction with the UI

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-356](https://issues.redhat.com/browse/DISCOVERY-356)
ongoing