### PR TITLE
fix(viewSourcesList): ds-813 useShowConnectionsApi catch errors

### DIFF
--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -303,7 +303,14 @@ const SourcesListView: React.FunctionComponent = () => {
       <Button
         variant={ButtonVariant.link}
         onClick={() => {
-          showConnections(source).then(success => setConnectionsData(success));
+          showConnections(source)
+            .then(success => setConnectionsData(success))
+            .catch(err => {
+              setConnectionsData(emptyConnectionData);
+              if (!helpers.TEST_MODE) {
+                console.error(err);
+              }
+            });
           setConnectionsSelected(source);
         }}
       >

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -306,7 +306,6 @@ const SourcesListView: React.FunctionComponent = () => {
           showConnections(source)
             .then(success => setConnectionsData(success))
             .catch(err => {
-              setConnectionsData(emptyConnectionData);
               if (!helpers.TEST_MODE) {
                 console.error(err);
               }

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -32,6 +32,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useStatusApi.ts:38:        console.error(error);",
   "views/scans/showScansModal.tsx:79:      console.log({ aValue, bValue });",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",
-  "views/sources/viewSourcesList.tsx:311:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:310:                console.error(err);",
 ]
 `;

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -32,5 +32,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useStatusApi.ts:38:        console.error(error);",
   "views/scans/showScansModal.tsx:79:      console.log({ aValue, bValue });",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",
+  "views/sources/viewSourcesList.tsx:311:                console.error(err);",
 ]
 `;


### PR DESCRIPTION
## What's included
<!-- Summary of changes/additions -->
- fix(viewSourcesList): ds-813 useShowConnectionsApi catch errors

### Notes
- applies a catch similar to the `addSourceModal` implementation of `getCredentials`
<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->
<!--
### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
-->
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start:stage`
1. you can attempt to emulate the behavior of what the display will look like on failure either
   - by mocking an error for the API call
   - or more directly by putting the same value used for the error inside the success callback, temporarily
   
   You should see a result similar to the example below on failure
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
![Screenshot 2024-10-18 at 3 23 11 PM](https://github.com/user-attachments/assets/c8e2f8af-fbc2-4bc7-a18f-aa8f04898191)

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-813](https://issues.redhat.com/browse/DISCOVERY-813)
