### PR TITLE
fix: ds-441 use correct API field when sorting scans

### DIFF
--- a/src/views/scans/useScansQuery.ts
+++ b/src/views/scans/useScansQuery.ts
@@ -29,7 +29,7 @@ export const useScansQuery = ({
     baseUrl: process.env.REACT_APP_SCANS_SERVICE,
     columnOrderMap: {
       name: 'name',
-      most_recent: 'most_recent_connect_scan__start_time'
+      most_recent: 'most_recent_scanjob__start_time'
     },
     tableState,
     setRefreshTime


### PR DESCRIPTION
[Scans sorting field is called `most_recent_scanjob__start_time`](https://github.com/quipucords/quipucords/blob/main/quipucords/api/scan/view.py#L261). `most_recent_connect_scan__start_time` is available only in sources API.

We even have that string in constants, but it is unused. I looked into git history and it seems that this mistake was introduced back during PF4 migration. Probably a mis-click when selecting a value from intellisense list.

I tested locally that with that patch, clicking headers in scans list changes the order of items. Let me know if there are more places I should change.