### PR TITLE
build: bump quay.expires-after from 5d to 7d to allow more test time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   STABLE_TAG: ${{ github.event_name == 'push' && github.ref_name || format('pr-{0}', github.event.pull_request.number) }}
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
-  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=5d' }}
+  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=7d' }}
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/quipucords-ui' }}
   REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 


### PR DESCRIPTION
As discussed at standup with @ruda and the dev team on 2024-11-12.