### PR TITLE
test: add ouiaId to make reports downloading easier

### DIFF
--- a/src/components/actionMenu/__tests__/__snapshots__/actionMenu.test.tsx.snap
+++ b/src/components/actionMenu/__tests__/__snapshots__/actionMenu.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`ActionMenu should display items and allow click after toggle is clicked
     aria-expanded="true"
     aria-label="Action Menu Toggle"
     class="pf-v5-c-menu-toggle pf-m-expanded pf-m-plain"
+    data-ouia-component-id="action_menu_toggle"
     type="button"
   >
     <svg

--- a/src/components/actionMenu/actionMenu.tsx
+++ b/src/components/actionMenu/actionMenu.tsx
@@ -36,6 +36,7 @@ const ActionMenu = <T,>({ item, actions }: ActionMenuProps<T>) => {
           variant="plain"
           onClick={() => setIsOpen(prev => !prev)}
           isExpanded={isOpen}
+          data-ouia-component-id="action_menu_toggle"
         >
           <EllipsisVIcon />
         </MenuToggle>

--- a/src/views/scans/showScansModal.tsx
+++ b/src/views/scans/showScansModal.tsx
@@ -120,8 +120,12 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
           <Table aria-label="Scan jobs table" ouiaId="scan_jobs_table">
             <Thead>
               <Tr>
-                <Th sort={getSortParams(0)}>Scan Time</Th>
-                <Th sort={getSortParams(1)}>Scan Result</Th>
+                <Th sort={getSortParams(0)} data-ouia-component-id="header_scan_time">
+                  Scan Time
+                </Th>
+                <Th sort={getSortParams(1)} data-ouia-component-id="header_scan_result">
+                  Scan Result
+                </Th>
                 <Th screenReaderText="Download column"></Th>
               </Tr>
             </Thead>

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -240,7 +240,8 @@ const ScansListView: React.FunctionComponent = () => {
                     actions={[
                       {
                         label: t('table.label', { context: 'delete' }),
-                        onClick: setPendingDeleteScan
+                        onClick: setPendingDeleteScan,
+                        ouiaId: 'delete'
                       },
                       {
                         label: t('table.label', { context: 'rescan' }),
@@ -249,7 +250,8 @@ const ScansListView: React.FunctionComponent = () => {
                             queryClient.invalidateQueries({ queryKey: [API_SCANS_LIST_QUERY] });
                             setScanSelected(undefined);
                           });
-                        }
+                        },
+                        ouiaId: 'rescan'
                       },
                       {
                         label: t('table.label', { context: 'download' }),
@@ -258,7 +260,8 @@ const ScansListView: React.FunctionComponent = () => {
                           if (scan?.most_recent) {
                             downloadReport(scan.most_recent.report_id);
                           }
-                        }
+                        },
+                        ouiaId: 'download'
                       }
                     ]}
                   />


### PR DESCRIPTION
SSIA - add a bunch of `ouiaId` attributes to make it easier for Camayoc to test flows around downloading reports.