### PR TITLE
refactor(addSourceModal): align form state with credential form

### DIFF
--- a/src/components/typeAheadCheckboxes/typeaheadCheckboxes.tsx
+++ b/src/components/typeAheadCheckboxes/typeaheadCheckboxes.tsx
@@ -25,6 +25,7 @@ interface TypeaheadCheckboxesProps {
   selectedOptions?: string[];
   placeholder?: string;
   menuToggleOuiaId?: number | string;
+  maxSelections?: number;
 }
 
 const TypeaheadCheckboxes: React.FC<TypeaheadCheckboxesProps> = ({
@@ -32,7 +33,8 @@ const TypeaheadCheckboxes: React.FC<TypeaheadCheckboxesProps> = ({
   options,
   selectedOptions = [],
   placeholder = '0 items selected',
-  menuToggleOuiaId
+  menuToggleOuiaId,
+  maxSelections = Infinity
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState<string>('');
@@ -143,11 +145,18 @@ const TypeaheadCheckboxes: React.FC<TypeaheadCheckboxesProps> = ({
 
   const onSelect = (value: string) => {
     if (value && value !== 'no results') {
-      const newSelected = selected.includes(value)
-        ? selected.filter(selection => selection !== value)
-        : [...selected, value];
-      onChange(newSelected);
-      setSelected(newSelected);
+      if (!selected.includes(value)) {
+        if (selected.length >= maxSelections) {
+          return;
+        }
+        const newSelected = [...selected, value];
+        onChange(newSelected);
+        setSelected(newSelected);
+      } else {
+        const newSelected = selected.filter(selection => selection !== value);
+        onChange(newSelected);
+        setSelected(newSelected);
+      }
     }
 
     textInputRef.current?.focus();

--- a/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`AddSourceModal should have the correct title: title 1`] = `
 <span
   class="pf-v5-c-modal-box__title-text"
 >
-  Add source: network
+  Add Source: network
 </span>
 `;
 
@@ -41,21 +41,177 @@ exports[`AddSourceModal should render a basic component: basic 1`] = `
   ouiaSafe={true}
   position="default"
   showClose={true}
-  title="Add source: undefined"
+  title="Add Source: "
   titleIconVariant={null}
   titleLabel=""
   variant="small"
 >
-  <FormContextProvider
-    initialValues={
-      {
-        "hosts": "",
-        "name": "",
-        "port": "",
-      }
-    }
-  >
-    [Function]
-  </FormContextProvider>
+  <SourceForm
+    onClose={[Function]}
+    onSubmit={[Function]}
+  />
 </Modal>
+`;
+
+exports[`SourceForm should render a basic component: basic 1`] = `
+<Form>
+  <FormGroup
+    fieldId="name"
+    isRequired={true}
+    label="Name"
+  >
+    <TextInput
+      id="source-name"
+      isRequired={true}
+      name="name"
+      onChange={[Function]}
+      ouiaId="name"
+      placeholder="Enter a name for the source"
+      type="text"
+      value=""
+    />
+  </FormGroup>
+  <FormGroup
+    fieldId="credentials"
+    isRequired={true}
+    label="Credentials"
+  >
+    <TypeaheadCheckboxes
+      menuToggleOuiaId="add_credentials_select"
+      onChange={[Function]}
+      options={[]}
+      selectedOptions={[]}
+    />
+  </FormGroup>
+  <React.Fragment>
+    <FormGroup
+      fieldId="hosts"
+      isRequired={true}
+      label="IP address or hostname"
+    >
+      <TextInput
+        id="source-hosts"
+        isRequired={true}
+        name="hosts"
+        onChange={[Function]}
+        ouiaId="hosts_single"
+        value=""
+      />
+      <HelperText>
+        Enter an IP address or hostname
+      </HelperText>
+    </FormGroup>
+    <FormGroup
+      fieldId="port"
+      label="Port"
+    >
+      <TextInput
+        id="source-port"
+        name="port"
+        onChange={[Function]}
+        ouiaId="port"
+        placeholder="Optional"
+        type="text"
+        value=""
+      />
+      <HelperText>
+        Default port is 443
+      </HelperText>
+    </FormGroup>
+  </React.Fragment>
+  <React.Fragment>
+    <FormGroup
+      fieldId="connection"
+      label="Connection"
+    >
+      <SimpleDropdown
+        dropdownItems={
+          [
+            {
+              "item": "SSLv23",
+              "ouiaId": "sslv23",
+            },
+            {
+              "item": "TLSv1",
+              "ouiaId": "tlsv1",
+            },
+            {
+              "item": "TLSv1.1",
+              "ouiaId": "tlsv11",
+            },
+            {
+              "item": "TLSv1.2",
+              "ouiaId": "tlsv12",
+            },
+            {
+              "item": "Disable SSL",
+              "ouiaId": "disable_ssl",
+            },
+          ]
+        }
+        isFullWidth={true}
+        label="SSLv23"
+        menuToggleOuiaId="options_ssl_protocol"
+        onSelect={[Function]}
+        variant="default"
+      />
+    </FormGroup>
+    <FormGroup
+      fieldId="ssl_verify"
+      label=""
+    >
+      <Checkbox
+        className=""
+        id="ssl_verify"
+        isChecked={true}
+        isDisabled={false}
+        isLabelWrapped={false}
+        isRequired={false}
+        isValid={true}
+        label="Verify SSL certificate"
+        onChange={[Function]}
+        ouiaId="options_ssl_cert"
+        ouiaSafe={true}
+      />
+    </FormGroup>
+  </React.Fragment>
+  <ActionGroup>
+    <Button
+      onClick={[Function]}
+      variant="primary"
+    >
+      Save
+    </Button>
+    <Button
+      onClick={[Function]}
+      variant="link"
+    >
+      Cancel
+    </Button>
+  </ActionGroup>
+</Form>
+`;
+
+exports[`useSourceForm should allow editing a source: formData, edit 1`] = `
+{
+  "credentials": [],
+  "hosts": "",
+  "name": "lorem",
+  "port": "456",
+  "sslProtocol": "SSLv23",
+  "sslVerify": true,
+  "useParamiko": false,
+}
+`;
+
+exports[`useSourceForm should initialize formData correctly: formData 1`] = `
+{
+  "credentials": [],
+  "hosts": "",
+  "name": "",
+  "port": "",
+  "sslProtocol": "SSLv23",
+  "sslVerify": true,
+  "useParamiko": false,
+}
 `;

--- a/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
@@ -77,11 +77,19 @@ exports[`SourceForm should render a basic component: basic 1`] = `
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      maxSelections={1}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
       options={[]}
       selectedOptions={[]}
     />
+    <HelperText>
+      <HelperTextItem
+        variant="warning"
+      >
+        Only one credential can be selected for this source type.
+      </HelperTextItem>
+    </HelperText>
   </FormGroup>
   <React.Fragment>
     <FormGroup

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -14,6 +14,7 @@ import {
   Form,
   FormGroup,
   HelperText,
+  HelperTextItem,
   Modal,
   ModalVariant,
   TextArea,
@@ -174,20 +175,19 @@ const SourceForm: React.FC<SourceFormProps> = ({
       <FormGroup label="Credentials" fieldId="credentials" isRequired>
         <TypeaheadCheckboxes
           onChange={(selections: string[]) => {
-            const selectedIds = selections.map(Number);
-            const validIds = selectedIds.filter(id => !isNaN(id));
-
-            // If the user selects more than one credential, display a warning
-            if (!isNetwork && validIds.length > 1) {
-              alert('Only one credential can be selected for this source type.');
-            } else {
-              handleInputChange('credentials', validIds);
-            }
+            const validIds = selections.map(Number).filter(id => !isNaN(id));
+            handleInputChange('credentials', validIds);
           }}
           options={credOptions}
           selectedOptions={formData?.credentials?.map(String) || []}
           menuToggleOuiaId="add_credentials_select"
+          maxSelections={isNetwork ? Infinity : 1} // Limit selection to 1 for non-network sources
         />
+        {!isNetwork && (
+          <HelperText>
+            <HelperTextItem variant="warning">Only one credential can be selected for this source type.</HelperTextItem>
+          </HelperText>
+        )}
       </FormGroup>
       {isNetwork ? (
         <React.Fragment>

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -6,13 +6,12 @@
  *
  * @module addSourceModal
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActionGroup,
   Button,
   Checkbox,
   Form,
-  FormContextProvider,
   FormGroup,
   HelperText,
   Modal,
@@ -30,35 +29,71 @@ interface AddSourceModalProps {
   isOpen: boolean;
   source?: SourceType;
   sourceType?: string;
+  sourceName?: string;
   onClose?: () => void;
-  onSubmit?: (payload) => void;
-  useGetCredentials?: typeof useGetCredentialsApi;
+  onSubmit?: (payload: any) => void;
 }
 
-const AddSourceModal: React.FC<AddSourceModalProps> = ({
-  isOpen,
-  source,
+interface SourceFormProps extends Omit<AddSourceModalProps, 'isOpen'> {
+  useForm?: typeof useSourceForm;
+}
+
+interface SourceFormType {
+  credentials?: number[];
+  useParamiko?: boolean;
+  sslVerify?: boolean;
+  sslProtocol: string;
+  name?: string;
+  hosts?: string;
+  port?: string;
+}
+
+const useSourceForm = ({
   sourceType,
-  onClose = Function.prototype,
-  onSubmit = Function.prototype,
+  source,
   useGetCredentials = useGetCredentialsApi
-}) => {
+}: { sourceType?: string; source?: Partial<SourceType>; useGetCredentials?: typeof useGetCredentialsApi } = {}) => {
+  const initialFormState: SourceFormType = {
+    credentials: [],
+    useParamiko: false,
+    sslVerify: true,
+    sslProtocol: 'SSLv23',
+    name: '',
+    hosts: '',
+    port: ''
+  };
+
   const { getCredentials } = useGetCredentials();
   const [credOptions, setCredOptions] = useState<{ value: string; label: string }[] | []>([]);
-  const [credentials, setCredentials] = useState<number[]>(source?.credentials?.map(c => c.id) || []);
-  const [useParamiko, setUseParamiko] = useState<boolean>(source?.options?.use_paramiko ?? false);
-  const [sslVerify, setSslVerify] = useState<boolean>(source?.options?.ssl_cert_verify ?? true);
-  const [sslProtocol, setSslProtocol] = useState<string>(
-    source?.options?.disable_ssl ? 'Disable SSL' : source?.options?.ssl_protocol || 'SSLv23'
-  );
+  const [formData, setFormData] = useState<SourceFormType>(initialFormState);
 
-  const sourceTypeValue = source?.source_type || sourceType?.split(' ')?.shift()?.toLowerCase();
-  const isNetwork = sourceTypeValue === 'network';
+  const typeValue = source?.source_type || sourceType?.split(' ')?.shift()?.toLowerCase();
+  const isNetwork = typeValue === 'network';
+
+  // Edit props, reset state on unmount
+  useEffect(() => {
+    if (source) {
+      setFormData({
+        credentials: source?.credentials?.map(c => c.id) || [],
+        useParamiko: source?.options?.use_paramiko || false,
+        sslVerify: source?.options?.ssl_cert_verify !== undefined ? source.options.ssl_cert_verify : true,
+        sslProtocol: (source?.options?.disable_ssl && 'Disable SSL') || source?.options?.ssl_protocol || 'SSLv23',
+        name: source?.name || '',
+        hosts: source?.hosts?.join(',') || '',
+        port: source?.port?.toString() || ''
+      });
+    }
+
+    return () => {
+      setFormData(initialFormState);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     getCredentials({
       params: {
-        cred_type: sourceTypeValue
+        cred_type: typeValue
       }
     })
       .then(response => {
@@ -70,188 +105,220 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({
           console.error(err);
         }
       });
-  }, [getCredentials, sourceTypeValue]);
+  }, [typeValue, getCredentials]);
 
-  const onAdd = values => {
-    const payload = {
-      credentials: credentials.map(c => Number(c)),
-      hosts: values['hosts'].split(','),
-      name: values['name'],
-      port: values['port'] || (isNetwork ? '22' : '443'),
-      options: !isNetwork
-        ? {
-            ssl_cert_verify: sslProtocol !== 'Disable SSL' && sslVerify,
-            disable_ssl: sslProtocol === 'Disable SSL',
-            ...(sslProtocol !== 'Disable SSL' && { ssl_protocol: sslProtocol })
-          }
-        : {
-            use_paramiko: useParamiko
-          },
-      ...(!source && { source_type: sourceTypeValue }),
-      ...(source && { id: source.id })
-    };
-    onSubmit(payload);
+  const handleInputChange = useCallback(
+    (field: string, value: unknown) => {
+      setFormData({ ...formData, [field]: value });
+    },
+    [formData]
+  );
+
+  const filterFormData = useCallback(
+    (data = formData) => {
+      const { credentials, useParamiko, sslVerify, sslProtocol, name, hosts, port } = data;
+      return {
+        name: name,
+        credentials: credentials?.map(c => Number(c)),
+        hosts: hosts?.split(','),
+        port: port || (isNetwork ? '22' : '443'),
+        options: !isNetwork
+          ? {
+              ssl_cert_verify: sslProtocol !== 'Disable SSL' && sslVerify,
+              disable_ssl: sslProtocol === 'Disable SSL',
+              ...(sslProtocol !== 'Disable SSL' && { ssl_protocol: sslProtocol })
+            }
+          : {
+              use_paramiko: useParamiko
+            },
+        ...(!source && { source_type: typeValue }),
+        ...(source && { id: source.id })
+      };
+    },
+    [isNetwork, formData, source, typeValue]
+  );
+
+  return {
+    credOptions,
+    formData,
+    isNetwork,
+    handleInputChange,
+    filterFormData,
+    typeValue
   };
+};
 
+const SourceForm: React.FC<SourceFormProps> = ({
+  source,
+  sourceType,
+  onClose = () => {},
+  onSubmit = () => {},
+  useForm = useSourceForm
+}) => {
+  const { formData, isNetwork, credOptions, handleInputChange, filterFormData } = useForm({ sourceType, source });
+  const onAdd = () => onSubmit(filterFormData());
+
+  return (
+    <Form>
+      <FormGroup label="Name" isRequired fieldId="name">
+        <TextInput
+          value={formData?.name}
+          placeholder="Enter a name for the source"
+          isRequired
+          type="text"
+          id="source-name"
+          name="name"
+          onChange={event => handleInputChange('name', (event.target as HTMLInputElement).value)}
+          ouiaId="name"
+        />
+      </FormGroup>
+      <FormGroup label="Credentials" fieldId="credentials" isRequired>
+        <TypeaheadCheckboxes
+          onChange={(selections: string[]) => {
+            const selectedIds = selections.map(Number);
+            const validIds = selectedIds.filter(id => !isNaN(id));
+
+            // If the user selects more than one credential, display a warning
+            if (!isNetwork && validIds.length > 1) {
+              alert('Only one credential can be selected for this source type.');
+            } else {
+              handleInputChange('credentials', validIds);
+            }
+          }}
+          options={credOptions}
+          selectedOptions={formData?.credentials?.map(String) || []}
+          menuToggleOuiaId="add_credentials_select"
+        />
+      </FormGroup>
+      {isNetwork ? (
+        <React.Fragment>
+          <FormGroup label="Search addresses" isRequired fieldId="hosts">
+            <TextArea
+              placeholder="Enter values separated by commas"
+              value={formData?.hosts}
+              onChange={event => handleInputChange('hosts', event.target.value)}
+              isRequired
+              id="source-hosts"
+              name="hosts"
+              data-ouia-component-id="hosts_multiple"
+            />
+            <HelperText>
+              Type IP addresses, IP ranges, and DNS host names. Wildcards are valid. Use CIDR or Ansible notation for
+              ranges.
+            </HelperText>
+          </FormGroup>
+          <FormGroup label="Port" fieldId="port">
+            <TextInput
+              value={formData?.port}
+              placeholder="Optional"
+              type="text"
+              id="source-port"
+              name="port"
+              onChange={event => handleInputChange('port', (event.target as HTMLInputElement).value)}
+              ouiaId="port"
+            />
+            <HelperText>Default port is 22</HelperText>
+          </FormGroup>
+        </React.Fragment>
+      ) : (
+        <React.Fragment>
+          <FormGroup label="IP address or hostname" isRequired fieldId="hosts">
+            <TextInput
+              value={formData?.hosts}
+              onChange={event => handleInputChange('hosts', (event.target as HTMLInputElement).value)}
+              isRequired
+              id="source-hosts"
+              name="hosts"
+              ouiaId="hosts_single"
+            />
+            <HelperText>Enter an IP address or hostname</HelperText>
+          </FormGroup>
+          <FormGroup label="Port" fieldId="port">
+            <TextInput
+              value={formData?.port}
+              placeholder="Optional"
+              type="text"
+              id="source-port"
+              name="port"
+              onChange={event => handleInputChange('port', (event.target as HTMLInputElement).value)}
+              ouiaId="port"
+            />
+            <HelperText>Default port is 443</HelperText>
+          </FormGroup>
+        </React.Fragment>
+      )}
+      {isNetwork ? (
+        <FormGroup label="" fieldId="paramiko">
+          <Checkbox
+            key="paramiko"
+            label="Connect using Paramiko instead of Open SSH"
+            id="paramiko"
+            isChecked={formData?.useParamiko}
+            onChange={(_ev, checked) => handleInputChange('useParamiko', checked)}
+            ouiaId="options_paramiko"
+          />
+        </FormGroup>
+      ) : (
+        <React.Fragment>
+          <FormGroup label="Connection" fieldId="connection">
+            <SimpleDropdown
+              isFullWidth
+              label={formData?.sslProtocol || 'Select protocol'}
+              menuToggleOuiaId="options_ssl_protocol"
+              variant={'default'}
+              onSelect={item => handleInputChange('sslProtocol', item)}
+              dropdownItems={[
+                { item: 'SSLv23', ouiaId: 'sslv23' },
+                { item: 'TLSv1', ouiaId: 'tlsv1' },
+                { item: 'TLSv1.1', ouiaId: 'tlsv11' },
+                { item: 'TLSv1.2', ouiaId: 'tlsv12' },
+                { item: 'Disable SSL', ouiaId: 'disable_ssl' }
+              ]}
+            />
+          </FormGroup>
+          <FormGroup label="" fieldId="ssl_verify">
+            <Checkbox
+              key="ssl_verify"
+              label="Verify SSL certificate"
+              id="ssl_verify"
+              isDisabled={formData?.sslProtocol === 'Disable SSL'}
+              isChecked={formData?.sslProtocol !== 'Disable SSL' && formData?.sslVerify}
+              onChange={(_ev, checked) => handleInputChange('sslVerify', checked)}
+              ouiaId="options_ssl_cert"
+            />
+          </FormGroup>
+        </React.Fragment>
+      )}
+      <ActionGroup>
+        <Button variant="primary" onClick={onAdd}>
+          Save
+        </Button>
+        <Button variant="link" onClick={() => onClose()}>
+          Cancel
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};
+
+const AddSourceModal: React.FC<AddSourceModalProps> = ({
+  isOpen,
+  source,
+  sourceType,
+  sourceName,
+  onClose = () => {},
+  onSubmit = () => {}
+}) => {
   return (
     <Modal
       variant={ModalVariant.small}
-      title={`${source ? 'Edit' : 'Add'} source: ${sourceType}`}
+      title={source ? `Edit Source: ${sourceName || ''}` : `Add Source: ${sourceType || ''}`}
       isOpen={isOpen}
       onClose={() => onClose()}
     >
-      <FormContextProvider
-        initialValues={{
-          name: source?.name || '',
-          hosts: source?.hosts?.join(',') || '',
-          port: source?.port ? String(source.port) : ''
-        }}
-      >
-        {({ setValue, getValue, values }) => (
-          <Form>
-            <FormGroup label="Name" isRequired fieldId="name">
-              <TextInput
-                value={getValue('name')}
-                placeholder="Enter a name for the source"
-                isRequired
-                type="text"
-                id="source-name"
-                name="name"
-                onChange={ev => {
-                  setValue('name', (ev.target as HTMLInputElement).value);
-                }}
-                ouiaId="name"
-              />
-            </FormGroup>
-            <FormGroup label="Credentials" fieldId="credentials" isRequired>
-              <TypeaheadCheckboxes
-                onChange={(selections: string[]) => {
-                  const selectedIds = selections.map(Number);
-                  const validIds = selectedIds.filter(id => !isNaN(id));
-                  setCredentials(validIds);
-                }}
-                options={credOptions}
-                selectedOptions={credentials?.map(String) || []}
-                menuToggleOuiaId="add_credentials_select"
-              />
-            </FormGroup>
-            {isNetwork ? (
-              <React.Fragment>
-                <FormGroup label="Search addresses" isRequired fieldId="hosts">
-                  <TextArea
-                    placeholder="Enter values separated by commas"
-                    value={getValue('hosts')}
-                    onChange={(_ev, val) => setValue('hosts', val)}
-                    isRequired
-                    id="source-hosts"
-                    name="hosts"
-                    data-ouia-component-id="hosts_multiple"
-                  />
-                  <HelperText>
-                    Type IP addresses, IP ranges, and DNS host names. Wildcards are valid. Use CIDR or Ansible notation
-                    for ranges.
-                  </HelperText>
-                </FormGroup>
-                <FormGroup label="Port" fieldId="port">
-                  <TextInput
-                    value={getValue('port')}
-                    placeholder="Optional"
-                    type="text"
-                    id="source-port"
-                    name="port"
-                    onChange={ev => {
-                      setValue('port', (ev.target as HTMLInputElement).value);
-                    }}
-                    ouiaId="port"
-                  />
-                  <HelperText>Default port is 22</HelperText>
-                </FormGroup>
-              </React.Fragment>
-            ) : (
-              <React.Fragment>
-                <FormGroup label="IP address or hostname" isRequired fieldId="hosts">
-                  <TextInput
-                    value={getValue('hosts')}
-                    onChange={(_ev, val) => setValue('hosts', val)}
-                    isRequired
-                    id="source-hosts"
-                    name="hosts"
-                    ouiaId="hosts_single"
-                  />
-                  <HelperText>Enter an IP address or hostname</HelperText>
-                </FormGroup>
-                <FormGroup label="Port" fieldId="port">
-                  <TextInput
-                    value={getValue('port')}
-                    placeholder="Optional"
-                    type="text"
-                    id="source-port"
-                    name="port"
-                    onChange={ev => {
-                      setValue('port', (ev.target as HTMLInputElement).value);
-                    }}
-                    ouiaId="port"
-                  />
-                  <HelperText>Default port is 443</HelperText>
-                </FormGroup>
-              </React.Fragment>
-            )}
-            {isNetwork ? (
-              <FormGroup label="" fieldId="paramiko">
-                <Checkbox
-                  key="paramiko"
-                  label="Connect using Paramiko instead of Open SSH"
-                  id="paramiko"
-                  isChecked={useParamiko}
-                  onChange={(_ev, ch) => setUseParamiko(ch)}
-                  ouiaId="options_paramiko"
-                />
-              </FormGroup>
-            ) : (
-              <React.Fragment>
-                <FormGroup label="Connection" fieldId="connection">
-                  <SimpleDropdown
-                    isFullWidth
-                    label={sslProtocol}
-                    menuToggleOuiaId="options_ssl_protocol"
-                    variant={'default'}
-                    onSelect={item => setSslProtocol(item)}
-                    dropdownItems={[
-                      { item: 'SSLv23', ouiaId: 'sslv23' },
-                      { item: 'TLSv1', ouiaId: 'tlsv1' },
-                      { item: 'TLSv1.1', ouiaId: 'tlsv11' },
-                      { item: 'TLSv1.2', ouiaId: 'tlsv12' },
-                      { item: 'Disable SSL', ouiaId: 'disable_ssl' }
-                    ]}
-                  />
-                </FormGroup>
-                <FormGroup label="" fieldId="ssl_verify">
-                  <Checkbox
-                    key="ssl_verify"
-                    label="Verify SSL certificate"
-                    id="ssl_verify"
-                    isDisabled={sslProtocol === 'Disable SSL'}
-                    isChecked={sslProtocol !== 'Disable SSL' && sslVerify}
-                    onChange={(_ev, ch) => setSslVerify(ch)}
-                    ouiaId="options_ssl_cert"
-                  />
-                </FormGroup>
-              </React.Fragment>
-            )}
-
-            <ActionGroup>
-              <Button variant="primary" onClick={() => onAdd({ ...values })}>
-                Save
-              </Button>
-              <Button variant="link" onClick={() => onClose()}>
-                Cancel
-              </Button>
-            </ActionGroup>
-          </Form>
-        )}
-      </FormContextProvider>
+      <SourceForm source={source} sourceType={sourceType} onClose={onClose} onSubmit={onSubmit} />
     </Modal>
   );
 };
 
-export { AddSourceModal as default, AddSourceModal, type AddSourceModalProps };
+export { AddSourceModal as default, AddSourceModal, SourceForm, useSourceForm, type AddSourceModalProps };

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -29,7 +29,6 @@ interface AddSourceModalProps {
   isOpen: boolean;
   source?: SourceType;
   sourceType?: string;
-  sourceName?: string;
   onClose?: () => void;
   onSubmit?: (payload: any) => void;
 }
@@ -76,7 +75,7 @@ const useSourceForm = ({
       setFormData({
         credentials: source?.credentials?.map(c => c.id) || [],
         useParamiko: source?.options?.use_paramiko || false,
-        sslVerify: source?.options?.ssl_cert_verify !== undefined ? source.options.ssl_cert_verify : true,
+        sslVerify: source?.options?.ssl_cert_verify ?? true,
         sslProtocol: (source?.options?.disable_ssl && 'Disable SSL') || source?.options?.ssl_protocol || 'SSLv23',
         name: source?.name || '',
         hosts: source?.hosts?.join(',') || '',
@@ -305,20 +304,17 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({
   isOpen,
   source,
   sourceType,
-  sourceName,
   onClose = () => {},
   onSubmit = () => {}
-}) => {
-  return (
-    <Modal
-      variant={ModalVariant.small}
-      title={source ? `Edit Source: ${sourceName || ''}` : `Add Source: ${sourceType || ''}`}
-      isOpen={isOpen}
-      onClose={() => onClose()}
-    >
-      <SourceForm source={source} sourceType={sourceType} onClose={onClose} onSubmit={onSubmit} />
-    </Modal>
-  );
-};
+}) => (
+  <Modal
+    variant={ModalVariant.small}
+    title={(source && `Edit Source: ${source.name || ''}`) || `Add Source: ${sourceType || ''}`}
+    isOpen={isOpen}
+    onClose={() => onClose()}
+  >
+    <SourceForm source={source} sourceType={sourceType} onClose={onClose} onSubmit={onSubmit} />
+  </Modal>
+);
 
 export { AddSourceModal as default, AddSourceModal, SourceForm, useSourceForm, type AddSourceModalProps };

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -452,6 +452,7 @@ const SourcesListView: React.FunctionComponent = () => {
       <AddSourceModal
         isOpen={sourceBeingEdited !== undefined}
         source={sourceBeingEdited}
+        sourceName={sourceBeingEdited?.name}
         onClose={() => setSourceBeingEdited(undefined)}
         onSubmit={(payload: SourceType) =>
           editSources(payload).finally(() => {

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -452,7 +452,6 @@ const SourcesListView: React.FunctionComponent = () => {
       <AddSourceModal
         isOpen={sourceBeingEdited !== undefined}
         source={sourceBeingEdited}
-        sourceName={sourceBeingEdited?.name}
         onClose={() => setSourceBeingEdited(undefined)}
         onSubmit={(payload: SourceType) =>
           editSources(payload).finally(() => {

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -29,6 +29,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "views/scans/showScansModal.tsx:77:      console.log({ aValue, bValue });",
-  "views/sources/addSourceModal.tsx:104:          console.error(err);",
+  "views/sources/addSourceModal.tsx:105:          console.error(err);",
 ]
 `;

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -29,6 +29,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "views/scans/showScansModal.tsx:77:      console.log({ aValue, bValue });",
-  "views/sources/addSourceModal.tsx:105:          console.error(err);",
+  "views/sources/addSourceModal.tsx:104:          console.error(err);",
 ]
 `;

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -29,6 +29,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "views/scans/showScansModal.tsx:77:      console.log({ aValue, bValue });",
-  "views/sources/addSourceModal.tsx:70:          console.error(err);",
+  "views/sources/addSourceModal.tsx:105:          console.error(err);",
 ]
 `;


### PR DESCRIPTION
Align form state with credential form in order to maintain consistency, but also to solve some of the state problems we are currently experiencing in the modal. 

### Notes
- fix to [Mirek] New source popup remembers credentials and “Verify SSL Certificate” state across closing and opening
easy way to reproduce: start creating a new source of any type. Select some credentials. Close the popup (Esc key or Cancel link). Now start creating a new source of different type. Credentials field will say that you have some credentials selected, but since they are of different type, they won’t appear on the list. If you try to submit form now, server will return error
- [Mirek] New OpenShift source modal. Credentials dropdown is multi-select, but if I try to submit OpenShift with many credentials, server will reject it saying that this source type can have only one credential.
Not tested, but I assume the same applies to virtually all source types except for Network
The only type of source that accepts multiple credentials is Network.
-  [Mirek] When editing a source, following fields have their default values, ignoring what was really in the source when it was created: 
Network: “Connect using Paramiko instead of Open SSH” (reverts to unchecked)
OpenShift: “Connection” (reverts to SSLv23) ; “Verify SSL Certificate” (reverts to checked) 
RHACS: “Connection” (reverts to SSLv23) ; “Verify SSL Certificate” (reverts to checked)
Satellite: “Connection” (reverts to SSLv23) ; “Verify SSL Certificate” (reverts to checked)
VCenter: “Connection” (reverts to SSLv23) ; “Verify SSL Certificate” (reverts to checked)
Ansible: “Connection” (reverts to SSLv23) ; “Verify SSL Certificate” (reverts to checked)
- [Mirek] When editing a source (any type), modal title says “Edit source: undefined”



<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
[Screencast from 2024-10-07 13-11-35.webm](https://github.com/user-attachments/assets/8dd60810-5b82-4c12-9900-89b2e56ec086)
[Screencast from 2024-10-07 13-12-56.webm](https://github.com/user-attachments/assets/f837ef98-61a6-4dc0-8a30-421cc60ff953)
[Screencast from 2024-10-07 13-13-44.webm](https://github.com/user-attachments/assets/18f70142-07eb-44c6-8c5d-6efcbaf6129f)
[Screencast from 2024-10-07 13-14-21.webm](https://github.com/user-attachments/assets/aed7ccc1-f27e-4ade-a5d0-87649f738e14)



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-436](https://issues.redhat.com/browse/DISCOVERY-436)