### PR TITLE
ci(konflux): disable sast-coverity-check

### DIFF
--- a/.tekton/discovery-ui-pull-request.yaml
+++ b/.tekton/discovery-ui-pull-request.yaml
@@ -429,70 +429,71 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-coverity-check
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - coverity-availability-check
-      taskRef:
-        params:
-        - name: name
-          value: sast-coverity-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:e765486b666ddd2fda3faa9e1ab92e0a1178492a4fdfed162cf2baf845311595
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      - input: $(tasks.coverity-availability-check.results.STATUS)
-        operator: in
-        values:
-        - success
-    - name: coverity-availability-check
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: coverity-availability-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:8653d290298593e4db9457ab00d9160738c31c384b7615ee30626ccab6f96ed8
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+    ## TODO uncomment sast-coverity-check after KONFLUX-6806 is fixed
+    # - name: sast-coverity-check
+    #   params:
+    #   - name: image-url
+    #     value: $(tasks.build-image-index.results.IMAGE_URL)
+    #   - name: IMAGE
+    #     value: $(params.output-image)
+    #   - name: DOCKERFILE
+    #     value: $(params.dockerfile)
+    #   - name: CONTEXT
+    #     value: $(params.path-context)
+    #   - name: HERMETIC
+    #     value: $(params.hermetic)
+    #   - name: PREFETCH_INPUT
+    #     value: $(params.prefetch-input)
+    #   - name: IMAGE_EXPIRES_AFTER
+    #     value: $(params.image-expires-after)
+    #   - name: COMMIT_SHA
+    #     value: $(tasks.clone-repository.results.commit)
+    #   - name: BUILD_ARGS
+    #     value:
+    #     - $(params.build-args[*])
+    #   - name: BUILD_ARGS_FILE
+    #     value: $(params.build-args-file)
+    #   - name: SOURCE_ARTIFACT
+    #     value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    #   - name: CACHI2_ARTIFACT
+    #     value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    #   runAfter:
+    #   - coverity-availability-check
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: sast-coverity-check-oci-ta
+    #     - name: bundle
+    #       value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:e765486b666ddd2fda3faa9e1ab92e0a1178492a4fdfed162cf2baf845311595
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   when:
+    #   - input: $(params.skip-checks)
+    #     operator: in
+    #     values:
+    #     - "false"
+    #   - input: $(tasks.coverity-availability-check.results.STATUS)
+    #     operator: in
+    #     values:
+    #     - success
+    # - name: coverity-availability-check
+    #   runAfter:
+    #   - build-image-index
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: coverity-availability-check
+    #     - name: bundle
+    #       value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:8653d290298593e4db9457ab00d9160738c31c384b7615ee30626ccab6f96ed8
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   when:
+    #   - input: $(params.skip-checks)
+    #     operator: in
+    #     values:
+    #     - "false"
     - name: sast-shell-check
       params:
       - name: image-digest

--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -429,70 +429,71 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-coverity-check
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - coverity-availability-check
-      taskRef:
-        params:
-        - name: name
-          value: sast-coverity-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:e765486b666ddd2fda3faa9e1ab92e0a1178492a4fdfed162cf2baf845311595
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      - input: $(tasks.coverity-availability-check.results.STATUS)
-        operator: in
-        values:
-        - success
-    - name: coverity-availability-check
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: coverity-availability-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:8653d290298593e4db9457ab00d9160738c31c384b7615ee30626ccab6f96ed8
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+    ## TODO uncomment sast-coverity-check after KONFLUX-6806 is fixed
+    # - name: sast-coverity-check
+    #   params:
+    #   - name: image-url
+    #     value: $(tasks.build-image-index.results.IMAGE_URL)
+    #   - name: IMAGE
+    #     value: $(params.output-image)
+    #   - name: DOCKERFILE
+    #     value: $(params.dockerfile)
+    #   - name: CONTEXT
+    #     value: $(params.path-context)
+    #   - name: HERMETIC
+    #     value: $(params.hermetic)
+    #   - name: PREFETCH_INPUT
+    #     value: $(params.prefetch-input)
+    #   - name: IMAGE_EXPIRES_AFTER
+    #     value: $(params.image-expires-after)
+    #   - name: COMMIT_SHA
+    #     value: $(tasks.clone-repository.results.commit)
+    #   - name: BUILD_ARGS
+    #     value:
+    #     - $(params.build-args[*])
+    #   - name: BUILD_ARGS_FILE
+    #     value: $(params.build-args-file)
+    #   - name: SOURCE_ARTIFACT
+    #     value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    #   - name: CACHI2_ARTIFACT
+    #     value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    #   runAfter:
+    #   - coverity-availability-check
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: sast-coverity-check-oci-ta
+    #     - name: bundle
+    #       value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:e765486b666ddd2fda3faa9e1ab92e0a1178492a4fdfed162cf2baf845311595
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   when:
+    #   - input: $(params.skip-checks)
+    #     operator: in
+    #     values:
+    #     - "false"
+    #   - input: $(tasks.coverity-availability-check.results.STATUS)
+    #     operator: in
+    #     values:
+    #     - success
+    # - name: coverity-availability-check
+    #   runAfter:
+    #   - build-image-index
+    #   taskRef:
+    #     params:
+    #     - name: name
+    #       value: coverity-availability-check
+    #     - name: bundle
+    #       value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:8653d290298593e4db9457ab00d9160738c31c384b7615ee30626ccab6f96ed8
+    #     - name: kind
+    #       value: task
+    #     resolver: bundles
+    #   when:
+    #   - input: $(params.skip-checks)
+    #     operator: in
+    #     values:
+    #     - "false"
     - name: sast-shell-check
       params:
       - name: image-digest


### PR DESCRIPTION
At the moment sast-coverity-check is broken. Let's keep this task disabled until the fix is available.

Relates to JIRA: DISCOVERY-708
Relates to JIRA: KONFLUX-6806