### PR TITLE
feat(aboutModal): ds-808 display user, status info

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,4 +1,12 @@
 {
+  "about": {
+    "browser-os": "Browser OS",
+    "browser-version": "Browser Version",
+    "copyright": "Copyright (c) {{year}} Red Hat Inc.",
+    "server-version": "Server Version",
+    "ui-version": "UI Version",
+    "username": "Username"
+  },
   "form-dialog": {
     "confirmation_heading_delete-scan": "Are you sure you want to delete the scan <0>{{name}}</0>?",
     "confirmation_heading_delete-credential": "Are you sure you want to delete the credential {{name}}?",

--- a/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.tsx.snap
+++ b/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AboutModal Component should attempt to display username, status data: username and status 1`] = `
+<AboutModal
+  aria-label="Quipucords"
+  backgroundImageSrc="aboutBg.png"
+  brandImageAlt="Quipucords"
+  brandImageSrc="title.svg"
+  isOpen={true}
+  onClose={[Function]}
+  trademark="t([
+  "about.copyright",
+  {
+    "year": "2024"
+  }
+])"
+>
+  <TextContent
+    className=""
+  >
+    <TextList
+      component="dl"
+    >
+      <React.Fragment>
+        <TextListItem
+          component="dt"
+        >
+          t([
+  "about.username"
+])
+        </TextListItem>
+        <TextListItem
+          component="dd"
+        >
+          lorem ipsum
+        </TextListItem>
+      </React.Fragment>
+      <React.Fragment>
+        <TextListItem
+          component="dt"
+        >
+          t([
+  "about.ui-version"
+])
+        </TextListItem>
+        <TextListItem
+          component="dd"
+        >
+          0.0.0.0000000
+        </TextListItem>
+      </React.Fragment>
+      <React.Fragment>
+        <TextListItem
+          className=""
+          component="dt"
+        >
+          t([
+  "about.server-version"
+])
+        </TextListItem>
+        <TextListItem
+          className=""
+          component="dd"
+        >
+          0.0.0.12345678
+        </TextListItem>
+      </React.Fragment>
+    </TextList>
+  </TextContent>
+</AboutModal>
+`;
+
+exports[`AboutModal Component should render a basic component: basic 1`] = `
+<AboutModal
+  aria-label="Quipucords"
+  backgroundImageSrc="aboutBg.png"
+  brandImageAlt="Quipucords"
+  brandImageSrc="title.svg"
+  isOpen={false}
+  onClose={[Function]}
+  trademark="t([
+  "about.copyright",
+  {
+    "year": "2024"
+  }
+])"
+>
+  <TextContent
+    className="fadein"
+  >
+    <TextList
+      component="dl"
+    >
+      <React.Fragment>
+        <TextListItem
+          component="dt"
+        >
+          t([
+  "about.ui-version"
+])
+        </TextListItem>
+        <TextListItem
+          component="dd"
+        >
+          0.0.0.0000000
+        </TextListItem>
+      </React.Fragment>
+    </TextList>
+  </TextContent>
+</AboutModal>
+`;

--- a/src/components/aboutModal/__tests__/aboutModal.test.tsx
+++ b/src/components/aboutModal/__tests__/aboutModal.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { shallowComponent } from '../../../../config/jest.setupTests';
+import { AboutModal } from '../aboutModal';
+
+describe('AboutModal Component', () => {
+  it('should render a basic component', async () => {
+    const props = {};
+    const component = await shallowComponent(<AboutModal {...props} />);
+    expect(component).toMatchSnapshot('basic');
+  });
+
+  it('should attempt to display username, status data', async () => {
+    const mockGetStatus = jest.fn().mockResolvedValue({ server_version: '0.0.0.12345678' });
+    const mockUseStatusApi = jest.fn().mockReturnValue({ getStatus: mockGetStatus });
+    const mockGetUser = jest.fn().mockResolvedValue('lorem ipsum');
+    const mockUseUserApi = jest.fn().mockReturnValue({ getUser: mockGetUser });
+    const props = {
+      isOpen: true,
+      useUser: mockUseUserApi,
+      useStatus: mockUseStatusApi
+    };
+
+    const component = await shallowComponent(<AboutModal {...props} />);
+    expect(component).toMatchSnapshot('username and status');
+  });
+
+  it('should call onClose', async () => {
+    const mockOnClose = jest.fn();
+    const props = {
+      isOpen: true,
+      useUser: jest.fn().mockReturnValue({ getUser: jest.fn().mockResolvedValue('lorem ipsum') }),
+      useStatus: jest.fn().mockReturnValue({ getStatus: jest.fn().mockResolvedValue({}) }),
+      onClose: mockOnClose
+    };
+
+    render(<AboutModal {...props} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText('Close Dialog'));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/aboutModal/aboutModal.tsx
+++ b/src/components/aboutModal/aboutModal.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AboutModal as PfAboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
+import { detect } from 'detect-browser';
+import moment from 'moment/moment';
+import { helpers } from '../../helpers';
+import { useUserApi } from '../../hooks/useLoginApi';
+import { useStatusApi, type ApiStatusSuccessType } from '../../hooks/useStatusApi';
+import backgroundImageSrc from '../../images/aboutBg.png';
+
+interface AboutModalProps {
+  currentYear?: string;
+  isOpen?: boolean;
+  onClose?: () => void;
+  titleImg?: string;
+  uiName?: string;
+  uiVersion?: string;
+  useStatus?: typeof useStatusApi;
+  useUser?: typeof useUserApi;
+}
+
+const AboutModal: React.FC<AboutModalProps> = ({
+  currentYear = moment.utc(helpers.getCurrentDate()).format('YYYY'),
+  isOpen = false,
+  onClose = Function.prototype,
+  titleImg = helpers.getTitleImg(),
+  uiName = helpers.UI_NAME,
+  uiVersion = helpers.UI_VERSION,
+  useStatus = useStatusApi,
+  useUser = useUserApi
+}) => {
+  const { t } = useTranslation();
+  const { getStatus } = useStatus();
+  const { getUser } = useUser();
+  const [userName, setUserName] = useState<string>();
+  const [stats, setStats] = useState<ApiStatusSuccessType>();
+  const browser = detect();
+  const loadingClassName = (!stats && 'fadein') || '';
+
+  useEffect(() => {
+    if (isOpen && !stats) {
+      getUser().then(username => setUserName(username));
+      getStatus().then(
+        data => setStats(data),
+        error => console.error(`About status error: ${error} `)
+      );
+    }
+  }, [isOpen, getStatus, getUser, stats]);
+
+  return (
+    <PfAboutModal
+      aria-label={uiName}
+      backgroundImageSrc={backgroundImageSrc as string}
+      brandImageAlt={uiName}
+      brandImageSrc={titleImg}
+      isOpen={isOpen}
+      onClose={() => onClose()}
+      trademark={t('about.copyright', { year: currentYear })}
+    >
+      <TextContent className={loadingClassName}>
+        <TextList component="dl">
+          {userName && (
+            <React.Fragment>
+              <TextListItem component="dt">{t('about.username')}</TextListItem>
+              <TextListItem component="dd">{userName}</TextListItem>
+            </React.Fragment>
+          )}
+          {browser && (
+            <React.Fragment>
+              <TextListItem component="dt">{t('about.browser-version')}</TextListItem>
+              <TextListItem component="dd">{`${browser.name} ${browser.version}`}</TextListItem>
+            </React.Fragment>
+          )}
+          {browser && (
+            <React.Fragment>
+              <TextListItem component="dt">{t('about.browser-os')}</TextListItem>
+              <TextListItem component="dd">{browser.os || ''}</TextListItem>
+            </React.Fragment>
+          )}
+          {uiVersion && (
+            <React.Fragment>
+              <TextListItem component="dt">{t('about.ui-version')}</TextListItem>
+              <TextListItem component="dd">{uiVersion}</TextListItem>
+            </React.Fragment>
+          )}
+          {stats?.server_version && (
+            <React.Fragment>
+              <TextListItem className={loadingClassName} component="dt">
+                {t('about.server-version')}
+              </TextListItem>
+              <TextListItem className={loadingClassName} component="dd">
+                {stats.server_version}
+              </TextListItem>
+            </React.Fragment>
+          )}
+        </TextList>
+      </TextContent>
+    </PfAboutModal>
+  );
+};
+
+export { AboutModal as default, AboutModal, type AboutModalProps };

--- a/src/components/viewLayout/__tests__/__snapshots__/viewLayoutToolbar.test.tsx.snap
+++ b/src/components/viewLayout/__tests__/__snapshots__/viewLayoutToolbar.test.tsx.snap
@@ -12,70 +12,100 @@ exports[`ViewToolbar should attempt to load and display a username: user 1`] = `
 `;
 
 exports[`ViewToolbar should render a basic component: basic 1`] = `
-<Toolbar
-  id="toolbar"
-  isFullHeight={true}
-  isStatic={true}
->
-  <ToolbarContent
-    isExpanded={false}
-    showClearFiltersButton={false}
+<React.Fragment>
+  <Toolbar
+    id="toolbar"
+    isFullHeight={true}
+    isStatic={true}
   >
-    <ForwardRef
-      align={
-        {
-          "default": "alignRight",
-        }
-      }
-      spacer={
-        {
-          "default": "spacerNone",
-          "md": "spacerMd",
-        }
-      }
-      variant="icon-button-group"
+    <ToolbarContent
+      isExpanded={false}
+      showClearFiltersButton={false}
     >
       <ForwardRef
-        variant="icon-button-group"
-        visibility={
+        align={
           {
-            "default": "hidden",
-            "lg": "visible",
+            "default": "alignRight",
           }
         }
+        spacer={
+          {
+            "default": "spacerNone",
+            "md": "spacerMd",
+          }
+        }
+        variant="icon-button-group"
       >
-        <ToolbarItem>
-          <ToggleGroup
-            aria-label="Dark theme toggle group"
-          >
-            <ToggleGroupItem
-              aria-label="light theme toggle"
-              icon={
-                <Icon
-                  size="md"
-                >
-                  <SunIcon />
-                </Icon>
+        <ForwardRef
+          variant="icon-button-group"
+          visibility={
+            {
+              "default": "hidden",
+              "lg": "visible",
+            }
+          }
+        >
+          <ToolbarItem>
+            <ToggleGroup
+              aria-label="Dark theme toggle group"
+            >
+              <ToggleGroupItem
+                aria-label="light theme toggle"
+                icon={
+                  <Icon
+                    size="md"
+                  >
+                    <SunIcon />
+                  </Icon>
+                }
+                isSelected={true}
+                onChange={[Function]}
+              />
+              <ToggleGroupItem
+                aria-label="dark theme toggle"
+                icon={
+                  <Icon
+                    size="md"
+                  >
+                    <MoonIcon />
+                  </Icon>
+                }
+                onChange={[Function]}
+              />
+            </ToggleGroup>
+          </ToolbarItem>
+          <ToolbarItem>
+            <Dropdown
+              isOpen={false}
+              onOpenChange={[Function]}
+              onSelect={[Function]}
+              popperProps={
+                {
+                  "position": "right",
+                }
               }
-              isSelected={true}
-              onChange={[Function]}
-            />
-            <ToggleGroupItem
-              aria-label="dark theme toggle"
-              icon={
-                <Icon
-                  size="md"
-                >
-                  <MoonIcon />
-                </Icon>
-              }
-              onChange={[Function]}
-            />
-          </ToggleGroup>
-        </ToolbarItem>
-        <ToolbarItem>
+              toggle={[Function]}
+            >
+              <DropdownItem
+                onClick={[Function]}
+                value="about"
+              >
+                About
+              </DropdownItem>
+            </Dropdown>
+          </ToolbarItem>
+        </ForwardRef>
+        <ToolbarItem
+          visibility={
+            {
+              "default": "visible",
+              "lg": "hidden",
+            }
+          }
+        >
           <Dropdown
             isOpen={false}
+            isPlain={true}
             onOpenChange={[Function]}
             onSelect={[Function]}
             popperProps={
@@ -86,10 +116,11 @@ exports[`ViewToolbar should render a basic component: basic 1`] = `
             toggle={[Function]}
           >
             <DropdownItem
+              data-ouia-component-id="logout"
               onClick={[Function]}
-              value="about"
+              value="logout"
             >
-              About
+              Logout
             </DropdownItem>
           </Dropdown>
         </ToolbarItem>
@@ -97,21 +128,15 @@ exports[`ViewToolbar should render a basic component: basic 1`] = `
       <ToolbarItem
         visibility={
           {
-            "default": "visible",
-            "lg": "hidden",
+            "default": "hidden",
+            "lg": "visible",
           }
         }
       >
         <Dropdown
           isOpen={false}
-          isPlain={true}
           onOpenChange={[Function]}
           onSelect={[Function]}
-          popperProps={
-            {
-              "position": "right",
-            }
-          }
           toggle={[Function]}
         >
           <DropdownItem
@@ -123,30 +148,11 @@ exports[`ViewToolbar should render a basic component: basic 1`] = `
           </DropdownItem>
         </Dropdown>
       </ToolbarItem>
-    </ForwardRef>
-    <ToolbarItem
-      visibility={
-        {
-          "default": "hidden",
-          "lg": "visible",
-        }
-      }
-    >
-      <Dropdown
-        isOpen={false}
-        onOpenChange={[Function]}
-        onSelect={[Function]}
-        toggle={[Function]}
-      >
-        <DropdownItem
-          data-ouia-component-id="logout"
-          onClick={[Function]}
-          value="logout"
-        >
-          Logout
-        </DropdownItem>
-      </Dropdown>
-    </ToolbarItem>
-  </ToolbarContent>
-</Toolbar>
+    </ToolbarContent>
+  </Toolbar>
+  <AboutModal
+    isOpen={false}
+    onClose={[Function]}
+  />
+</React.Fragment>
 `;

--- a/src/components/viewLayout/__tests__/viewLayout.test.tsx
+++ b/src/components/viewLayout/__tests__/viewLayout.test.tsx
@@ -14,7 +14,7 @@ describe('ViewLayout', () => {
   it('should render a brand component', async () => {
     const props = {
       children: 'Lorem ipsum',
-      isBrand: true,
+      titleImg: 'titleBrand.svg',
       uiName: 'Discovery'
     };
     const component = await shallowComponent(<ViewLayout {...props} />);

--- a/src/components/viewLayout/viewLayout.tsx
+++ b/src/components/viewLayout/viewLayout.tsx
@@ -28,18 +28,20 @@ import {
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
 import { helpers } from '../../helpers';
-import titleImg from '../../images/title.svg';
-import titleImgBrand from '../../images/titleBrand.svg';
 import { IAppRoute, IAppRouteGroup, routes } from '../../routes';
 import { AppToolbar } from './viewLayoutToolbar';
 
 interface AppLayoutProps {
   children: React.ReactNode;
-  isBrand?: boolean;
+  titleImg?: string;
   uiName?: string;
 }
 
-const AppLayout: React.FC<AppLayoutProps> = ({ children, isBrand = helpers.UI_BRAND, uiName = helpers.UI_NAME }) => {
+const AppLayout: React.FC<AppLayoutProps> = ({
+  children,
+  titleImg = helpers.getTitleImg(),
+  uiName = helpers.UI_NAME
+}) => {
   const { t } = useTranslation();
   const [sidebarOpen, setSidebarOpen] = React.useState(true);
 
@@ -53,7 +55,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children, isBrand = helpers.UI_BR
       <MastheadMain>
         <MastheadBrand>
           <Brand alt={t('view.alt-logo', { name: uiName })} heights={{ default: '36px' }}>
-            <source srcSet={((isBrand && titleImgBrand) || titleImg) as string} />
+            <source srcSet={titleImg} />
           </Brand>
         </MastheadBrand>
       </MastheadMain>

--- a/src/components/viewLayout/viewLayoutToolbar.tsx
+++ b/src/components/viewLayout/viewLayoutToolbar.tsx
@@ -22,6 +22,7 @@ import { EllipsisVIcon, MoonIcon, QuestionCircleIcon, SunIcon } from '@patternfl
 import { useLogoutApi, useUserApi } from '../../hooks/useLoginApi';
 import '@patternfly/react-styles/css/components/Avatar/avatar.css';
 import './viewLayoutToolbar.css';
+import AboutModal from '../aboutModal/aboutModal';
 
 interface AppToolbarProps {
   useLogout?: typeof useLogoutApi;
@@ -33,6 +34,7 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ useLogout = useLogoutApi, useUs
   const { getUser } = useUser();
   const [userName, setUserName] = useState<string>();
   const [helpOpen, setHelpOpen] = useState<boolean>(false);
+  const [aboutOpen, setAboutOpen] = useState<boolean>(false);
   const [userDropdownOpen, setUserDropdownOpen] = useState<boolean>(false);
   const [kebabDropdownOpen, setKebabDropdownOpen] = useState<boolean>(false);
   const [isDarkTheme, setIsDarkTheme] = useState(
@@ -56,7 +58,9 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ useLogout = useLogoutApi, useUs
   };
   applyTheme(isDarkTheme);
 
-  const onAbout = () => {};
+  const onAbout = () => setAboutOpen(true);
+
+  const onAboutClose = () => setAboutOpen(false);
 
   const onHelpSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
@@ -75,86 +79,114 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ useLogout = useLogoutApi, useUs
   };
 
   return (
-    <Toolbar id="toolbar" isFullHeight isStatic>
-      <ToolbarContent>
-        <ToolbarGroup
-          variant="icon-button-group"
-          align={{ default: 'alignRight' }}
-          spacer={{ default: 'spacerNone', md: 'spacerMd' }}
-        >
-          <ToolbarGroup variant="icon-button-group" visibility={{ default: 'hidden', lg: 'visible' }}>
-            <ToolbarItem>
-              <ToggleGroup aria-label="Dark theme toggle group">
-                <ToggleGroupItem
-                  aria-label="light theme toggle"
-                  icon={
-                    <Icon size="md">
-                      <SunIcon />
-                    </Icon>
-                  }
-                  isSelected={!isDarkTheme}
-                  onChange={() => {
-                    setIsDarkTheme(false);
-                    applyTheme(false);
-                  }}
-                />
-                <ToggleGroupItem
-                  aria-label="dark theme toggle"
-                  icon={
-                    <Icon size="md">
-                      <MoonIcon />
-                    </Icon>
-                  }
-                  isSelected={isDarkTheme}
-                  onChange={() => {
-                    setIsDarkTheme(true);
-                    applyTheme(true);
-                  }}
-                />
-              </ToggleGroup>
-            </ToolbarItem>
-            <ToolbarItem>
+    <React.Fragment>
+      <Toolbar id="toolbar" isFullHeight isStatic>
+        <ToolbarContent>
+          <ToolbarGroup
+            variant="icon-button-group"
+            align={{ default: 'alignRight' }}
+            spacer={{ default: 'spacerNone', md: 'spacerMd' }}
+          >
+            <ToolbarGroup variant="icon-button-group" visibility={{ default: 'hidden', lg: 'visible' }}>
+              <ToolbarItem>
+                <ToggleGroup aria-label="Dark theme toggle group">
+                  <ToggleGroupItem
+                    aria-label="light theme toggle"
+                    icon={
+                      <Icon size="md">
+                        <SunIcon />
+                      </Icon>
+                    }
+                    isSelected={!isDarkTheme}
+                    onChange={() => {
+                      setIsDarkTheme(false);
+                      applyTheme(false);
+                    }}
+                  />
+                  <ToggleGroupItem
+                    aria-label="dark theme toggle"
+                    icon={
+                      <Icon size="md">
+                        <MoonIcon />
+                      </Icon>
+                    }
+                    isSelected={isDarkTheme}
+                    onChange={() => {
+                      setIsDarkTheme(true);
+                      applyTheme(true);
+                    }}
+                  />
+                </ToggleGroup>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Dropdown
+                  popperProps={{ position: 'right' }}
+                  onSelect={onHelpSelect}
+                  onOpenChange={(isOpen: boolean) => setHelpOpen(isOpen)}
+                  isOpen={helpOpen}
+                  toggle={toggleRef => (
+                    <MenuToggle
+                      aria-label="Toggle"
+                      ref={toggleRef}
+                      variant="plain"
+                      onClick={() => setHelpOpen(prev => !prev)}
+                      isExpanded={helpOpen}
+                    >
+                      <QuestionCircleIcon />
+                    </MenuToggle>
+                  )}
+                >
+                  <DropdownItem onClick={onAbout} value="about">
+                    About
+                  </DropdownItem>
+                </Dropdown>
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarItem visibility={{ default: 'visible', lg: 'hidden' }}>
               <Dropdown
+                isPlain
                 popperProps={{ position: 'right' }}
-                onSelect={onHelpSelect}
-                onOpenChange={(isOpen: boolean) => setHelpOpen(isOpen)}
-                isOpen={helpOpen}
+                onSelect={onUserDropdownSelect}
+                onOpenChange={(isOpen: boolean) => setKebabDropdownOpen(isOpen)}
+                isOpen={kebabDropdownOpen}
                 toggle={toggleRef => (
                   <MenuToggle
                     aria-label="Toggle"
                     ref={toggleRef}
                     variant="plain"
-                    onClick={() => setHelpOpen(prev => !prev)}
-                    isExpanded={helpOpen}
+                    onClick={() => setKebabDropdownOpen(prev => !prev)}
+                    isExpanded={kebabDropdownOpen}
+                    style={{ width: 'auto' }}
+                    data-ouia-component-id="user_dropdown_button"
                   >
-                    <QuestionCircleIcon />
+                    <EllipsisVIcon />
                   </MenuToggle>
                 )}
               >
-                <DropdownItem onClick={onAbout} value="about">
-                  About
+                <DropdownItem value="logout" onClick={onLogout} data-ouia-component-id="logout">
+                  Logout
                 </DropdownItem>
               </Dropdown>
             </ToolbarItem>
           </ToolbarGroup>
-          <ToolbarItem visibility={{ default: 'visible', lg: 'hidden' }}>
+          <ToolbarItem visibility={{ default: 'hidden', lg: 'visible' }}>
             <Dropdown
-              isPlain
-              popperProps={{ position: 'right' }}
               onSelect={onUserDropdownSelect}
-              onOpenChange={(isOpen: boolean) => setKebabDropdownOpen(isOpen)}
-              isOpen={kebabDropdownOpen}
+              onOpenChange={(isOpen: boolean) => setUserDropdownOpen(isOpen)}
+              isOpen={userDropdownOpen}
               toggle={toggleRef => (
                 <MenuToggle
                   aria-label="Toggle"
                   ref={toggleRef}
                   variant="plain"
-                  onClick={() => setKebabDropdownOpen(prev => !prev)}
-                  isExpanded={kebabDropdownOpen}
-                  style={{ width: 'auto' }}
+                  onClick={() => setUserDropdownOpen(prev => !prev)}
+                  isExpanded={userDropdownOpen}
                   data-ouia-component-id="user_dropdown_button"
                 >
-                  <EllipsisVIcon />
+                  <div className="quipucords-toolbar__user-dropdown">
+                    <span className="pf-v5-c-avatar" />
+                    {userName}
+                  </div>
                 </MenuToggle>
               )}
             >
@@ -163,35 +195,10 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ useLogout = useLogoutApi, useUs
               </DropdownItem>
             </Dropdown>
           </ToolbarItem>
-        </ToolbarGroup>
-        <ToolbarItem visibility={{ default: 'hidden', lg: 'visible' }}>
-          <Dropdown
-            onSelect={onUserDropdownSelect}
-            onOpenChange={(isOpen: boolean) => setUserDropdownOpen(isOpen)}
-            isOpen={userDropdownOpen}
-            toggle={toggleRef => (
-              <MenuToggle
-                aria-label="Toggle"
-                ref={toggleRef}
-                variant="plain"
-                onClick={() => setUserDropdownOpen(prev => !prev)}
-                isExpanded={userDropdownOpen}
-                data-ouia-component-id="user_dropdown_button"
-              >
-                <div className="quipucords-toolbar__user-dropdown">
-                  <span className="pf-v5-c-avatar" />
-                  {userName}
-                </div>
-              </MenuToggle>
-            )}
-          >
-            <DropdownItem value="logout" onClick={onLogout} data-ouia-component-id="logout">
-              Logout
-            </DropdownItem>
-          </Dropdown>
-        </ToolbarItem>
-      </ToolbarContent>
-    </Toolbar>
+        </ToolbarContent>
+      </Toolbar>
+      <AboutModal isOpen={aboutOpen} onClose={onAboutClose} />
+    </React.Fragment>
   );
 };
 

--- a/src/helpers/__tests__/__snapshots__/helpers.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/helpers.test.ts.snap
@@ -11,10 +11,28 @@ exports[`getAuthType should return a credential type: credentialTypes 1`] = `
 ]
 `;
 
+exports[`getCurrentDate should return a predictable current date: current date 1`] = `
+{
+  "currentDate": 2024-10-01T00:00:00.000Z,
+}
+`;
+
 exports[`getTimeDisplayHowLongAgo should return a timestamp estimate: timestamps 1`] = `
 [
   "a few seconds ago",
   "a month ago",
   "a day ago",
 ]
+`;
+
+exports[`getTitleImg should return a brand title image: brand title image 1`] = `
+{
+  "titleImg": "titleBrand.svg",
+}
+`;
+
+exports[`getTitleImg should return a title image: title image 1`] = `
+{
+  "titleImg": "title.svg",
+}
 `;

--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -64,6 +64,25 @@ describe('getAuthType', () => {
   });
 });
 
+describe('getCurrentDate', () => {
+  it('should return a predictable current date', () => {
+    const currentDate = helpers.getCurrentDate();
+    expect({ currentDate }).toMatchSnapshot('current date');
+  });
+});
+
+describe('getTitleImg', () => {
+  it('should return a title image', () => {
+    const titleImg = helpers.getTitleImg();
+    expect({ titleImg }).toMatchSnapshot('title image');
+  });
+
+  it('should return a brand title image', () => {
+    const titleImg = helpers.getTitleImg(true);
+    expect({ titleImg }).toMatchSnapshot('brand title image');
+  });
+});
+
 describe('noopTranslate', () => {
   it('should format key, value, and components into a string', () => {
     const key = 'testKey';

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -7,6 +7,8 @@
  */
 import React from 'react';
 import moment, { type MomentInput } from 'moment';
+import titleImg from '../images/title.svg';
+import titleImgBrand from '../images/titleBrand.svg';
 import { type CredentialType } from '../types/types';
 
 /**
@@ -38,6 +40,12 @@ const UI_BRAND = process.env.REACT_APP_UI_BRAND === 'true';
  * See dotenv config files for updating.
  */
 const UI_NAME = (UI_BRAND && process.env.REACT_APP_UI_BRAND_NAME) || `${process.env.REACT_APP_UI_NAME}`;
+
+/**
+ * UI packaged application version, with generated hash.
+ * See dotenv config files for updating. See build scripts for generated hash.
+ */
+const UI_VERSION = process.env.REACT_APP_UI_VERSION;
 
 /**
  * Generates a translation key for internationalization.
@@ -189,20 +197,38 @@ const downloadData = (data: string | ArrayBuffer | ArrayBufferView | Blob, fileN
 const generateId = (prefix = 'generatedid') =>
   `${prefix}-${(process.env.REACT_APP_ENV !== 'test' && Math.ceil(1e5 * Math.random())) || ''}`;
 
+/**
+ * Return a consistent current date
+ *
+ * @returns {string|Date}
+ */
+const getCurrentDate = () => (TEST_MODE && moment.utc('20241001').toDate()) || moment.utc().toDate();
+
+/**
+ * Return a consistent title image
+ *
+ * @param {boolean} isBrand
+ * @returns {string}
+ */
+const getTitleImg = (isBrand = UI_BRAND) => ((isBrand && titleImgBrand) || titleImg) as string;
+
 const helpers = {
   authType,
   downloadData,
   noopTranslate,
   generateId,
   getAuthType,
+  getCurrentDate,
   getTimeDisplayHowLongAgo,
+  getTitleImg,
   formatDate,
   normalizeTotal,
   DEV_MODE,
   PROD_MODE,
   TEST_MODE,
   UI_BRAND,
-  UI_NAME
+  UI_NAME,
+  UI_VERSION
 };
 
 export { helpers as default, helpers };

--- a/src/hooks/__tests__/__snapshots__/useStatusApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useStatusApi.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useStatusApi should attempt an api call to get a status: apiCall 1`] = `
+[
+  [
+    "/api/v1/status/",
+  ],
+]
+`;
+
+exports[`useStatusApi should handle errors while attempting to get a status: getStatus, error 1`] = `
+{
+  "isAxiosError": true,
+  "message": "Mock error",
+}
+`;
+
+exports[`useStatusApi should handle success while attempting to get a status: getStatus, success 1`] = `undefined`;
+
+exports[`useStatusApi should process an API error response: callbackError 1`] = `
+{
+  "response": {
+    "data": {
+      "message": "Dolor sit",
+    },
+  },
+}
+`;
+
+exports[`useStatusApi should process an API success response: callbackSuccess 1`] = `
+{
+  "api_version": "lorem ipsum",
+  "server_version": "dolor sit",
+}
+`;

--- a/src/hooks/__tests__/useStatusApi.test.ts
+++ b/src/hooks/__tests__/useStatusApi.test.ts
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import axios from 'axios';
+import { useStatusApi } from '../useStatusApi';
+
+describe('useStatusApi', () => {
+  let hookResult;
+
+  beforeEach(() => {
+    const hook = renderHook(() => useStatusApi());
+    hookResult = hook?.result?.current;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should attempt an api call to get a status', () => {
+    const { apiCall } = hookResult;
+    const spyAxios = jest.spyOn(axios, 'get');
+
+    apiCall();
+    expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
+  });
+
+  it('should handle success while attempting to get a status', async () => {
+    const { getStatus } = hookResult;
+    jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({}));
+
+    await expect(getStatus()).resolves.toMatchSnapshot('getStatus, success');
+  });
+
+  it('should handle errors while attempting to get a status', async () => {
+    const { getStatus } = hookResult;
+    jest.spyOn(axios, 'get').mockImplementation(() => Promise.reject({ isAxiosError: true, message: 'Mock error' }));
+
+    await expect(getStatus()).rejects.toMatchSnapshot('getStatus, error');
+  });
+
+  it('should process an API success response', async () => {
+    const { callbackSuccess } = hookResult;
+
+    expect(callbackSuccess({ data: { api_version: 'lorem ipsum', server_version: 'dolor sit' } })).toMatchSnapshot(
+      'callbackSuccess'
+    );
+  });
+
+  it('should process an API error response', async () => {
+    const { callbackError } = hookResult;
+
+    await expect(
+      callbackError({
+        response: {
+          data: {
+            message: 'Dolor sit'
+          }
+        }
+      })
+    ).rejects.toMatchSnapshot('callbackError');
+  });
+});

--- a/src/hooks/useStatusApi.ts
+++ b/src/hooks/useStatusApi.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import axios, { type AxiosError, type AxiosResponse, isAxiosError } from 'axios';
+import helpers from '../helpers';
+
+type ApiStatusSuccessType = {
+  server_version: string;
+};
+
+type ApiStatusErrorType = {
+  detail?: string;
+  message: string;
+};
+
+/**
+ * A status API call
+ */
+const useStatusApi = () => {
+  const apiCall = useCallback(
+    (): Promise<AxiosResponse<ApiStatusSuccessType>> => axios.get(`${process.env.REACT_APP_STATUS_SERVICE}`),
+    []
+  );
+
+  const callbackSuccess = useCallback((response: AxiosResponse<ApiStatusSuccessType>) => response?.data, []);
+
+  const callbackError = useCallback((error: AxiosError<ApiStatusErrorType>) => {
+    return Promise.reject(error);
+  }, []);
+
+  const getStatus = useCallback(async () => {
+    let response;
+    try {
+      response = await apiCall();
+    } catch (error) {
+      if (isAxiosError(error)) {
+        return callbackError(error);
+      }
+      if (!helpers.TEST_MODE) {
+        console.error(error);
+      }
+    }
+    return callbackSuccess(response);
+  }, [apiCall, callbackSuccess, callbackError]);
+
+  return {
+    apiCall,
+    callbackError,
+    callbackSuccess,
+    getStatus
+  };
+};
+
+export { useStatusApi, type ApiStatusSuccessType };

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -2,8 +2,9 @@
 
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 [
-  "components/viewLayout/viewLayoutToolbar.tsx:65:    console.log('selected', value);",
-  "components/viewLayout/viewLayoutToolbar.tsx:73:    console.log('selected', value);",
+  "components/aboutModal/aboutModal.tsx:45:        error => console.error(\`About status error: \${error} \`)",
+  "components/viewLayout/viewLayoutToolbar.tsx:69:    console.log('selected', value);",
+  "components/viewLayout/viewLayoutToolbar.tsx:77:    console.log('selected', value);",
   "helpers/queryHelpers.ts:70:        console.log(\`Query: \`, query);",
   "helpers/queryHelpers.ts:75:        console.error(error);",
   "hooks/useCredentialApi.ts:81:          console.log(missingCredsMsg);",
@@ -28,6 +29,7 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:127:          console.error(error);",
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
+  "hooks/useStatusApi.ts:38:        console.error(error);",
   "views/scans/showScansModal.tsx:79:      console.log({ aValue, bValue });",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",
 ]


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- feat(aboutModal): ds-808 display user, status info
   * aboutModal, display user and status info
   * viewLayout, use title image helper
   * viewLayoutToolbar, add about modal open, close
   * helpers, add ui_version, getCurrentDate, getTitleImg
   * useStatusApi, use status api response

### Notes
- modifies the brand image into a centralized helper to avoid recreating the logic in multiple places
- adds the centralized `getCurrentDate` and `UI_VERSION` helpers from `v1.8`
- what this doesn't do (these items can be iterated on if necessary)
   - ~skips adding the UI browser type from `v1.8` since it involves adding in one more NPM.~
   - skips the `v1.8` custom copy/paste behavior.
- running locally
   - the randomized data local run using `$ npm start` (generated from the `spec` file) returns a `500` level error from the generated `status` call, unclear if there is something malformed in the `spec` since it complains about the shape of the response
   - there's a slight delay in the normal/`staging` run when the initial `status` api call is made. this may, or may not happen, in the standard run. to compensate we use a quick css transition to mask the load jump. if it becomes obvious we may need another solution to indicate loading for `api_version` and `server_version`
- The use of `Red Hat Inc` in the copyright/trademark... is pulled from `v1.8`, confirmation may be needed on the use of `Inc`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start:stage`
1. select the question mark circle next to the user name
   - confirm it displays the about modal similar to the example

<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
_*note: the ui version 1.8.0 is currently the package.json version. this is local run behavior. the format for the ui version in production follows the format `0.0.0.XXXXXXX`, a combination of the package.json version and git hash_

![Screenshot 2024-10-15 at 9 48 44 PM](https://github.com/user-attachments/assets/ee92bbd6-7b12-4a6b-9f72-2b6821a59368)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-808](https://issues.redhat.com/browse/DISCOVERY-808)
