### PR TITLE
style(credentials): ds-438 fix inconsistent style

### DIFF
--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -165,8 +165,7 @@ const CredentialsListView: React.FunctionComponent = () => {
     idProperty: 'id',
     isLoading,
     currentPageItems: data?.results || [],
-    totalItemCount: helpers.normalizeTotal(data),
-    variant: 'compact'
+    totalItemCount: helpers.normalizeTotal(data)
   });
 
   const {
@@ -223,7 +222,7 @@ const CredentialsListView: React.FunctionComponent = () => {
   return (
     <PageSection variant="light">
       {renderToolbar()}
-      <Table aria-label="Example things table">
+      <Table aria-label="Example things table" variant="compact">
         <Thead>
           <Tr isHeaderRow>
             <Th columnKey="name" />


### PR DESCRIPTION
Removed variant from table battery component that was the responsible for causing inconsistencies in padding across views. 

### Notes
- fix "[Mirek] Top margin in page content (below black header) is smaller on Credentials than it is on Sources and Scans"

<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-09-18 18-12-32](https://github.com/user-attachments/assets/18fe70f5-ea4b-44db-a572-32244e45316b)
![Screenshot from 2024-09-18 18-12-26](https://github.com/user-attachments/assets/0c255b07-bdb4-45da-bbe4-a625b575eb84)
![Screenshot from 2024-09-18 18-12-21](https://github.com/user-attachments/assets/6311a135-f387-48f9-a6b5-16e46596dd44)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-438](https://issues.redhat.com/browse/DISCOVERY-438)
