### PR TITLE
Fix creds in edit source

### DIFF
--- a/src/components/typeAheadCheckboxes/typeaheadCheckboxes.tsx
+++ b/src/components/typeAheadCheckboxes/typeaheadCheckboxes.tsx
@@ -50,6 +50,10 @@ const TypeaheadCheckboxes: React.FC<TypeaheadCheckboxesProps> = ({
   }, [options]);
 
   useEffect(() => {
+    setSelected(selectedOptions);
+  }, [selectedOptions]);
+
+  useEffect(() => {
     let newSelectOptions: SelectOptionProps[] = options;
 
     // Filter menu items based on the text input value when one exists


### PR DESCRIPTION
New useEffect: The useEffect that syncs the internal selected state with the selectedOptions prop ensures that when the selectedOptions prop changes (such as when editing a source), the dropdown reflects the correct pre-selected credentials.

### Notes
- fix to [Mirek] When editing a source, “Credentials” field say “0 items selected”. Looks like credentials are not correctly associated with existing source in the list component.
if I edit a source and select new credentials, and then save, these new credentials will be selected when I edit the source again. So this affects only editing after create


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-10-10 16-51-34](https://github.com/user-attachments/assets/10eff0ec-a1cd-40db-9a55-4d53a53c0fb6)
![Screenshot from 2024-10-10 16-51-20](https://github.com/user-attachments/assets/0e69774d-0595-46b9-8f21-bd622e06026e)
![Screenshot from 2024-10-10 16-51-14](https://github.com/user-attachments/assets/bd30b9c8-2e04-4012-91b6-378749ccc785)





## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-436](https://issues.redhat.com/browse/DISCOVERY-436)
