### PR TITLE
fix(creds): ds-438 use consistent naming

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -138,7 +138,7 @@
   "table": {
     "header_name": "Name",
     "header_type": "Type",
-    "header_auth-type": "Authorization type",
+    "header_auth-type": "Authentication type",
     "header_credentials": "Credentials",
     "header_failed": "Failed systems",
     "header_failed_sources": "Failed hosts",
@@ -156,7 +156,7 @@
     "label_auth_cell": "Username and password",
     "label_auth_cell_authToken": "Token",
     "label_auth_cell_sshKey": "SSH Key",
-    "label_auth_tooltip": "Authorization type",
+    "label_auth_tooltip": "Authentication type",
     "label_close": "Close",
     "label_delete": "Delete",
     "label_edit": "Edit",


### PR DESCRIPTION
Mirek noticed both authorization and authentication type being used in different places to refer to credentials. We agreed Authentication type  was the right word to be used. 


<!-- ### Notes -->
<!-- Any issues that aren't resolved by this merge request, or things of note? -->
- fix to [Mirek] Credential page has column “Authorization type”, but add credential modal has the same field labeled “Authentication Type”. Both should use the same word.
In Slack thread ([link](https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1726840763284999)) we agree that correct word is “Authentication”, so column name should change



## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
 [DISCOVERY-438](https://issues.redhat.com/browse/DISCOVERY-438) 
