### PR TITLE
feat(sources): ds-503 add hosts field validation

### DIFF
--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -5,6 +5,7 @@
  * checks.
  */
 import React from 'react';
+import { ValidatedOptions } from '@patternfly/react-core';
 import moment from 'moment';
 import { helpers } from '../helpers';
 
@@ -152,6 +153,46 @@ describe('normalizeHosts', () => {
     const expected = ['127.0.0.1', '127.0.0.2'];
 
     expect(helpers.normalizeHosts(input)).toEqual(expected);
+  });
+});
+
+describe('validateHosts', () => {
+  // values copied from backend test
+  // quipucords/tests/api/source/test_source.py::TestSource::test_create_valid_hosts
+  it.each([
+    ['10.10.181.9'],
+    ['10.10.181.9/16'],
+    ['10.10.128.[1:25]'],
+    ['10.10.[1:20].25'],
+    ['10.10.[1:20].[1:25]'],
+    ['localhost'],
+    ['my_cool_underscore.com'],
+    ['bgimages.com'],
+    ['my_rhel[a:d].company.com'],
+    ['my_rhel[120:400].company.com'],
+    ['my-rhel[a:d].company.com'],
+    ['my-rhel[120:400].company.com'],
+    ['my-rh_el[120:400].comp_a-ny.com']
+  ])('should accept valid host [%s]', host => {
+    expect(helpers.validateHosts(host, Infinity)).toBe(ValidatedOptions.default);
+  });
+
+  it('should reject empty hosts', () => {
+    const input = ',,';
+
+    expect(helpers.validateHosts(input, Infinity)).toBe(ValidatedOptions.error);
+  });
+
+  it('should reject multiple hosts when only one is allowed', () => {
+    const input = '127.0.0.1 127.0.0.2';
+
+    expect(helpers.validateHosts(input, 1)).toBe(ValidatedOptions.error);
+  });
+
+  it('should reject too long host', () => {
+    const input = 'a'.repeat(400);
+
+    expect(helpers.validateHosts(input, Infinity)).toBe(ValidatedOptions.error);
   });
 });
 

--- a/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`SourceForm should render a basic component: basic 1`] = `
         name="hosts"
         onChange={[Function]}
         ouiaId="hosts_single"
+        validated="error"
         value=""
       />
       <HelperText>

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -201,14 +201,14 @@ const SourceForm: React.FC<SourceFormProps> = ({
               placeholder="Enter values separated by commas"
               value={formData?.hosts}
               onChange={event => handleInputChange('hosts', event.target.value)}
+              validated={helpers.validateHosts(formData?.hosts, Infinity)}
               isRequired
               id="source-hosts"
               name="hosts"
               data-ouia-component-id="hosts_multiple"
             />
             <HelperText>
-              Type IP addresses, IP ranges, and DNS host names. Wildcards are valid. Use CIDR or Ansible notation for
-              ranges.
+              Type IP addresses, IP ranges, and DNS host names. Use CIDR or Ansible notation for ranges.
             </HelperText>
           </FormGroup>
           <FormGroup label="Port" fieldId="port">
@@ -231,6 +231,7 @@ const SourceForm: React.FC<SourceFormProps> = ({
               value={formData?.hosts}
               onChange={event => handleInputChange('hosts', (event.target as HTMLInputElement).value)}
               isRequired
+              validated={helpers.validateHosts(formData?.hosts, 1)}
               id="source-hosts"
               name="hosts"
               ouiaId="hosts_single"


### PR DESCRIPTION
This was originally part of #475 .

Add function that validates the content of hosts field. It is generally meant to reject empty lists and lists that have too many items (everything but network works against single host), but it also looks into individual hosts and rejects ones that won't be accepted by backend anyway.

Regular expressions used in `hostValid` are [copied from backend](https://github.com/quipucords/quipucords/blob/main/quipucords/api/source/serializer.py#L329).

One thing I don't like in current implementation is that field is marked as invalid right as you open the modal. It should be marked as such only if user touched a field / tries to submit form without touching a field. Hints how to solve that are most appreciated!