### PR TITLE
feat(scans): ds-437 add close button to modal

### DIFF
--- a/src/views/scans/showScansModal.tsx
+++ b/src/views/scans/showScansModal.tsx
@@ -21,6 +21,7 @@ interface ShowScansModalProps {
   scanJobs?: Pick<ScanJobType, 'id' | 'end_time' | 'report_id' | 'status'>[];
   onDownload?: (number) => void;
   onClose?: () => void;
+  actions?: React.ReactNode[];
 }
 
 const ShowScansModal: React.FC<ShowScansModalProps> = ({
@@ -28,7 +29,8 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
   scan,
   scanJobs,
   onDownload = Function.prototype,
-  onClose = Function.prototype
+  onClose = Function.prototype,
+  actions
 }) => {
   const { t } = useTranslation();
   const [activeSortIndex, setActiveSortIndex] = useState<number | undefined>();
@@ -88,6 +90,7 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
       title={t('view.label', { context: 'scans-names', name: scan?.name })}
       isOpen={isOpen}
       onClose={() => onClose()}
+      {...(actions && { actions })}
     >
       {(scanJobs && (
         <React.Fragment>

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -279,6 +279,18 @@ const ScansListView: React.FunctionComponent = () => {
           setScanSelected(undefined);
           setScanJobs(undefined);
         }}
+        actions={[
+          <Button
+            key="close"
+            variant="secondary"
+            onClick={() => {
+              setScanSelected(undefined); // Close the modal when this is clicked
+              setScanJobs(undefined);
+            }}
+          >
+            {t('table.label', { context: 'close' })}
+          </Button>
+        ]}
       />
       <Modal
         variant={ModalVariant.small}

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -28,7 +28,7 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:127:          console.error(error);",
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
-  "views/scans/showScansModal.tsx:77:      console.log({ aValue, bValue });",
+  "views/scans/showScansModal.tsx:79:      console.log({ aValue, bValue });",
   "views/sources/addSourceModal.tsx:105:          console.error(err);",
 ]
 `;


### PR DESCRIPTION
Add close button to last-scanned modal to keep consistency with all other modals. 

### Notes
- fix to [Mirek] “Last Scanned” modal does not have “Close” link/button at the bottom. Every other modal has it (create credential / source, Last connected in Sources, Credentials / Sources modal - but see above). For consistency, that one should have it as well.


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-10-10 19-29-03](https://github.com/user-attachments/assets/476cbe5b-0d38-42dd-93df-565cae0bf17f)




## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-437](https://issues.redhat.com/browse/DISCOVERY-437)
