### PR TITLE
ci: configure konflux build

### DIFF
--- a/.tekton/discovery-ui-pull-request.yaml
+++ b/.tekton/discovery-ui-pull-request.yaml
@@ -36,6 +36,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"type": "npm", "path": "."}'
+  - name: build-args-file
+    value: ".tekton/downstream-build-arguments.conf"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/discovery-ui-pull-request.yaml
+++ b/.tekton/discovery-ui-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value: '{"type": "npm", "path": "."}'
   pipelineSpec:

--- a/.tekton/discovery-ui-pull-request.yaml
+++ b/.tekton/discovery-ui-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
     value: Containerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/discovery-ui-pull-request.yaml
+++ b/.tekton/discovery-ui-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: prefetch-input
+    value: '{"type": "npm", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: prefetch-input
+    value: '{"type": "npm", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -27,6 +27,8 @@ spec:
     value: Containerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -33,6 +33,8 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"type": "npm", "path": "."}'
+  - name: build-args-file
+    value: ".tekton/downstream-build-arguments.conf"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value: '{"type": "npm", "path": "."}'
   pipelineSpec:

--- a/.tekton/downstream-build-arguments.conf
+++ b/.tekton/downstream-build-arguments.conf
@@ -1,0 +1,6 @@
+K8S_DESCRIPTION=Discovery UI
+K8S_DISPLAY_NAME=discovery-ui
+K8S_NAME=discovery/discovery-ui-rhel9
+OCP_TAGS=discovery
+QUIPUCORDS_BRANDED=true
+REDHAT_COMPONENT=discovery-ui-container

--- a/Containerfile
+++ b/Containerfile
@@ -28,3 +28,11 @@ RUN chown ${NGINX_USER} -R /licenses /opt/app-root/
 USER ${NGINX_USER}
 
 CMD ["/bin/bash", "/opt/app-root/entrypoint.sh"]
+
+LABEL com.redhat.component="discovery-ui-container" \
+    description="Discovery UI" \
+    io.k8s.description="Discovery UI" \
+    io.k8s.display-name="discovery-ui" \
+    io.openshift.tags="discovery" \
+    name="discovery/discovery-ui-rhel9" \
+    summary="Discovery UI"

--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,10 @@ RUN dnf update -y && dnf clean all
 # install dependencies in a separate layer to save dev time
 WORKDIR /app
 COPY package.json package-lock.json .
-RUN npm install --omit=dev
+RUN npm ci \
+    --no-audit \
+    --legacy-peer-deps \
+    --omit=dev
 
 COPY . .
 RUN export UI_BRAND=${QUIPUCORDS_BRANDED}; npm run build

--- a/Containerfile
+++ b/Containerfile
@@ -2,8 +2,6 @@ FROM registry.access.redhat.com/ubi9/nodejs-18 as npm_builder
 ARG QUIPUCORDS_BRANDED="false"
 # Become root before installing anything
 USER root
-RUN dnf update -y && dnf clean all
-
 # install dependencies in a separate layer to save dev time
 WORKDIR /app
 COPY package.json package-lock.json .

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,19 @@ COPY . .
 RUN npm run build
 
 FROM registry.access.redhat.com/ubi9/nginx-122
+# original NGINX user; update if the number ever change
+# https://github.com/sclorg/nginx-container/blob/e7d8db9bc5299a4c4e254f8a82e917c7c136468b/1.22/Dockerfile.rhel9#L84
+ENV NGINX_USER=1001
+# temporarily switch to root user
+USER root
+# konflux requires licenses in this folder
+RUN mkdir /licenses
+COPY --from=npm_builder /app/LICENSE /licenses/LICENSE
 COPY --from=npm_builder /app/build /opt/app-root/src
 COPY deploy/nginx.conf /etc/nginx/nginx.conf.template
 COPY deploy/entrypoint.sh /opt/app-root/.
+# set ownership to nginx user and change back to it
+RUN chown ${NGINX_USER} -R /licenses /opt/app-root/
+USER ${NGINX_USER}
+
 CMD ["/bin/bash", "/opt/app-root/entrypoint.sh"]

--- a/Containerfile
+++ b/Containerfile
@@ -14,6 +14,12 @@ COPY . .
 RUN export UI_BRAND=${QUIPUCORDS_BRANDED}; npm run build
 
 FROM registry.access.redhat.com/ubi9/nginx-122
+ARG K8S_DESCRIPTION="Quipucords UI"
+ARG K8S_DISPLAY_NAME="quipucords-ui"
+ARG K8S_NAME="quipucords/quipucords-ui"
+ARG OCP_TAGS="quipucords"
+ARG REDHAT_COMPONENT="quipucords-ui-container"
+
 # original NGINX user; update if the number ever change
 # https://github.com/sclorg/nginx-container/blob/e7d8db9bc5299a4c4e254f8a82e917c7c136468b/1.22/Dockerfile.rhel9#L84
 ENV NGINX_USER=1001
@@ -31,10 +37,10 @@ USER ${NGINX_USER}
 
 CMD ["/bin/bash", "/opt/app-root/entrypoint.sh"]
 
-LABEL com.redhat.component="discovery-ui-container" \
-    description="Discovery UI" \
-    io.k8s.description="Discovery UI" \
-    io.k8s.display-name="discovery-ui" \
-    io.openshift.tags="discovery" \
-    name="discovery/discovery-ui-rhel9" \
-    summary="Discovery UI"
+LABEL com.redhat.component=${REDHAT_COMPONENT} \
+    description=${K8S_DESCRIPTION} \
+    io.k8s.description=${K8S_DESCRIPTION} \
+    io.k8s.display-name=${K8S_DISPLAY_NAME} \
+    io.openshift.tags=${OCP_TAGS} \
+    name=${K8S_NAME} \
+    summary=${K8S_DESCRIPTION}

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/nodejs-18 as npm_builder
+ARG QUIPUCORDS_BRANDED="false"
 # Become root before installing anything
 USER root
 RUN dnf update -y && dnf clean all
@@ -9,7 +10,7 @@ COPY package.json package-lock.json .
 RUN npm install --omit=dev
 
 COPY . .
-RUN npm run build
+RUN export UI_BRAND=${QUIPUCORDS_BRANDED}; npm run build
 
 FROM registry.access.redhat.com/ubi9/nginx-122
 # original NGINX user; update if the number ever change


### PR DESCRIPTION
## What's included
konflux configuration adjusted to have all required checks passing on Red Hat Enterprise Contract.
With these changes, the same `Containerfile` can be used for upstream and downstream builds.

## How to test
make sure both konflux checks in this PR are passing.

### Check the build
~~export IMAGE=$(kubectl get component discovery-ui -o json | jq '.status.lastPromotedImage' -r)~~

```
export IMAGE="quay.io/redhat-user-workloads/discovery-tenant/discovery/discovery-ui:on-pr-$(git log --format="%H" -1)"

kubectl get secret imagerepository-for-discovery-ui-image-pull -o json | jq '.data[] | @base64d | fromjson | {auths: (.auths // .)}' > /tmp/auth.json
podman pull ${IMAGE} --authfile /tmp/auth.json 
# then run the following (assuming quipucords/discovery is running through default installer)
podman run -p 9999:9999 -e QUIPUCORDS_APP_PORT=9999 -e QUIPUCORDS_SERVER_URL:-host.containers.internal:9443 -it $IMAGE
```

## Example
<!-- Append a demo/screenshot/animated gif of the solution -->
...

## Updates issue/story

Relates to JIRA: DISCOVERY-708
[DISCOVERY-708](https://issues.redhat.com/browse/DISCOVERY-708)

