### PR TITLE
fix(showScansModal): ds-437 sort last scanned headers

### DIFF
--- a/src/views/scans/__tests__/__snapshots__/showScansModal.test.tsx.snap
+++ b/src/views/scans/__tests__/__snapshots__/showScansModal.test.tsx.snap
@@ -62,3 +62,139 @@ exports[`ShowScansModal should render a basic component: basic 1`] = `
   </Bullseye>
 </Modal>
 `;
+
+exports[`getSortValue should return the correct sort value for the given column index: sort value for invalid index 1`] = `""`;
+
+exports[`getSortValue should return the correct sort value for the given column index: sort value for status 1`] = `"completed"`;
+
+exports[`getSortValue should return the correct sort value for the given column index: sort value for time 1`] = `1730037600000`;
+
+exports[`sortByLatestTime should sort scan jobs by latest scan time in descending order: sorted by latest time 1`] = `
+[
+  {
+    "end_time": 2024-10-27T14:00:00.000Z,
+    "id": 1,
+    "report_id": 101,
+    "start_time": 2024-10-27T12:00:00.000Z,
+    "status": "completed",
+  },
+  {
+    "end_time": 2024-10-27T11:00:00.000Z,
+    "id": 2,
+    "report_id": 102,
+    "start_time": 2024-10-27T10:00:00.000Z,
+    "status": "running",
+  },
+  {
+    "end_time": 2024-10-26T12:00:00.000Z,
+    "id": 3,
+    "report_id": 103,
+    "start_time": 2024-10-26T10:00:00.000Z,
+    "status": "failed",
+  },
+]
+`;
+
+exports[`sortJobs should sort jobs by status in ascending order: sorted jobs by status (asc) 1`] = `
+[
+  {
+    "end_time": 2024-10-26T12:00:00.000Z,
+    "id": 2,
+    "report_id": 102,
+    "start_time": 2024-10-26T10:00:00.000Z,
+    "status": "completed",
+  },
+  {
+    "end_time": 2024-10-28T12:00:00.000Z,
+    "id": 3,
+    "report_id": 103,
+    "start_time": 2024-10-28T10:00:00.000Z,
+    "status": "failed",
+  },
+  {
+    "end_time": 2024-10-27T12:00:00.000Z,
+    "id": 1,
+    "report_id": 101,
+    "start_time": 2024-10-27T10:00:00.000Z,
+    "status": "running",
+  },
+]
+`;
+
+exports[`sortJobs should sort jobs by status in descending order: sorted jobs by status (desc) 1`] = `
+[
+  {
+    "end_time": 2024-10-27T12:00:00.000Z,
+    "id": 1,
+    "report_id": 101,
+    "start_time": 2024-10-27T10:00:00.000Z,
+    "status": "running",
+  },
+  {
+    "end_time": 2024-10-28T12:00:00.000Z,
+    "id": 3,
+    "report_id": 103,
+    "start_time": 2024-10-28T10:00:00.000Z,
+    "status": "failed",
+  },
+  {
+    "end_time": 2024-10-26T12:00:00.000Z,
+    "id": 2,
+    "report_id": 102,
+    "start_time": 2024-10-26T10:00:00.000Z,
+    "status": "completed",
+  },
+]
+`;
+
+exports[`sortJobs should sort jobs by time in ascending order: sorted jobs by time (asc) 1`] = `
+[
+  {
+    "end_time": 2024-10-26T12:00:00.000Z,
+    "id": 2,
+    "report_id": 102,
+    "start_time": 2024-10-26T10:00:00.000Z,
+    "status": "completed",
+  },
+  {
+    "end_time": 2024-10-27T12:00:00.000Z,
+    "id": 1,
+    "report_id": 101,
+    "start_time": 2024-10-27T10:00:00.000Z,
+    "status": "running",
+  },
+  {
+    "end_time": 2024-10-28T12:00:00.000Z,
+    "id": 3,
+    "report_id": 103,
+    "start_time": 2024-10-28T10:00:00.000Z,
+    "status": "failed",
+  },
+]
+`;
+
+exports[`sortJobs should sort jobs by time in descending order: sorted jobs by time (desc) 1`] = `
+[
+  {
+    "end_time": 2024-10-28T12:00:00.000Z,
+    "id": 3,
+    "report_id": 103,
+    "start_time": 2024-10-28T10:00:00.000Z,
+    "status": "failed",
+  },
+  {
+    "end_time": 2024-10-27T12:00:00.000Z,
+    "id": 1,
+    "report_id": 101,
+    "start_time": 2024-10-27T10:00:00.000Z,
+    "status": "running",
+  },
+  {
+    "end_time": 2024-10-26T12:00:00.000Z,
+    "id": 2,
+    "report_id": 102,
+    "start_time": 2024-10-26T10:00:00.000Z,
+    "status": "completed",
+  },
+]
+`;

--- a/src/views/scans/__tests__/showScansModal.test.tsx
+++ b/src/views/scans/__tests__/showScansModal.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { shallowComponent } from '../../../../config/jest.setupTests';
-import { ShowScansModal } from '../showScansModal';
+import { ShowScansModal, getSortValue, sortByLatestTime, sortJobs } from '../showScansModal';
 
 describe('ShowScansModal', () => {
   let mockOnClose;
@@ -60,5 +60,96 @@ describe('ShowScansModal', () => {
     await user.click(screen.getByLabelText('Close'));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('sortByLatestTime', () => {
+  const jobs = [
+    {
+      id: 1,
+      report_id: 101,
+      status: 'completed',
+      start_time: new Date('2024-10-27T12:00:00Z'),
+      end_time: new Date('2024-10-27T14:00:00Z')
+    },
+    {
+      id: 2,
+      report_id: 102,
+      status: 'running',
+      start_time: new Date('2024-10-27T10:00:00Z'),
+      end_time: new Date('2024-10-27T11:00:00Z')
+    },
+    {
+      id: 3,
+      report_id: 103,
+      status: 'failed',
+      start_time: new Date('2024-10-26T10:00:00Z'),
+      end_time: new Date('2024-10-26T12:00:00Z')
+    }
+  ];
+  it('should sort scan jobs by latest scan time in descending order', () => {
+    const sortedJobs = sortByLatestTime(jobs);
+    expect(sortedJobs).toMatchSnapshot('sorted by latest time');
+  });
+});
+
+describe('getSortValue', () => {
+  const job = {
+    id: 1,
+    report_id: 101,
+    status: 'completed',
+    start_time: new Date('2024-10-27T12:00:00Z'),
+    end_time: new Date('2024-10-27T14:00:00Z')
+  };
+  it('should return the correct sort value for the given column index', () => {
+    expect(getSortValue(job, 0)).toMatchSnapshot('sort value for time');
+    expect(getSortValue(job, 1)).toMatchSnapshot('sort value for status');
+    expect(getSortValue(job, 2)).toMatchSnapshot('sort value for invalid index');
+  });
+});
+
+describe('sortJobs', () => {
+  const jobs = [
+    {
+      id: 1,
+      report_id: 101,
+      status: 'running',
+      start_time: new Date('2024-10-27T10:00:00Z'),
+      end_time: new Date('2024-10-27T12:00:00Z')
+    },
+    {
+      id: 2,
+      report_id: 102,
+      status: 'completed',
+      start_time: new Date('2024-10-26T10:00:00Z'),
+      end_time: new Date('2024-10-26T12:00:00Z')
+    },
+    {
+      id: 3,
+      report_id: 103,
+      status: 'failed',
+      start_time: new Date('2024-10-28T10:00:00Z'),
+      end_time: new Date('2024-10-28T12:00:00Z')
+    }
+  ];
+
+  it('should sort jobs by time in ascending order', () => {
+    const sortedJobs = sortJobs(jobs, 0, 'asc');
+    expect(sortedJobs).toMatchSnapshot('sorted jobs by time (asc)');
+  });
+
+  it('should sort jobs by time in descending order', () => {
+    const sortedJobs = sortJobs(jobs, 0, 'desc');
+    expect(sortedJobs).toMatchSnapshot('sorted jobs by time (desc)');
+  });
+
+  it('should sort jobs by status in ascending order', () => {
+    const sortedJobs = sortJobs(jobs, 1, 'asc');
+    expect(sortedJobs).toMatchSnapshot('sorted jobs by status (asc)');
+  });
+
+  it('should sort jobs by status in descending order', () => {
+    const sortedJobs = sortJobs(jobs, 1, 'desc');
+    expect(sortedJobs).toMatchSnapshot('sorted jobs by status (desc)');
   });
 });


### PR DESCRIPTION
Fix sorting mechanism in "Last Scanned" modal headers. 

### Notes
- fix to  [Mirek] “Last Scanned” modal. Clicking table header items inside modal does not actually change the order of items in table.
- This PR does not include pagination. If the number of scan jobs exceeds the visible screen area, you will need to scroll down to view all of them. However, sorting is applied across the entire list of scan jobs.


<!-- Any issues that aren't resolved by this merge request, or things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

### Local run check
1. update the NPM packages with `$ npm install`
1. `$ npm run start`
1. confirm connections display as intended
<!--
### Check the build
1. update the NPM packages with `$ npm install`
1. `$ npm run build`
1. next...
-->

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-437](https://issues.redhat.com/browse/DISCOVERY-437)
