### PR TITLE
fix(sources): ds-436 accept wider range of directories values

### DIFF
--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -125,33 +125,33 @@ describe('formatDate', () => {
   });
 });
 
-describe('normalizeHosts', () => {
+describe('normalizeCommaSeparated', () => {
   it('should accept values separated by space', () => {
     const input = '127.0.0.1 127.0.0.2';
     const expected = ['127.0.0.1', '127.0.0.2'];
 
-    expect(helpers.normalizeHosts(input)).toEqual(expected);
+    expect(helpers.normalizeCommaSeparated(input)).toEqual(expected);
   });
 
   it('should accept values separated by newline (\\n)', () => {
     const input = '127.0.0.1\n127.0.0.2';
     const expected = ['127.0.0.1', '127.0.0.2'];
 
-    expect(helpers.normalizeHosts(input)).toEqual(expected);
+    expect(helpers.normalizeCommaSeparated(input)).toEqual(expected);
   });
 
   it('should accept values separated by newline (\\r)', () => {
     const input = '127.0.0.1\r127.0.0.2';
     const expected = ['127.0.0.1', '127.0.0.2'];
 
-    expect(helpers.normalizeHosts(input)).toEqual(expected);
+    expect(helpers.normalizeCommaSeparated(input)).toEqual(expected);
   });
 
   it('should filter out empty values', () => {
     const input = '127.0.0.1\n 127.0.0.2 ';
     const expected = ['127.0.0.1', '127.0.0.2'];
 
-    expect(helpers.normalizeHosts(input)).toEqual(expected);
+    expect(helpers.normalizeCommaSeparated(input)).toEqual(expected);
   });
 });
 

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -99,12 +99,13 @@ const getTimeDisplayHowLongAgo = (timestamp: MomentInput, { devMode = DEV_MODE }
 const formatDate = (date: Date) => moment.utc(date).format('DD MMMM Y, h:mm A z');
 
 /**
- * Normalizes hosts textarea content into array that can be submitted to backend.
+ * Normalizes comma-separated textarea content into array that can be submitted to backend.
+ * Used by hosts and search_directories fields.
  *
  * @param {string} data - host textarea content.
  * @returns Array of host values which will be submitted to backend.
  */
-const normalizeHosts = (data?: string) =>
+const normalizeCommaSeparated = (data?: string) =>
   data
     ?.trim()
     ?.replaceAll(/\\n|\\r|\s/g, ',')
@@ -235,7 +236,7 @@ const helpers = {
   getTimeDisplayHowLongAgo,
   getTitleImg,
   formatDate,
-  normalizeHosts,
+  normalizeCommaSeparated,
   normalizeTotal,
   DEV_MODE,
   PROD_MODE,

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -121,7 +121,7 @@ const useSourceForm = ({
       return {
         name: name,
         credentials: credentials?.map(c => Number(c)),
-        hosts: helpers.normalizeHosts(hosts),
+        hosts: helpers.normalizeCommaSeparated(hosts),
         port: port || (isOpenshift && '6443') || (isNetwork && '22') || '443',
         options: !isNetwork
           ? {

--- a/src/views/sources/addSourcesScanModal.tsx
+++ b/src/views/sources/addSourcesScanModal.tsx
@@ -19,6 +19,7 @@ import {
   TextArea,
   TextInput
 } from '@patternfly/react-core';
+import { helpers } from '../../helpers';
 import { type Scan, type SourceType } from '../../types/types';
 
 interface AddSourcesScanModalProps {
@@ -59,7 +60,7 @@ const AddSourcesScanModal: React.FC<AddSourcesScanModalProps> = ({
           jboss_eap: deepScans.includes('jboss_eap'),
           jboss_fuse: deepScans.includes('jboss_fuse'),
           jboss_ws: deepScans.includes('jboss_ws'),
-          search_directories: values['scan-alt-scan']?.split(',')
+          search_directories: helpers.normalizeCommaSeparated(values['scan-alt-scan'])
         }
       }
     };


### PR DESCRIPTION
I noticed that search directories textarea ("deep scan") has the same problem as hosts textarea. We fixed hosts in #475 (b1909a77b458f8be618dea023519fce1611a1230), now it's time to fix that one.

As far as I can tell, there are no other fields that would take comma-separated list of values.

I decided to rename `normalizeHosts` helper into something more generic and re-use that. This will conflict badly with #492 . I guess the alternative is to have internal helper `normalizeCommaSeparated` and public-facing `normalizeHosts` and `normalizeSearchDirs`. Not sure which solution is more aligned with current code practices.

