### PR TITLE
refactor: ds-438 display items alphabetical order

### DIFF
--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -303,9 +303,11 @@ const CredentialsListView: React.FunctionComponent = () => {
         ]}
       >
         <List isPlain isBordered>
-          {sourcesSelected.map(c => (
-            <ListItem key={c.name}>{c.name}</ListItem>
-          ))}
+          {sourcesSelected
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(c => (
+              <ListItem key={c.name}>{c.name}</ListItem>
+            ))}
         </List>
         {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
       </Modal>

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -273,7 +273,9 @@ const ScansListView: React.FunctionComponent = () => {
         ]}
       >
         <List isPlain isBordered>
-          {scanSelectedForSources?.sources.map(s => <ListItem key={s.id}>{s.name}</ListItem>)}
+          {scanSelectedForSources?.sources
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(s => <ListItem key={s.id}>{s.name}</ListItem>)}
         </List>
       </Modal>
       <ShowScansModal

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -406,9 +406,11 @@ const SourcesListView: React.FunctionComponent = () => {
         ]}
       >
         <List isPlain isBordered>
-          {credentialsSelected.map(c => (
-            <ListItem key={c.name}>{c.name}</ListItem>
-          ))}
+          {credentialsSelected
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(c => (
+              <ListItem key={c.name}>{c.name}</ListItem>
+            ))}
         </List>
         {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
       </Modal>


### PR DESCRIPTION
Display list of sources and credentials in alphabetical order

### Notes
- fix to [Mirek] A list of Sources used by a credential, or sources used by a scan (the one that appears in modal) is sorted by related items id. It would be more natural to sort it alphabetically.
Not tested, but I assume the same applies to list of credentials used by a source


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-10-15 21-38-32](https://github.com/user-attachments/assets/24eb8114-7d09-4590-88b9-8a206475a946)
![Screenshot from 2024-10-15 21-38-25](https://github.com/user-attachments/assets/ff655758-9448-4b60-8882-c3fee6aa72dd)
![Screenshot from 2024-10-15 21-38-16](https://github.com/user-attachments/assets/406705b0-c36f-42d5-bb0b-3356f9b248ee)




## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-438](https://issues.redhat.com/browse/DISCOVERY-438)

