### PR TITLE
feat: ds-356 run the container without setting QUIPUCORDS_APP_PORT

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 # on podman, host.containers.internal resolves to the host. this is equivalent to
 # host.docker.internal for docker.
 export QUIPUCORDS_SERVER_URL="${QUIPUCORDS_SERVER_URL:-http://host.containers.internal:8000}"
+export QUIPUCORDS_APP_PORT="${QUIPUCORDS_APP_PORT:-9443}"
 CERTS_PATH="/opt/app-root/certs"
 
 # verify if user provided certificates exist or create a self signed certificate.


### PR DESCRIPTION
## What's included
This enables a user to start a working container with just:

    podman run -p 9443:9443 quipucords-ui:latest

Previously the QUIPUCORDS_APP_PORT environment variable was required, and nginx would fail to start and present a very non-obvious error indicating its absence.

## How to test
```sh
podman build -t quipucords-ui:latest .
podman run -p 9443:9443 quipucords-ui:latest
# open https://localhost:9443 in a web browser to confirm it serves content
```