### PR TITLE
refactor: creating a Source should not create a connect-type ScanJob

### DIFF
--- a/src/hooks/__tests__/__snapshots__/useSourceApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useSourceApi.test.ts.snap
@@ -7,11 +7,6 @@ exports[`useAddSourceApi should attempt an api call to add sources: apiCall 1`] 
     {
       "name": "Lorem",
     },
-    {
-      "params": {
-        "scan": true,
-      },
-    },
   ],
 ]
 `;

--- a/src/hooks/useSourceApi.ts
+++ b/src/hooks/useSourceApi.ts
@@ -145,7 +145,7 @@ const useAddSourceApi = (onAddAlert: (alert: AlertProps) => void) => {
 
   const apiCall = useCallback(
     (payload: SourceType): Promise<AxiosResponse<SourceType>> =>
-      axios.post(`${process.env.REACT_APP_SOURCES_SERVICE}`, payload, { params: { scan: true } }),
+      axios.post(`${process.env.REACT_APP_SOURCES_SERVICE}`, payload),
     []
   );
 


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-784

This is the UI change that corresponds with this API change: https://github.com/quipucords/quipucords/pull/2812