### PR TITLE
Fix/scans

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -137,7 +137,7 @@ export type ScanJobType = {
   };
   report_id: number;
   start_time: Date;
-  end_time: Date;
+  end_time?: Date;
   systems_count: number;
   systems_scanned: number;
   systems_failed: number;

--- a/src/views/scans/__tests__/showScansModal.test.tsx
+++ b/src/views/scans/__tests__/showScansModal.test.tsx
@@ -17,6 +17,7 @@ describe('ShowScansModal', () => {
           {
             id: 12345,
             status: 'DOLOR SIT',
+            start_time: new Date('2024-09-06'),
             end_time: new Date('2024-09-06'),
             report_id: 67890
           }

--- a/src/views/scans/showScansModal.tsx
+++ b/src/views/scans/showScansModal.tsx
@@ -18,7 +18,7 @@ import { type Scan, type ScanJobType } from '../../types/types';
 interface ShowScansModalProps {
   isOpen: boolean;
   scan?: Pick<Scan, 'name'>;
-  scanJobs?: Pick<ScanJobType, 'id' | 'end_time' | 'report_id' | 'status'>[];
+  scanJobs?: Pick<ScanJobType, 'id' | 'start_time' | 'report_id' | 'status' | 'end_time'>[];
   onDownload?: (report_id: number) => void;
   onClose?: () => void;
   actions?: React.ReactNode[];
@@ -35,7 +35,6 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
   const { t } = useTranslation();
   const [activeSortIndex, setActiveSortIndex] = useState<number | undefined>();
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc' | undefined>();
-  // const [selectedJobs, setSelectedJobs] = useState<number[]>([]);
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
@@ -49,40 +48,6 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
     },
     columnIndex
   });
-
-  /* ToDo: This code is for future use around Discovery-437. If it isn't used when the issue has resolved remove it
- *
-  const isJobSelected = (job: ScanJobType) => { return selectedJobs.includes(job.id); };
-  const isJobSelectable = (job: ScanJobType) => { return true || job.status === "completed"; };
-  const selectableJobs = scanJobs ? scanJobs.filter(isJobSelectable) : [];
-  const onSelectJob = (job: ScanJobType, rowIndex: number, isSelecting: boolean) => {
-      setSelectedJobs((prevSelected) => {
-          const otherSelected = prevSelected.filter((j) => j !== job.id);
-          return isSelecting && isJobSelectable(job) ? [...otherSelected, job.id] : otherSelected;
-        });
-  };
-  const areAllJobsSelected = false;
-
-  const selectAllJobs = (isSelecting: boolean = true) => {
-      setSelectedJobs(isSelecting ? selectableJobs.map((j) => j.id) : []);
-  };
-  const getSortableRowValues = (scanJob: ScanJobType): (Date | string)[] => {
-  const { end_time, status } = scanJob;
-  return [end_time, status];
-};
-
-  let sortedJobs = scanJobs;
-  if (activeSortIndex !== undefined && scanJobs) {
-    sortedJobs = scanJobs.sort((a, b) => {
-      const aValue = getSortableRowValues(a)[activeSortIndex];
-      const bValue = getSortableRowValues(b)[activeSortIndex];
-      console.log({ aValue, bValue });
-      if (activeSortDirection === 'asc') {
-        return (aValue as string)?.localeCompare(bValue as string);
-      }
-      return (bValue as string)?.localeCompare(aValue as string);
-    });
-  }*/
 
   return (
     <Modal
@@ -101,12 +66,6 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
           <Table aria-label="Scan jobs table" ouiaId="scan_jobs_table">
             <Thead>
               <Tr>
-                {/* <Th
-                                    select={{
-                                        onSelect: (_event, isSelecting) => selectAllJobs(isSelecting),
-                                        isSelected: areAllJobsSelected
-                                    }}
-                                /> */}
                 <Th aria-labelledby="Sort by column" sort={getSortParams(0)}>
                   Scan Time
                 </Th>
@@ -119,15 +78,7 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
             <Tbody>
               {scanJobs.map(job => (
                 <Tr key={job.id}>
-                  {/* <Td
-                                        select={{
-                                            rowIndex,
-                                            onSelect: (_event, isSelecting) => onSelectJob(job, rowIndex, isSelecting),
-                                            isSelected: isJobSelected(job),
-                                            isDisabled: !isJobSelectable(job)
-                                        }}
-                                    /> */}
-                  <Td dataLabel="Scan Time">{job.end_time ? helpers.formatDate(job.end_time) : ''}</Td>
+                  <Td dataLabel="Scan Time">{helpers.formatDate(job.end_time || job.start_time)}</Td>
                   <Td dataLabel="Scan Result">{job.status}</Td>
                   <Td dataLabel="Download" isActionCell>
                     {job.report_id && job.end_time && (

--- a/src/views/scans/showScansModal.tsx
+++ b/src/views/scans/showScansModal.tsx
@@ -49,6 +49,13 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
     columnIndex
   });
 
+  // Sort scanJobs by scan time (latest first)
+  const sortedScanJobs = (scanJobs || []).sort((a, b) => {
+    const timeA = a.end_time ? new Date(a.end_time).getTime() : new Date(a.start_time).getTime();
+    const timeB = b.end_time ? new Date(b.end_time).getTime() : new Date(b.start_time).getTime();
+    return timeB - timeA; // Sort in descending order (latest first)
+  });
+
   return (
     <Modal
       variant={ModalVariant.medium}
@@ -57,10 +64,10 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
       onClose={() => onClose()}
       {...(actions && { actions })}
     >
-      {(scanJobs && (
+      {(sortedScanJobs.length && (
         <React.Fragment>
           <div>
-            {scanJobs?.length} scan{scanJobs?.length === 1 ? ' has' : 's have'} run
+            {sortedScanJobs.length} scan{sortedScanJobs.length === 1 ? ' has' : 's have'} run
           </div>
           <br />
           <Table aria-label="Scan jobs table" ouiaId="scan_jobs_table">
@@ -76,7 +83,7 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
               </Tr>
             </Thead>
             <Tbody>
-              {scanJobs.map(job => (
+              {sortedScanJobs.map(job => (
                 <Tr key={job.id}>
                   <Td dataLabel="Scan Time">{helpers.formatDate(job.end_time || job.start_time)}</Td>
                   <Td dataLabel="Scan Result">{job.status}</Td>

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -30,7 +30,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "hooks/useStatusApi.ts:38:        console.error(error);",
-  "views/scans/showScansModal.tsx:79:      console.log({ aValue, bValue });",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",
   "views/sources/viewSourcesList.tsx:310:                console.error(err);",
 ]


### PR DESCRIPTION
Populate Scan time field with start_time if end_time is not available.
Sort scanjobs to be displayed latest first in descending order

### Notes
- fix to  [Mirek] “Last Scanned” modal. While scan is still running, “Scan time” is empty. Right now it seems to refer to end_time field, which is not present in API response for a running scan. It should either always display start_time field, or display end_time if present, but fall back to start_time
- Scans [Mirek] “Last Scanned” modal does not support /api/v1/scans/<id>/jobs/ paging. It will only display first page of results, and results are sorted from oldest to newest. “X scans have run” above table is populated with a length of results, not response count field value, so there is no way of knowing that the most recent scan results are not available through UI.




<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot from 2024-10-17 17-14-57](https://github.com/user-attachments/assets/7dadb205-37e8-4962-b353-a9597e39f6ac)


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-437](https://issues.redhat.com/browse/DISCOVERY-437)
