### PR TITLE
fix(scans): ds-437 Prevent empty modal

### DIFF
--- a/src/components/contextIcon/contextIcon.tsx
+++ b/src/components/contextIcon/contextIcon.tsx
@@ -18,6 +18,7 @@ import {
   ExclamationTriangleIcon,
   IdCardIcon,
   InfoCircleIcon,
+  OffIcon,
   OpenshiftIcon,
   PencilAltIcon,
   PficonNetworkRangeIcon,
@@ -73,6 +74,7 @@ const ContextIconVariant: { [key: string]: string } = {
   idCard: 'idCard',
   info: 'info',
   network: 'network',
+  off: 'off',
   openshift: 'openshift',
   pencil: 'pencil',
   satellite: 'satellite',
@@ -104,6 +106,8 @@ const ContextIcon: React.FC<{
       return <InfoCircleIcon {...props} />;
     case ContextIconVariant.network:
       return <PficonNetworkRangeIcon {...props} />;
+    case ContextIconVariant.off:
+      return <OffIcon {...props} />;
     case ContextIconVariant.openshift:
       return <OpenshiftIcon {...props} />;
     case ContextIconVariant.acs:

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -160,6 +160,7 @@ const ScansListView: React.FunctionComponent = () => {
   const renderConnection = (scan: Scan) => (
     <Button
       variant={ButtonVariant.link}
+      isDisabled={!scan.most_recent}
       onClick={() => {
         setScanSelected(scan);
         getScanJobs(scan.id).then(res => {
@@ -168,8 +169,8 @@ const ScansListView: React.FunctionComponent = () => {
       }}
     >
       <ContextIcon
-        symbol={scan.most_recent ? ContextIconVariant[scan.most_recent.status] : ContextIconVariant['defaultStatus']}
-      />
+        symbol={scan.most_recent ? ContextIconVariant[scan.most_recent.status] : ContextIconVariant['off']}
+      />{' '}
       {scan.most_recent && (
         <React.Fragment>
           {scan.most_recent.status === 'failed' && t('table.label', { context: 'status_failed_scans' })}


### PR DESCRIPTION
If the scan has been created but not run yet, don't make "Scan created" cell in table a link. This prevents `<ShowScansModal>` from appearing. Modal would contain empty table.

Also changed icon from unknown to off. [Patternfly icon library](https://www.patternfly.org/design-foundations/icons/) says it "Represents status: powered off", which seems exactly what we have here.

Unfortunately, it has the same mis-alignment issue as #497 . Fortunately, most users will never see this.

This fixes following two issues from docs:

> Scan objects that were never scanned (duh) still have clickable “Scan created” in Last scanned column. The modal displays empty table

> [Mirek] Scans page. In “Last scanned” column, there’s no space between icon and text. Very similar to issue that Bruno reported for Sources, where I believe it was fixed.

## Before:

![Screenshot from 2024-10-23 14-13-32](https://github.com/user-attachments/assets/15bc7af2-a21f-460a-ac71-f79fd0b4f81d)

![Screenshot from 2024-10-23 14-13-47](https://github.com/user-attachments/assets/bc67d59d-534e-4e21-9f7a-40fdd3bf41e2)


## After:

![Screenshot from 2024-10-23 13-50-33](https://github.com/user-attachments/assets/875e1702-0f39-4ffc-a454-1fa279da5bec)


Relates to JIRA: DISCOVERY-437
