### PR TITLE
fix: ds-356 login loading, error messages

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -124,6 +124,7 @@
   },
   "login": {
     "description": "Welcome! This inspection and reporting tool is designed to identify and report environment data, or facts, such as the number of physical and virtual systems on a network, their operating systems, and other configuration data.",
+    "error_400": "Unable to log in with provided credentials.",
     "label_login": "Log in",
     "label_username": "Username",
     "label_password": "Password",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -124,7 +124,7 @@
   },
   "login": {
     "description": "Welcome! This inspection and reporting tool is designed to identify and report environment data, or facts, such as the number of physical and virtual systems on a network, their operating systems, and other configuration data.",
-    "error_400": "Unable to log in with provided credentials.",
+    "error": "Unable to log in with provided credentials.",
     "label_login": "Log in",
     "label_username": "Username",
     "label_password": "Password",

--- a/src/components/login/__tests__/__snapshots__/login.test.tsx.snap
+++ b/src/components/login/__tests__/__snapshots__/login.test.tsx.snap
@@ -46,6 +46,11 @@ exports[`Login should render a basic component: basic 1`] = `
 ])"
     passwordValue=""
     showHelperText={false}
+    style={
+      {
+        "opacity": 1,
+      }
+    }
     usernameLabel="t([
   "login.label",
   {

--- a/src/components/login/login.tsx
+++ b/src/components/login/login.tsx
@@ -61,7 +61,7 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
             },
             error => {
               setLoginError(
-                (error?.status === 400 && t('login.error', { context: error.status })) ||
+                (error?.status === 400 && t('login.error', { context: error?.status })) ||
                   apiHelpers.extractErrorMessage(error)
               );
             }

--- a/src/components/login/login.tsx
+++ b/src/components/login/login.tsx
@@ -8,9 +8,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LoginForm, LoginPage } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import apiHelpers from '../../helpers/apiHelpers';
 import { useLoginApi, useGetSetAuthApi } from '../../hooks/useLoginApi';
 import bgImage from '../../images/aboutBg.png';
-import apiHelpers from '../../helpers/apiHelpers';
 
 interface LoginProps {
   children: React.ReactNode;
@@ -24,7 +24,7 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
   const { login } = useLogin();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
-  const [loginError, setLoginError] = useState<string | undefined>(undefined);
+  const [loginError, setLoginError] = useState<string | undefined>();
   const [isValidUsername, setIsValidUsername] = useState(true);
   const [isValidPassword, setIsValidPassword] = useState(true);
   const [username, setUsername] = useState<string>('');
@@ -60,7 +60,10 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
               setIsLoggedIn(true);
             },
             error => {
-              setLoginError(apiHelpers.extractErrorMessage(error));
+              setLoginError(
+                (error?.status === 400 && t('login.error', { context: error.status })) ||
+                  apiHelpers.extractErrorMessage(error)
+              );
             }
           )
           .finally(() => {

--- a/src/components/login/login.tsx
+++ b/src/components/login/login.tsx
@@ -10,6 +10,7 @@ import { LoginForm, LoginPage } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useLoginApi, useGetSetAuthApi } from '../../hooks/useLoginApi';
 import bgImage from '../../images/aboutBg.png';
+import apiHelpers from '../../helpers/apiHelpers';
 
 interface LoginProps {
   children: React.ReactNode;
@@ -23,7 +24,7 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
   const { login } = useLogin();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
-  const [isLoginError, setIsLoginError] = useState<boolean>(false);
+  const [loginError, setLoginError] = useState<string | undefined>(undefined);
   const [isValidUsername, setIsValidUsername] = useState(true);
   const [isValidPassword, setIsValidPassword] = useState(true);
   const [username, setUsername] = useState<string>('');
@@ -58,8 +59,8 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
             () => {
               setIsLoggedIn(true);
             },
-            () => {
-              setIsLoginError(true);
+            error => {
+              setLoginError(apiHelpers.extractErrorMessage(error));
             }
           )
           .finally(() => {
@@ -83,8 +84,8 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
     >
       <LoginForm
         style={{ opacity: (isLoading && 0.5) || 1 }}
-        showHelperText={isLoginError}
-        helperText={t('login.invalid')}
+        showHelperText={loginError !== undefined}
+        helperText={loginError || t('login.invalid')}
         helperTextIcon={<ExclamationCircleIcon />}
         usernameLabel={t('login.label', { context: 'username' })}
         usernameValue={username}

--- a/src/components/login/login.tsx
+++ b/src/components/login/login.tsx
@@ -21,6 +21,7 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
   const { t } = useTranslation();
   const { isAuthorized } = useGetSetAuth();
   const { login } = useLogin();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const [isLoginError, setIsLoginError] = useState<boolean>(false);
   const [isValidUsername, setIsValidUsername] = useState(true);
@@ -49,18 +50,24 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
     ) => {
       event.preventDefault();
 
-      if (username && password) {
-        login({ username, password }).then(
-          () => {
-            setIsLoggedIn(true);
-          },
-          () => {
-            setIsLoginError(true);
-          }
-        );
+      if (!isLoading && username && password) {
+        setIsLoading(true);
+
+        login({ username, password })
+          .then(
+            () => {
+              setIsLoggedIn(true);
+            },
+            () => {
+              setIsLoginError(true);
+            }
+          )
+          .finally(() => {
+            setIsLoading(false);
+          });
       }
     },
-    [login]
+    [isLoading, login]
   );
 
   if (isLoggedIn) {
@@ -75,6 +82,7 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
       backgroundImgSrc={bgImage}
     >
       <LoginForm
+        style={{ opacity: (isLoading && 0.5) || 1 }}
         showHelperText={isLoginError}
         helperText={t('login.invalid')}
         helperTextIcon={<ExclamationCircleIcon />}

--- a/tests/__snapshots__/dist.test.ts.snap
+++ b/tests/__snapshots__/dist.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`Build distribution should match a specific file output: dist-output 1`] = `
 [
   "",
-  "./build/113*js",
   "./build/362*css",
   "./build/362*js",
+  "./build/701*js",
   "./build/820*js",
   "./build/99*js",
   "./build/app*css",


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix: ds-356 login loading, error messages

### Notes
- error messaging for login was previously more integrated with the Django templates. moving to the token service does not provide the same level of error messages
- went ahead and provide the immediate response for 400, bad request, level status since that's what's provided by the API error response
   - this starts the process of applying error codes, via status codes, to UI locale strings
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests now come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start:stage`
1. confirm login error messages attempt to display on the login
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot 2024-10-11 at 2 04 56 PM](https://github.com/user-attachments/assets/f464ce85-0e1e-4420-91d4-cff9732ffd88)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
 [DISCOVERY-356](https://issues.redhat.com/browse/DISCOVERY-356)
