### PR TITLE
fix(creds,sources): ds-438 names inconsistency

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -317,7 +317,7 @@
   "dataSource": {
     "rhacs": "RHACS",
     "ansible": "Ansible Controller",
-    "network": "Network",
+    "network": "Network range",
     "openshift": "OpenShift",
     "satellite": "Satellite",
     "vcenter": "vCenter Server"

--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -118,32 +118,32 @@ const CredentialsListView: React.FunctionComponent = () => {
             {
               key: API_DATA_SOURCE_TYPES.ANSIBLE,
               label: API_DATA_SOURCE_TYPES.ANSIBLE,
-              value: t('toolbar.label', { context: 'chip_ansible' })
+              value: t('dataSource.ansible')
             },
             {
               key: API_DATA_SOURCE_TYPES.NETWORK,
               label: API_DATA_SOURCE_TYPES.NETWORK,
-              value: t('toolbar.label', { context: 'chip_network' })
+              value: t('dataSource.network')
             },
             {
               key: API_DATA_SOURCE_TYPES.OPENSHIFT,
               label: API_DATA_SOURCE_TYPES.OPENSHIFT,
-              value: t('toolbar.label', { context: 'chip_openshift' })
+              value: t('dataSource.openshift')
             },
             {
               key: API_DATA_SOURCE_TYPES.RHACS,
               label: API_DATA_SOURCE_TYPES.RHACS,
-              value: t('toolbar.label', { context: 'chip_rhacs' })
+              value: t('dataSource.rhacs')
             },
             {
               key: API_DATA_SOURCE_TYPES.SATELLITE,
               label: API_DATA_SOURCE_TYPES.SATELLITE,
-              value: t('toolbar.label', { context: 'chip_satellite' })
+              value: t('dataSource.satellite')
             },
             {
               key: API_DATA_SOURCE_TYPES.VCENTER,
               label: API_DATA_SOURCE_TYPES.VCENTER,
-              value: t('toolbar.label', { context: 'chip_vcenter' })
+              value: t('dataSource.vcenter')
             }
           ]
         }

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -169,32 +169,32 @@ const SourcesListView: React.FunctionComponent = () => {
             {
               key: API_DATA_SOURCE_TYPES.ANSIBLE,
               label: API_DATA_SOURCE_TYPES.ANSIBLE,
-              value: t('toolbar.label', { context: 'chip_ansible' })
+              value: t('dataSource.ansible')
             },
             {
               key: API_DATA_SOURCE_TYPES.NETWORK,
               label: API_DATA_SOURCE_TYPES.NETWORK,
-              value: t('toolbar.label', { context: 'chip_network' })
+              value: t('dataSource.network')
             },
             {
               key: API_DATA_SOURCE_TYPES.OPENSHIFT,
               label: API_DATA_SOURCE_TYPES.OPENSHIFT,
-              value: t('toolbar.label', { context: 'chip_openshift' })
+              value: t('dataSource.openshift')
             },
             {
               key: API_DATA_SOURCE_TYPES.RHACS,
               label: API_DATA_SOURCE_TYPES.RHACS,
-              value: t('toolbar.label', { context: 'chip_rhacs' })
+              value: t('dataSource.rhacs')
             },
             {
               key: API_DATA_SOURCE_TYPES.SATELLITE,
               label: API_DATA_SOURCE_TYPES.SATELLITE,
-              value: t('toolbar.label', { context: 'chip_satellite' })
+              value: t('dataSource.satellite')
             },
             {
               key: API_DATA_SOURCE_TYPES.VCENTER,
               label: API_DATA_SOURCE_TYPES.VCENTER,
-              value: t('toolbar.label', { context: 'chip_vcenter' })
+              value: t('dataSource.vcenter')
             }
           ]
         }


### PR DESCRIPTION
Follow consistent pattern in displaying credentials and sources names. 

### Notes
- fix "[Mirek] On Credentials page, when filtering by Credential Type, items in dropdown use different labels than “Type” column in a table:
Filter says “vCenter”, but table says “vCenter Server”
Filter says “Ansible”, but table says “Ansible Controller”
Other labels are consistent
The same applies to Sources page and Source Type
[Mirek] On Credentials page, when filtering by Credential Type, items in dropdown are sorted alphabetically. But when clicking “Add Credentials”, the same set of items is sorted in arbitrary order (Network on top, Ansible last). They probably should be consistent
The same applies to Sources page and Source Type filter"


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-09-19 11-44-28](https://github.com/user-attachments/assets/77de7f69-0093-4558-9fe3-3281d14ea031)
![Screenshot from 2024-09-19 11-44-07](https://github.com/user-attachments/assets/73f8a6af-fd84-47cb-8cf0-0ed9a1ea22d8)
![Screenshot from 2024-09-20 20-36-38](https://github.com/user-attachments/assets/c353fc29-dbe7-4ec7-8400-000f6e7351d9)
![Screenshot from 2024-09-20 20-36-31](https://github.com/user-attachments/assets/06d6a25f-5be3-4dc3-83ae-84196e53c99b)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-438](https://issues.redhat.com/browse/DISCOVERY-438)
