### PR TITLE
feat(about): dsc-857 show CPU architecture

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -3,6 +3,7 @@
     "browser-os": "Browser OS",
     "browser-version": "Browser Version",
     "copyright": "Copyright (c) {{year}} Red Hat Inc.",
+    "server-cpu-arch": "Server Architecture",
     "server-version": "Server Version",
     "ui-version": "UI Version",
     "username": "Username"

--- a/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.tsx.snap
+++ b/src/components/aboutModal/__tests__/__snapshots__/aboutModal.test.tsx.snap
@@ -65,6 +65,22 @@ exports[`AboutModal Component should attempt to display username, status data: u
           0.0.0.12345678
         </TextListItem>
       </React.Fragment>
+      <React.Fragment>
+        <TextListItem
+          className=""
+          component="dt"
+        >
+          t([
+  "about.server-cpu-arch"
+])
+        </TextListItem>
+        <TextListItem
+          className=""
+          component="dd"
+        >
+          i386
+        </TextListItem>
+      </React.Fragment>
     </TextList>
   </TextContent>
 </AboutModal>

--- a/src/components/aboutModal/__tests__/aboutModal.test.tsx
+++ b/src/components/aboutModal/__tests__/aboutModal.test.tsx
@@ -12,7 +12,9 @@ describe('AboutModal Component', () => {
   });
 
   it('should attempt to display username, status data', async () => {
-    const mockGetStatus = jest.fn().mockResolvedValue({ server_version: '0.0.0.12345678' });
+    const mockGetStatus = jest
+      .fn()
+      .mockResolvedValue({ server_version: '0.0.0.12345678', platform: { machine: 'i386' } });
     const mockUseStatusApi = jest.fn().mockReturnValue({ getStatus: mockGetStatus });
     const mockGetUser = jest.fn().mockResolvedValue('lorem ipsum');
     const mockUseUserApi = jest.fn().mockReturnValue({ getUser: mockGetUser });
@@ -28,10 +30,14 @@ describe('AboutModal Component', () => {
 
   it('should call onClose', async () => {
     const mockOnClose = jest.fn();
+    const mockGetStatus = jest
+      .fn()
+      .mockResolvedValue({ server_version: '0.0.0.12345678', platform: { machine: 'i386' } });
+    const mockUseStatusApi = jest.fn().mockReturnValue({ getStatus: mockGetStatus });
     const props = {
       isOpen: true,
       useUser: jest.fn().mockReturnValue({ getUser: jest.fn().mockResolvedValue('lorem ipsum') }),
-      useStatus: jest.fn().mockReturnValue({ getStatus: jest.fn().mockResolvedValue({}) }),
+      useStatus: mockUseStatusApi,
       onClose: mockOnClose
     };
 

--- a/src/components/aboutModal/aboutModal.tsx
+++ b/src/components/aboutModal/aboutModal.tsx
@@ -93,6 +93,16 @@ const AboutModal: React.FC<AboutModalProps> = ({
               </TextListItem>
             </React.Fragment>
           )}
+          {stats?.platform.machine && (
+            <React.Fragment>
+              <TextListItem className={loadingClassName} component="dt">
+                {t('about.server-cpu-arch')}
+              </TextListItem>
+              <TextListItem className={loadingClassName} component="dd">
+                {stats.platform.machine}
+              </TextListItem>
+            </React.Fragment>
+          )}
         </TextList>
       </TextContent>
     </PfAboutModal>

--- a/src/hooks/useStatusApi.ts
+++ b/src/hooks/useStatusApi.ts
@@ -2,8 +2,13 @@ import { useCallback } from 'react';
 import axios, { type AxiosError, type AxiosResponse, isAxiosError } from 'axios';
 import helpers from '../helpers';
 
+type ApiStatusPlatformType = {
+  machine: string;
+};
+
 type ApiStatusSuccessType = {
   server_version: string;
+  platform: ApiStatusPlatformType;
 };
 
 type ApiStatusErrorType = {

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -29,7 +29,7 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useSourceApi.ts:127:          console.error(error);",
   "hooks/useSourceApi.ts:191:          console.error(error);",
   "hooks/useSourceApi.ts:255:          console.error(error);",
-  "hooks/useStatusApi.ts:38:        console.error(error);",
+  "hooks/useStatusApi.ts:43:        console.error(error);",
   "views/credentials/viewCredentialsList.tsx:386:                console.error(err);",
   "views/credentials/viewCredentialsList.tsx:403:                console.error(err);",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",


### PR DESCRIPTION
Add CPU Architecture field to "About" dialog. Data is already provided by a server. I decided to use [`platform.machine()`](https://docs.python.org/3/library/platform.html#platform.machine), the alternative being [`platform.processor()`](https://docs.python.org/3/library/platform.html#platform.processor). On upstream container both provide the same value, while on my local Python running on bare metal `processor()` is empty string.

I guess technically backend container might be using different arch than frontend container, but we don't support setups like that.

Relates to JIRA: DISCOVERY-857


![Screenshot From 2025-03-24 14-31-41](https://github.com/user-attachments/assets/c9ff3074-ac23-4145-a47e-cdaea7f39df6)
