### PR TITLE
fix(sources): ds-436 wrap scan not run message in Button

### DIFF
--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -290,7 +290,11 @@ const SourcesListView: React.FunctionComponent = () => {
 
   const renderConnection = (source: SourceType) => {
     if (!source?.connection) {
-      return t('table.label_status_not_started', { context: 'sources' });
+      return (
+        <Button variant={ButtonVariant.link} isDisabled={true}>
+          <ContextIcon symbol="off" /> {t('table.label_status_not_started', { context: 'sources' })}
+        </Button>
+      );
     }
     const isPending =
       source.connection.status === 'created' ||

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -31,6 +31,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "hooks/useStatusApi.ts:38:        console.error(error);",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",
-  "views/sources/viewSourcesList.tsx:310:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:314:                console.error(err);",
 ]
 `;


### PR DESCRIPTION
This is followup to fd447c501c5a4852f581ee2e81b41e8adfb3485f (#497). After that commit, "Scan not started" message was not aligned with other statuses. Now message is wrapped in disabled Button and has an icon, making a look more consistent.

![Screenshot from 2024-10-31 12-41-08](https://github.com/user-attachments/assets/2425dcb5-6da5-444d-9b5c-3083d97ada00)


Relates to JIRA: DISCOVERY-436