### PR TITLE
build(konflux): lock base image by digest

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-18 as npm_builder
+FROM registry.access.redhat.com/ubi9/nodejs-18@sha256:4e4fd31431dcfb7f1856a972030cd6c798e2b8a47e47e7540dd9880b3ed2698b as npm_builder
 ARG QUIPUCORDS_BRANDED="false"
 # Become root before installing anything
 USER root
@@ -13,7 +13,7 @@ RUN npm ci \
 COPY . .
 RUN export UI_BRAND=${QUIPUCORDS_BRANDED}; npm run build
 
-FROM registry.access.redhat.com/ubi9/nginx-122
+FROM registry.access.redhat.com/ubi9/nginx-124@sha256:a39459f55e5f8df68b9b58fd33cd53c8acabbbb9cd3df1a071187e071858f32f
 ARG K8S_DESCRIPTION="Quipucords UI"
 ARG K8S_DISPLAY_NAME="quipucords-ui"
 ARG K8S_NAME="quipucords/quipucords-ui"


### PR DESCRIPTION
## What's included
Lock base image by digest for reproducibility. This will also allow konflux to automatically open PRs updating the base images (through renovate/mintmaker).

Relates to JIRA: DISCOVERY-708

## How to test
Use the image built by konflux: 

```
quay.io/redhat-user-workloads/discovery-tenant/discovery/discovery-ui:on-pr-$(git log --format="%H" -1)
```


## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
[DISCOVERY-708](https://issues.redhat.com/browse/DISCOVERY-708)
