### PR TITLE
fix(scans) ds-531 Stop showing download button too soon

### DIFF
--- a/src/views/scans/showScansModal.tsx
+++ b/src/views/scans/showScansModal.tsx
@@ -19,7 +19,7 @@ interface ShowScansModalProps {
   isOpen: boolean;
   scan?: Pick<Scan, 'name'>;
   scanJobs?: Pick<ScanJobType, 'id' | 'end_time' | 'report_id' | 'status'>[];
-  onDownload?: (number) => void;
+  onDownload?: (report_id: number) => void;
   onClose?: () => void;
   actions?: React.ReactNode[];
 }
@@ -130,7 +130,7 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
                   <Td dataLabel="Scan Time">{job.end_time ? helpers.formatDate(job.end_time) : ''}</Td>
                   <Td dataLabel="Scan Result">{job.status}</Td>
                   <Td dataLabel="Download" isActionCell>
-                    {job.report_id && (
+                    {job.report_id && job.end_time && (
                       <Button onClick={() => onDownload(job.report_id)} icon={<DownloadIcon />} variant="link">
                         Download
                       </Button>


### PR DESCRIPTION
Scan Download button is displayed when scan has report_id field. However, report_id is assigned as soon as scan finished running, but before fingerprinting phase has finished. And it is not possible to download a scan before fingerprinting phase finished.

Arguably this is API not playing very nice, but it's trivial for UI to wait for end_time field. That field is only present on scans that are all completed and reports can be downloaded.

Also, fix typing warning in the same file.

Relates to JIRA: DISCOVERY-531