### PR TITLE
style(cred,source,scan): ds-438  popup style fix

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -156,6 +156,7 @@
     "label_auth_cell_authToken": "Token",
     "label_auth_cell_sshKey": "SSH Key",
     "label_auth_tooltip": "Authorization type",
+    "label_close": "Close",
     "label_delete": "Delete",
     "label_edit": "Edit",
     "label_network": "Network",

--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -293,15 +293,12 @@ const CredentialsListView: React.FunctionComponent = () => {
         actions={[
           <Button
             key="confirm"
-            variant="danger"
+            variant="secondary"
             onClick={() => {
               setSourcesSelected([]);
             }}
           >
             {t('table.label', { context: 'close' })}
-          </Button>,
-          <Button key="cancel" variant="link" onClick={() => setSourcesSelected([])}>
-            {t('form-dialog.label', { context: 'cancel' })}
           </Button>
         ]}
       >

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -257,15 +257,12 @@ const ScansListView: React.FunctionComponent = () => {
         actions={[
           <Button
             key="confirm"
-            variant="danger"
+            variant="secondary"
             onClick={() => {
               setScanSelectedForSources(undefined);
             }}
           >
             {t('table.label', { context: 'close' })}
-          </Button>,
-          <Button key="cancel" variant="link" onClick={() => setScanSelectedForSources(undefined)}>
-            {t('form-dialog.label', { context: 'cancel' })}
           </Button>
         ]}
       >

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -394,16 +394,12 @@ const SourcesListView: React.FunctionComponent = () => {
         actions={[
           <Button
             key="confirm"
-            variant="danger"
+            variant="secondary"
             onClick={() => {
-              // Add your specific action if needed
               setCredentialsSelected([]);
             }}
           >
             {t('table.label', { context: 'close' })}
-          </Button>,
-          <Button key="cancel" variant="link" onClick={() => setCredentialsSelected([])}>
-            {t('form-dialog.label', { context: 'cancel' })}
           </Button>
         ]}
       >


### PR DESCRIPTION
Unify popup style across Sources, Creds, Scans
Remove cancel button

### Notes
- fix to "[Mirek] On “Sources” list. I can click a number in “Credentials” column and that will open new popup window. That window has both “close” button and “cancel” link (all lowercase). “close” is with red background, as if that was destructive action. That popup should probably use the same style as “Last connected” popup - it is purely informative.
The same applies to popup that appears on “Credentials” page, when clicking number in “Sources” column
It also appears on “Scans” page, when clicking number in “Sources” column"


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-09-18 13-44-29](https://github.com/user-attachments/assets/2898be88-1842-42a2-af28-0f669b37cb4e)
![Screenshot from 2024-09-18 13-42-12](https://github.com/user-attachments/assets/2339c93e-5880-4d72-a4d4-eac263248a5b)
![Screenshot from 2024-09-18 13-42-03](https://github.com/user-attachments/assets/8abef4e9-cb03-47b4-96ee-006ad94c78dd)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-438](https://issues.redhat.com/browse/DISCOVERY-438)
