### PR TITLE
fix(sources): ds-503 accept wider range of hosts values

### DIFF
--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -125,6 +125,36 @@ describe('formatDate', () => {
   });
 });
 
+describe('normalizeHosts', () => {
+  it('should accept values separated by space', () => {
+    const input = '127.0.0.1 127.0.0.2';
+    const expected = ['127.0.0.1', '127.0.0.2'];
+
+    expect(helpers.normalizeHosts(input)).toEqual(expected);
+  });
+
+  it('should accept values separated by newline (\\n)', () => {
+    const input = '127.0.0.1\n127.0.0.2';
+    const expected = ['127.0.0.1', '127.0.0.2'];
+
+    expect(helpers.normalizeHosts(input)).toEqual(expected);
+  });
+
+  it('should accept values separated by newline (\\r)', () => {
+    const input = '127.0.0.1\r127.0.0.2';
+    const expected = ['127.0.0.1', '127.0.0.2'];
+
+    expect(helpers.normalizeHosts(input)).toEqual(expected);
+  });
+
+  it('should filter out empty values', () => {
+    const input = '127.0.0.1\n 127.0.0.2 ';
+    const expected = ['127.0.0.1', '127.0.0.2'];
+
+    expect(helpers.normalizeHosts(input)).toEqual(expected);
+  });
+});
+
 describe('normalizeTotal', () => {
   it('should normalize total values', () => {
     expect(helpers.normalizeTotal({ count: 142 }, true, undefined)).toBe(42);

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -99,6 +99,19 @@ const getTimeDisplayHowLongAgo = (timestamp: MomentInput, { devMode = DEV_MODE }
 const formatDate = (date: Date) => moment.utc(date).format('DD MMMM Y, h:mm A z');
 
 /**
+ * Normalizes hosts textarea content into array that can be submitted to backend.
+ *
+ * @param {string} data - host textarea content.
+ * @returns Array of host values which will be submitted to backend.
+ */
+const normalizeHosts = (data?: string) =>
+  data
+    ?.trim()
+    ?.replaceAll(/\\n|\\r|\s/g, ',')
+    ?.split(',')
+    ?.filter(Boolean);
+
+/**
  * Normalizes a total count to a non-negative number less than a given modulus,
  * optionally based on development mode.
  *
@@ -222,6 +235,7 @@ const helpers = {
   getTimeDisplayHowLongAgo,
   getTitleImg,
   formatDate,
+  normalizeHosts,
   normalizeTotal,
   DEV_MODE,
   PROD_MODE,

--- a/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
@@ -5,9 +5,7 @@ exports[`AddSourceModal should call onSubmit with the correct filtered data when
   [
     {
       "credentials": [],
-      "hosts": [
-        "",
-      ],
+      "hosts": [],
       "name": "Test Source",
       "options": {
         "use_paramiko": false,

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -121,7 +121,7 @@ const useSourceForm = ({
       return {
         name: name,
         credentials: credentials?.map(c => Number(c)),
-        hosts: hosts?.split(','),
+        hosts: helpers.normalizeHosts(hosts),
         port: port || (isOpenshift && '6443') || (isNetwork && '22') || '443',
         options: !isNetwork
           ? {


### PR DESCRIPTION
Allow user to delimit hosts (hostnames, IP addresses or IP ranges) by space or newline, in addition to comma. This brings new UI in line with old UI, which allowed wider range of user values and transformed them automatically before submitting to backend.

Relates to JIRA: DISCOVERY-503

Questions / points for discussion:

* Should we also have client-side validation of values? Backend rules for what counts as valid host address are [somewhat complex](https://github.com/quipucords/quipucords/blob/main/quipucords/api/source/serializer.py#L276) and I don't really want to repeat them here, but we can definitely fail early for things that are obviously wrong - empty values, invalid host names, multiple hosts where only one should be applied.

* This function is applied when submitting a form and is shared for both "network sources" and "http sources". The problem is, network sources might contain multiple hosts while all the others require exactly one hostname. Should I extend this PR to handle that case somehow? And how?
    1. Take the value of "hosts" field verbatim and send as only member of list. If user types space or comma, this is obviously invalid address that backend will reject
    2. Transform value of "hosts" field, as we do now, but send only first list element. This might lead to what appears to be silent data loss, as typing space or comma is valid, but everything after space or comma is silently dismissed.
    3. ???
