### PR TITLE
build: move to node 22

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - "*"
   pull_request:
-env:
-  COV_NODE_VERSION: 20
-  UPSTREAM_TAR: quipucords-ui-dist.tar
 
 jobs:
   Integration:
@@ -42,21 +39,3 @@ jobs:
         run: npm run test:ci-build
       - name: Unit tests
         run: npm run test:ci-coverage
-      - name: Compress upstream assets
-        if: ${{ success() && startsWith(matrix.node-version, env.COV_NODE_VERSION) && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          tar -cf ${UPSTREAM_TAR} build
-          gzip -f --best ${UPSTREAM_TAR}
-      - name: Release artifacts
-        uses: ncipollo/release-action@v1.13.0
-        if: ${{ success() && startsWith(matrix.node-version, env.COV_NODE_VERSION) && startsWith(github.ref, 'refs/tags/') }}
-        with:
-          artifacts: "${{ env.UPSTREAM_TAR }}.gz"
-          # set allow updates so we can create releases to trigger this
-          allowUpdates: true
-          # don't override what's set on the release
-          omitBodyDuringUpdate: true
-          omitNameDuringUpdate: true
-          omitPrereleaseDuringUpdate: true
-          # required for publishing artifacts and updating the release
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package_audit.yml
+++ b/.github/workflows/package_audit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js ${{ matrix.node-version }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-18@sha256:a2cc112367458e595ae93e01bb20501cd8c31a0e992d2331dd6474e21d05b007 as npm_builder
+FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:7917ceb14e18a6cfcc61c46cdd196da566388ab96585b277080e756d91adceed as npm_builder
 ARG QUIPUCORDS_BRANDED="false"
 # Become root before installing anything
 USER root

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Web user interface for [Quipucords](https://github.com/quipucords/quipucords), b
 
 ### Requirements
 Before developing, the basic requirements:
- * Your system needs to be running [NodeJS version 18+ and NPM](https://nodejs.org/)
+ * Your system needs to be running [NodeJS version 22+ and NPM](https://nodejs.org/)
     * Yarn install is discouraged. There are dependency install issues with Yarn `1.x.x` versions.
  * [podman desktop](https://podman-desktop.io/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "ts-jest": "^29.2.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:eject": "echo \"Outputing webpack config. Remember to move files and scripts into place, and manually remove the weldable package.\"; weldable --standalone",
     "build:post": "bash ./scripts/post.sh",
     "build:pre": "bash ./scripts/pre.sh",
-    "release": "changelog --link-url https://github.com/quipucords/quipucords-ui.git --commit=false",
+    "release": "changelog --link-url https://github.com/quipucords/quipucords-ui.git",
     "start": "export PROTOCOL=http; export HOST=127.0.0.1; export PORT=${PORT:-3000}; export MOCK_PORT=${MOCK_PORT:-3030}; run-p -l api:dev start:js start:open",
     "start:using-server": "export PROTOCOL=${QUIPUCORDS_SERVER_PROTOCOL:-https}; export HOST=${QUIPUCORDS_SERVER_HOST:-127.0.0.1}; export PORT=${PORT:-3000}; export MOCK_PORT=${QUIPUCORDS_SERVER_PORT:-9443}; run-p -l start:js start:open",
     "start:js": "export NODE_ENV=development; weldable -l ts -x ./config/webpack.dev.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/quipucords/quipucords-ui/issues"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "api:dev": "node ./scripts/apiDev.js --port $MOCK_PORT --file https://raw.githubusercontent.com/quipucords/quipucords/master/docs/swagger.yml",


### PR DESCRIPTION
Node 18 support shall end in the next 2 months. We need to migrate.
We could move to version 20, but considering 22 is also a LTS version and its EOL is set to 2027, let's try that.

## Updates issue/story
[DISCOVERY-901](https://issues.redhat.com/browse/DISCOVERY-901)
