### PR TITLE
fix(views): ds-832 unselect items upon deletion

### DIFF
--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -170,7 +170,7 @@ const CredentialsListView: React.FunctionComponent = () => {
   });
 
   const {
-    selection: { selectedItems },
+    selection: { selectedItems, setSelectedItems },
     currentPageItems,
     numRenderedColumns,
     components: { Toolbar, FilterToolbar, PaginationToolbarItem, Pagination, Table, Tbody, Td, Th, Thead, Tr }
@@ -206,7 +206,12 @@ const CredentialsListView: React.FunctionComponent = () => {
           <Button
             variant={ButtonVariant.secondary}
             isDisabled={!hasSelectedCredentials()}
-            onClick={() => deleteCredentials(selectedItems).finally(() => onRefresh())}
+            onClick={() =>
+              deleteCredentials(selectedItems).finally(() => {
+                setSelectedItems([]);
+                onRefresh();
+              })
+            }
           >
             {t('table.label', { context: 'delete' })}
           </Button>

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -123,7 +123,7 @@ const ScansListView: React.FunctionComponent = () => {
   });
 
   const {
-    selection: { selectedItems },
+    selection: { selectedItems, setSelectedItems },
     currentPageItems,
     numRenderedColumns,
     components: { Toolbar, FilterToolbar, PaginationToolbarItem, Pagination, Table, Tbody, Td, Th, Thead, Tr }
@@ -140,6 +140,7 @@ const ScansListView: React.FunctionComponent = () => {
             onClick={() =>
               deleteScans(selectedItems).finally(() => {
                 setPendingDeleteScan(undefined);
+                setSelectedItems([]);
                 onRefresh();
               })
             }

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -228,7 +228,7 @@ const SourcesListView: React.FunctionComponent = () => {
   });
 
   const {
-    selection: { selectedItems },
+    selection: { selectedItems, setSelectedItems },
     currentPageItems,
     numRenderedColumns,
     components: { Toolbar, FilterToolbar, PaginationToolbarItem, Pagination, Table, Tbody, Td, Th, Thead, Tr }
@@ -273,7 +273,12 @@ const SourcesListView: React.FunctionComponent = () => {
           <Button
             variant={ButtonVariant.secondary}
             isDisabled={!hasSelectedSources()}
-            onClick={() => deleteSources(selectedItems).finally(() => onRefresh())}
+            onClick={() =>
+              deleteSources(selectedItems).finally(() => {
+                setSelectedItems([]);
+                onRefresh();
+              })
+            }
           >
             {t('table.label', { context: 'delete' })}
           </Button>

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -31,6 +31,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:255:          console.error(error);",
   "hooks/useStatusApi.ts:38:        console.error(error);",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",
-  "views/sources/viewSourcesList.tsx:314:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:319:                console.error(err);",
 ]
 `;


### PR DESCRIPTION
Selecting multiple items and deleting them kept them selected in state, which could result in failures of subsequent operations - especially creating scans (because scan would try to involve sources that no longer exist).

Since bulk delete might result in deleting some items, but not the others, arguably these that were not deleted should still be selected. With current code they won't. But that seems like a relatively minor inconvenience at best.

Relates to JIRA: DISCOVERY-832