### PR TITLE
build: Use buildah for multi arch manifests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
     branches: [ main ]
 
 env:
+  # Forks that do not set secrets and override the variables may fail build steps using them.
   STABLE_TAG: ${{ github.event_name == 'push' && github.ref_name || format('pr-{0}', github.event.pull_request.number) }}
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
@@ -44,7 +45,6 @@ jobs:
             --ulimit nofile=4096:4096
 
       - name: Push amd64 To quay.io
-        # Forks that do not set secrets and override the variables may fail this step.
         id: push-image-amd64
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -80,7 +80,6 @@ jobs:
             --ulimit nofile=4096:4096
 
       - name: Push arm64 To quay.io
-        # Forks that do not set secrets and override the variables may fail this step.
         id: push-image-arm64
         uses: redhat-actions/push-to-registry@v2
         with:
@@ -100,12 +99,26 @@ jobs:
         shell: bash
         run: echo "IMAGE_TAG=${{ env.STABLE_TAG == 'main' && 'latest' || env.STABLE_TAG }}" >> "${GITHUB_ENV}"
 
+      - name: Login to Registry
+        id: login-to-registry
+        shell: bash
+        run: podman login --username "${{ secrets.QUAYIO_USERNAME }}" --password "${{ secrets.QUAYIO_PASSWORD }}" "${{ env.REGISTRY }}"
+
+      - name: Create Manifest
+        id: create-manifest
+        shell: bash
+        run:  |
+              echo "Creating manifest ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} ..."
+              buildah manifest create --all ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+                ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-amd64 \
+                ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-arm64
+
       - name: Push Manifest
         id: push-manifest
-        uses: pixelfederation/gh-action-manifest-tool@v0.1.7
+        uses: redhat-actions/push-to-registry@v2
         with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAG }}
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}
-          platforms: linux/amd64,linux/arm64
-          template: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-ARCH
-          target: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ env:
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/quipucords-ui' }}
   REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 
+
 jobs:
   build-amd64:
     runs-on: ubuntu-latest


### PR DESCRIPTION
build: preferring to use buildah to create multi-arch images.
    
- Preferring to use our own buildah github action for creating the multi-arch manifests.

