### PR TITLE
fix(scans): dsc-891 Use "scan" in scan removal dialog

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -8,13 +8,14 @@
     "username": "Username"
   },
   "form-dialog": {
-    "confirmation_heading_delete-scan": "Are you sure you want to delete the scan <0>{{name}}</0>?",
+    "confirmation_heading_delete-scan": "Are you sure you want to delete the scan {{name}}?",
     "confirmation_heading_delete-credential": "Are you sure you want to delete the credential {{name}}?",
     "confirmation_heading_delete-credential_other": "Are you sure you want to delete the following credentials?",
     "confirmation_title_delete-credential": "Delete Credential",
     "confirmation_title_delete-credential_other": "Delete Credentials",
     "confirmation_title_delete-source": "Delete Source",
     "confirmation_title_delete-source_other": "Delete Sources",
+    "confirmation_title_delete-scan": "Delete Scan",
     "confirmation_heading_delete-source": "Are you sure you want to delete the source {{name}}?",
     "confirmation_heading_delete-source_other": "Are you sure you want to delete the following sources?",
     "label": "{{context}}",

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -319,7 +319,7 @@ const ScansListView: React.FunctionComponent = () => {
       />
       <Modal
         variant={ModalVariant.small}
-        title={t('form-dialog.confirmation', { context: 'title_delete-source' })}
+        title={t('form-dialog.confirmation', { context: 'title_delete-scan' })}
         isOpen={pendingDeleteScan !== undefined}
         onClose={() => setPendingDeleteScan(undefined)}
         actions={[
@@ -343,7 +343,7 @@ const ScansListView: React.FunctionComponent = () => {
         ]}
       >
         {t('form-dialog.confirmation_heading', {
-          context: 'delete-source',
+          context: 'delete-scan',
           name: pendingDeleteScan?.name
         })}
         {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}


### PR DESCRIPTION
Scan removal confirmation dialog should refer to "scan", not "source".

There was already a string for dialog body, but it was unused. That string contained `<0>` `</0>`, which I assume should be HTML elements to wrap scan name - but they were printed verbatim by UI. Also, neither credential nor source wraps their name in element, so there's consistency in not using it in scan.

Relates to JIRA: DISCOVERY-891