### PR TITLE
feat(ActionMenu<Scan>): ds-437 add download report button

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -173,6 +173,7 @@
     "label_satellite": "Satellite",
     "label_rhacs": "RHACS",
     "label_rescan": "Rescan",
+    "label_download": "Download",
     "label_scan": "Scan",
     "label_source": "Source",
     "label_source_other": "Sources",

--- a/src/components/actionMenu/actionMenu.tsx
+++ b/src/components/actionMenu/actionMenu.tsx
@@ -11,7 +11,7 @@ import { EllipsisVIcon } from '@patternfly/react-icons';
 
 interface ActionMenuProps<T = unknown> {
   item: T;
-  actions: { label: string; onClick: (item: T) => void }[];
+  actions: { label: string; onClick: (item: T) => void; disabled?: boolean }[];
 }
 
 const ActionMenu = <T,>({ item, actions }: ActionMenuProps<T>) => {
@@ -43,6 +43,7 @@ const ActionMenu = <T,>({ item, actions }: ActionMenuProps<T>) => {
             onClick={() => {
               a.onClick(item);
             }}
+            isDisabled={a.disabled}
           >
             {a.label}
           </DropdownItem>

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -9,7 +9,7 @@ import React from 'react';
 import moment, { type MomentInput } from 'moment';
 import titleImg from '../images/title.svg';
 import titleImgBrand from '../images/titleBrand.svg';
-import { type CredentialType } from '../types/types';
+import { type CredentialType, type MostRecentScan, type scanJob } from '../types/types';
 
 /**
  * Is dev mode active.
@@ -226,8 +226,22 @@ const getCurrentDate = () => (TEST_MODE && moment.utc('20241001').toDate()) || m
  */
 const getTitleImg = (isBrand = UI_BRAND) => ((isBrand && titleImgBrand) || titleImg) as string;
 
+/**
+ * Return if a report associated with given ScanJob can be downloaded
+ *
+ * @param {scanJob | MostRecentScan} job
+ * @returns {boolean}
+ */
+const canDownloadReport = (job?: scanJob | MostRecentScan) => {
+  if (job && job.status === 'completed' && job.report_id) {
+    return true;
+  }
+  return false;
+};
+
 const helpers = {
   authType,
+  canDownloadReport,
   downloadData,
   noopTranslate,
   generateId,

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -232,12 +232,8 @@ const getTitleImg = (isBrand = UI_BRAND) => ((isBrand && titleImgBrand) || title
  * @param {scanJob | MostRecentScan} job
  * @returns {boolean}
  */
-const canDownloadReport = (job?: scanJob | MostRecentScan) => {
-  if (job && job.status === 'completed' && job.report_id) {
-    return true;
-  }
-  return false;
-};
+const canDownloadReport = (job?: scanJob | MostRecentScan) =>
+  job?.status === 'completed' && job?.report_id !== undefined;
 
 const helpers = {
   authType,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -174,12 +174,16 @@ export type ScanOptions = {
 export type scanJob = {
   id: number;
   report_id: number;
+  status: string;
 };
 
 export type StatusDetails = {
   job_status_message: string;
 };
 
+// TODO: the object returned from the API representing scanJob and MostRecentScan are the same;
+// consider this in a future refactor. Also, MostRecentScan is a ScanJob, not a scan. Yeah, quipucords
+// is confusing...
 export type MostRecentScan = {
   id: number;
   report_id: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -181,9 +181,9 @@ export type StatusDetails = {
   job_status_message: string;
 };
 
-// TODO: the object returned from the API representing scanJob and MostRecentScan are the same;
-// consider this in a future refactor. Also, MostRecentScan is a ScanJob, not a scan. Yeah, quipucords
-// is confusing...
+// TODO: Considerations for a future refactor: merge and/or rename scanJob and MostRecentScan.
+// Reason: the object returned from the api representing scanJob and MostRecentScan are the same;
+// also, in quipucords jargon, MostRecentScan is a ScanJob, not a Scan.
 export type MostRecentScan = {
   id: number;
   report_id: number;

--- a/src/views/scans/__tests__/showScansModal.test.tsx
+++ b/src/views/scans/__tests__/showScansModal.test.tsx
@@ -16,7 +16,7 @@ describe('ShowScansModal', () => {
         scanJobs={[
           {
             id: 12345,
-            status: 'DOLOR SIT',
+            status: 'completed',
             start_time: new Date('2024-09-06'),
             end_time: new Date('2024-09-06'),
             report_id: 67890

--- a/src/views/scans/showScansModal.tsx
+++ b/src/views/scans/showScansModal.tsx
@@ -131,7 +131,7 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
                   <Td dataLabel="Scan Time">{helpers.formatDate(job.end_time || job.start_time)}</Td>
                   <Td dataLabel="Scan Result">{job.status}</Td>
                   <Td dataLabel="Download" isActionCell>
-                    {job.report_id && job.end_time && (
+                    {helpers.canDownloadReport(job) && (
                       <Button onClick={() => onDownload(job.report_id)} icon={<DownloadIcon />} variant="link">
                         Download
                       </Button>

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -250,6 +250,15 @@ const ScansListView: React.FunctionComponent = () => {
                             setScanSelected(undefined);
                           });
                         }
+                      },
+                      {
+                        label: t('table.label', { context: 'download' }),
+                        disabled: !helpers.canDownloadReport(scan?.most_recent),
+                        onClick: () => {
+                          if (scan?.most_recent) {
+                            downloadReport(scan.most_recent.report_id);
+                          }
+                        }
                       }
                     ]}
                   />


### PR DESCRIPTION
The button shall only be enabled when the scan is completed.

## What's included

Includes a dropdown button on scan row kebab for downloading reports.

### Notes
- The button should be disabled for failed or incomplete scans.
- If a "complete" scan doesn't have a `report_id` (due to a bug/edge-case on the backend?). a client-side error will be thrown

## Example
Kebab for scans ~in progress~ not ready for download
![image](https://github.com/user-attachments/assets/c906be88-5984-453e-b664-901dd188dc4f)
...and for completed ones
![image](https://github.com/user-attachments/assets/1c314a65-1892-40b3-abc5-f52a90c86bd2)
On download completion, an alert should be displayed. Same shall happen on errors, but that's harder to test without
monkey-patching the server
![image](https://github.com/user-attachments/assets/b8a7d5cf-b5c0-4fb4-94fe-81e79a7cd914)

...

## Updates issue/story

[DISCOVERY-347](https://issues.redhat.com/browse/DISCOVERY-347)
