### PR TITLE
ci(konflux): make snyk results available on ui

### DIFF
--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -388,6 +388,9 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        # This customization makes snyk results available on its UI
+        value: "--project-name=Discovery/discovery-ui --report --org=3e74668d-0a76-49f9-8822-a84cec963cde"
       runAfter:
       - build-image-index
       taskRef:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:eject": "echo \"Outputing webpack config. Remember to move files and scripts into place, and manually remove the weldable package.\"; weldable --standalone",
     "build:post": "bash ./scripts/post.sh",
     "build:pre": "bash ./scripts/pre.sh",
-    "release": "changelog --link-url https://github.com/quipucords/quipucords-ui.git",
+    "release": "changelog --link-url https://github.com/quipucords/quipucords-ui.git --commit=false",
     "start": "export PROTOCOL=http; export HOST=127.0.0.1; export PORT=${PORT:-3000}; export MOCK_PORT=${MOCK_PORT:-3030}; run-p -l api:dev start:js start:open",
     "start:using-server": "export PROTOCOL=${QUIPUCORDS_SERVER_PROTOCOL:-https}; export HOST=${QUIPUCORDS_SERVER_HOST:-127.0.0.1}; export PORT=${PORT:-3000}; export MOCK_PORT=${QUIPUCORDS_SERVER_PORT:-9443}; run-p -l start:js start:open",
     "start:js": "export NODE_ENV=development; weldable -l ts -x ./config/webpack.dev.js",


### PR DESCRIPTION
## What's included
Makes snyk results on "push" pipeline to be available on our org snyk dashboard.

### Notes
This was inspired on @abellotti work on RedHatInsights/rhproxy-engine#75. One thing I chose to do differently
was to only enable this behavior on the "push" pipeline, as adding results from PRs could add too much noise
and confuse us (what would we see on snyk would be reflecting the current state of main or some change proposed in a PR?).
