### PR TITLE
Add source name filter to scans view

### DIFF
--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -93,6 +93,12 @@ const ScansListView: React.FunctionComponent = () => {
           title: t('toolbar.label', { context: 'option_name' }),
           type: FilterType.search,
           placeholderText: t('toolbar.label', { context: 'placeholder_filter_search_by_name' })
+        },
+        {
+          key: API_QUERY_TYPES.SEARCH_SOURCES_NAME,
+          title: t('toolbar.label', { context: 'option_search_sources_by_name' }),
+          type: FilterType.search,
+          placeholderText: t('toolbar.label', { context: 'placeholder_filter_search_sources_by_name' })
         }
       ]
     },

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -158,7 +158,7 @@ const SourcesListView: React.FunctionComponent = () => {
           key: API_QUERY_TYPES.SEARCH_CREDENTIALS_NAME,
           title: t('toolbar.label', { context: 'option_search_credentials_by_name' }),
           type: FilterType.search,
-          placeholderText: t('toolbar.label', { context: 'placeholder_filter_cred_type' })
+          placeholderText: t('toolbar.label', { context: 'placeholder_filter_search_credentials_by_name' })
         },
         {
           key: API_QUERY_TYPES.SOURCE_TYPE,


### PR DESCRIPTION
- Add source name filter to scans view
- Fix credential by name filter text in sources view

### Notes
- fix to  [Mirek] In Scans page, it is not possible to filter scans by source name. In old UI I could filter by “Name” or “Source
- fix to  [Mirek] Sources page. In filters, select “Credential name”. The input placeholder says “Filter by credential type” (should be “by credential name”)


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-10-15 22-03-13](https://github.com/user-attachments/assets/8d86916c-18f0-4d6e-b214-35fbcd154445)
![Screenshot from 2024-10-15 22-03-56](https://github.com/user-attachments/assets/ffa439cf-cdca-4b09-ae95-ff94325e173f)





## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-437](https://issues.redhat.com/browse/DISCOVERY-437)
[DISCOVERY-436](https://issues.redhat.com/browse/DISCOVERY-436)