### PR TITLE
fix: ds-436 Add OCP default port in form logic

### DIFF
--- a/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
@@ -123,7 +123,8 @@ exports[`SourceForm should render a basic component: basic 1`] = `
         value=""
       />
       <HelperText>
-        Default port is 443
+        Default port is 
+        443
       </HelperText>
     </FormGroup>
   </React.Fragment>
@@ -198,6 +199,59 @@ exports[`SourceForm should render a basic component: basic 1`] = `
     </Button>
   </ActionGroup>
 </Form>
+`;
+
+exports[`SourceForm should render specifics to different source types: form, ansible 1`] = `
+<div
+  class="pf-v5-c-helper-text"
+>
+  Default port is 
+  443
+</div>
+`;
+
+exports[`SourceForm should render specifics to different source types: form, network 1`] = `
+<div
+  class="pf-v5-c-helper-text"
+>
+  Default port is 22
+</div>
+`;
+
+exports[`SourceForm should render specifics to different source types: form, openshift 1`] = `
+<div
+  class="pf-v5-c-helper-text"
+>
+  Default port is 
+  6443
+</div>
+`;
+
+exports[`SourceForm should render specifics to different source types: form, rhacs 1`] = `
+<div
+  class="pf-v5-c-helper-text"
+>
+  Default port is 
+  443
+</div>
+`;
+
+exports[`SourceForm should render specifics to different source types: form, satellite 1`] = `
+<div
+  class="pf-v5-c-helper-text"
+>
+  Default port is 
+  443
+</div>
+`;
+
+exports[`SourceForm should render specifics to different source types: form, vcenter 1`] = `
+<div
+  class="pf-v5-c-helper-text"
+>
+  Default port is 
+  443
+</div>
 `;
 
 exports[`useSourceForm should allow editing a source: formData, edit 1`] = `

--- a/src/views/sources/__tests__/addSourceModal.test.tsx
+++ b/src/views/sources/__tests__/addSourceModal.test.tsx
@@ -103,4 +103,14 @@ describe('SourceForm', () => {
     const component = await shallowComponent(<SourceForm />);
     expect(component).toMatchSnapshot('basic');
   });
+
+  it('should render specifics to different source types', async () => {
+    const sourceTypes = ['network', 'openshift', 'rhacs', 'ansible', 'satellite', 'vcenter'];
+    for (const type of sourceTypes) {
+      const component = await shallowComponent(<SourceForm sourceType={type} />);
+      const portFormGroup = component.querySelector('#source-port').closest('.pf-v5-c-form__group');
+      const portHelperText = portFormGroup.querySelector('.pf-v5-c-helper-text');
+      expect(portHelperText).toMatchSnapshot(`form, ${type}`);
+    }
+  });
 });

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -69,6 +69,7 @@ const useSourceForm = ({
 
   const typeValue = source?.source_type || sourceType?.split(' ')?.shift()?.toLowerCase();
   const isNetwork = typeValue === 'network';
+  const isOpenshift = typeValue === 'openshift';
 
   // Edit props, reset state on unmount
   useEffect(() => {
@@ -121,7 +122,7 @@ const useSourceForm = ({
         name: name,
         credentials: credentials?.map(c => Number(c)),
         hosts: hosts?.split(','),
-        port: port || (isNetwork ? '22' : '443'),
+        port: port || (isOpenshift && '6443') || (isNetwork && '22') || '443',
         options: !isNetwork
           ? {
               ssl_cert_verify: sslProtocol !== 'Disable SSL' && sslVerify,
@@ -135,13 +136,14 @@ const useSourceForm = ({
         ...(source && { id: source.id })
       };
     },
-    [isNetwork, formData, source, typeValue]
+    [isNetwork, isOpenshift, formData, source, typeValue]
   );
 
   return {
     credOptions,
     formData,
     isNetwork,
+    isOpenshift,
     handleInputChange,
     filterFormData,
     typeValue
@@ -155,7 +157,10 @@ const SourceForm: React.FC<SourceFormProps> = ({
   onSubmit = () => {},
   useForm = useSourceForm
 }) => {
-  const { formData, isNetwork, credOptions, handleInputChange, filterFormData } = useForm({ sourceType, source });
+  const { formData, isNetwork, isOpenshift, credOptions, handleInputChange, filterFormData } = useForm({
+    sourceType,
+    source
+  });
   const onAdd = () => onSubmit(filterFormData());
 
   return (
@@ -242,7 +247,7 @@ const SourceForm: React.FC<SourceFormProps> = ({
               onChange={event => handleInputChange('port', (event.target as HTMLInputElement).value)}
               ouiaId="port"
             />
-            <HelperText>Default port is 443</HelperText>
+            <HelperText>Default port is {isOpenshift ? '6443' : '443'}</HelperText>
           </FormGroup>
         </React.Fragment>
       )}

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -29,6 +29,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "views/scans/showScansModal.tsx:79:      console.log({ aValue, bValue });",
-  "views/sources/addSourceModal.tsx:105:          console.error(err);",
+  "views/sources/addSourceModal.tsx:106:          console.error(err);",
 ]
 `;


### PR DESCRIPTION
Add conditional default port for OpenShift in form logic

### Notes
- fix to [mirek] improve port logic on sources:
[check for mirek comment](https://github.com/quipucords/quipucords-ui/pull/460)
default ports: 22 network / 6443 openshift / 443 rest


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-10-14 10-55-10](https://github.com/user-attachments/assets/cab851dc-a39f-441d-b8b9-bda5ea141fe6)
![Screenshot from 2024-10-14 10-55-03](https://github.com/user-attachments/assets/5189c6df-b4e2-43e7-a9e4-1c8826667677)
![Screenshot from 2024-10-14 10-54-55](https://github.com/user-attachments/assets/8d6a5e9a-ad18-4d4b-8173-7cc58848f743)
![Screenshot from 2024-10-14 10-54-40](https://github.com/user-attachments/assets/1c49acdf-0ae5-4514-bc23-d733bfadbebb)






## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-436](https://issues.redhat.com/browse/DISCOVERY-436)
