### PR TITLE
chore(build): ds-748 use correct container label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             ./Containerfile
           labels: |
             ${{ env.EXPIRATION_LABEL }}
-            quipucords.backend.git_sha=${{ github.sha }}
+            quipucords.frontend.git_sha=${{ github.sha }}
           extra-args: |
             --ulimit nofile=4096:4096
 


### PR DESCRIPTION
It doesn't make sense for frontend / app container to have a "quipucords.backend" label in container image.

Relates to JIRA: DISCOVERY-748