### PR TITLE
fix(sources): ds-436 display message if scan has not run yet

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -188,6 +188,7 @@
     "label_status_pending": "In progress",
     "label_status_running": "In progress",
     "label_status_paused": "Paused",
+    "label_status_not_started_sources": "Scan not started",
     "label_status_completed_scan": "Completed",
     "label_status_completed_sources": "Last connected",
     "label_status_failed_sources": "Connection failed",

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -290,7 +290,7 @@ const SourcesListView: React.FunctionComponent = () => {
 
   const renderConnection = (source: SourceType) => {
     if (!source?.connection) {
-      return null;
+      return t('table.label_status_not_started', { context: 'sources' });
     }
     const isPending =
       source.connection.status === 'created' ||


### PR DESCRIPTION
Fixes a minor issue from the doc:

> Sources [Mirek] Sources page may display empty cell in “Last connected” column.
> * Steps: Create a source. Click “Scan” to scan it. Wait for scan to finish and go to “Scans”. Find that scan and remove it. Go back to “Sources” page.

This also happens if you create a source using CLI or API directly, where you can opt-out of initial scan.

I'm happy to take suggestions how phrasing can be improved.

Not a huge fan of how this text is misaligned compared to text displayed when scan is running or finished (see screenshot). But for "scan-ful" sources text is displayed inside `<Button>`, which adds left padding, and as far as I can tell, we can't have "transparent" buttons (i.e. apply all the paddings, but none of text formatting). Given that most of users are never going to see that text, it's probably best to leave things like that.

![Screenshot from 2024-10-22 15-33-36](https://github.com/user-attachments/assets/1b4dfcff-35b8-4411-9967-3ce076172715)

Relates to JIRA: DISCOVERY-436