### PR TITLE
build: stop pushing `main` container tags (but continue pushing `latest`)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}
           archs: amd64
-          tags: ${{ env.STABLE_TAG }}-amd64 ${{ env.STABLE_TAG == 'main' && 'latest-amd64' || '' }}
+          tags: ${{ env.STABLE_TAG != 'main' && format('{0}-amd64', env.STABLE_TAG) || 'latest-amd64' }}
           containerfiles: |
             ./Containerfile
           labels: |
@@ -70,7 +70,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}
           archs: arm64
-          tags: ${{ env.STABLE_TAG }}-arm64 ${{ env.STABLE_TAG == 'main' && 'latest-arm64' || '' }}
+          tags: ${{ env.STABLE_TAG != 'main' && format('{0}-arm64', env.STABLE_TAG) || 'latest-arm64' }}
           containerfiles: |
             ./Containerfile
           labels: |


### PR DESCRIPTION
See also this PR for quipucords:
https://github.com/quipucords/quipucords/pull/2931

See this conversation for context:
https://redhat-internal.slack.com/archives/C02QSNF1UKE/p1746208791358419

TLDR: I discovered that we are pushing the combined manifest for `latest` but not for `main`, `latest` basically aliases the `main` tag, and nothing we know currently uses `main`. So, drop `main` and keep `latest`.