### PR TITLE
fix(credential):ds-438 use auth_type sent from api

### DIFF
--- a/src/helpers/__tests__/__snapshots__/helpers.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/helpers.test.ts.snap
@@ -5,6 +5,9 @@ exports[`getAuthType should return a credential type: credentialTypes 1`] = `
   "Username and Password",
   "Token",
   "SSH Key",
+  "SSH Key File",
+  "Unknown credential type",
+  "Unknown credential type",
 ]
 `;
 

--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -48,21 +48,19 @@ describe('getAuthType', () => {
       become_user: undefined,
       become_password: undefined,
       sources: [],
+      auth_type: undefined,
       ...partialCredential
     });
 
   it(`should return a credential type`, () => {
     expect([
-      generateAuthType({ username: 'testUser', password: 'testPassword' }),
-      generateAuthType({ auth_token: 'mockToken' }),
-      generateAuthType({ ssh_key: 'mockSSH' })
+      generateAuthType({ auth_type: 'password' }),
+      generateAuthType({ auth_type: 'auth_token' }),
+      generateAuthType({ auth_type: 'ssh_key' }),
+      generateAuthType({ auth_type: 'ssh_keyfile' }),
+      generateAuthType({ auth_type: 'lorem' }),
+      generateAuthType({ auth_type: 'ipsum' })
     ]).toMatchSnapshot('credentialTypes');
-  });
-
-  it('should throw an error when credential has no authentication information', () => {
-    expect(() => {
-      generateAuthType({});
-    }).toThrow('Unknown credential type');
   });
 });
 

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -87,7 +87,9 @@ const normalizeTotal = (
 enum authType {
   UsernameAndPassword = 'Username and Password',
   Token = 'Token',
-  SSHKey = 'SSH Key'
+  SSHKey = 'SSH Key',
+  SSHKeyFile = 'SSH Key File',
+  Unknown = 'Unknown credential type'
 }
 
 /**
@@ -96,17 +98,19 @@ enum authType {
  * @param {CredentialType} credential - The CredentialType object representing authentication information.
  * @returns {string} - A string indicating the authentication type, e.g., "Username and Password".
  */
-const getAuthType = ({ username, password, auth_token, ssh_key }: CredentialType): authType => {
-  if (username && password) {
-    return authType.UsernameAndPassword;
+const getAuthType = ({ auth_type }: CredentialType): authType => {
+  switch (auth_type) {
+    case 'password':
+      return authType.UsernameAndPassword;
+    case 'auth_token':
+      return authType.Token;
+    case 'ssh_key':
+      return authType.SSHKey;
+    case 'ssh_keyfile':
+      return authType.SSHKeyFile;
+    default:
+      return authType.Unknown;
   }
-  if (auth_token) {
-    return authType.Token;
-  }
-  if (ssh_key) {
-    return authType.SSHKey;
-  }
-  throw new Error('Unknown credential type');
 };
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -18,6 +18,7 @@ export type CredentialType = {
   become_user: string;
   become_password: string;
   sources: SourceType[];
+  auth_type: string;
 };
 
 export type SourceConnectionType = {


### PR DESCRIPTION
Utilize newly added auth_type field sent by the API instead of inferring it in the front end 

### Notes
- [Related server side PR ](https://github.com/quipucords/quipucords/pull/2735)
- fix to "[Brad] If you start by running the old UI, create a network credential in the old UI using an SSH key (file path), and then start running the new UI, the credentials page crashes and turns completely blank.
2024-09-18 In progress PR
Old behavior: You can see all credentials.
Expected behavior: You can see all credentials that were created with the old UI in the new UI.
Current behavior: The credentials page crashes and shows a completely blank page (no UI or HTML/DOM at all).
[Slack thread with details](https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1726001863082449?thread_ts=1726001806.711239&cid=C02QSNF1UKE)


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-09-18 13-27-17](https://github.com/user-attachments/assets/a55006b6-4300-4349-bc56-0c67a9b07c06)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-438](https://issues.redhat.com/browse/DISCOVERY-438)
