### PR TITLE
ci(konflux): adjust pipeline to support discovery release workflow

### DIFF
--- a/.tekton/discovery-ui-pull-request.yaml
+++ b/.tekton/discovery-ui-pull-request.yaml
@@ -9,7 +9,8 @@ metadata:
     # custom tasks defined in this repo https://pipelinesascode.com/docs/guide/resolver/#tasks-or-pipelines-inside-the-repository
     pipelinesascode.tekton.dev/task: '[.tekton/task/generate-version-labels.yaml]'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main, release/*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: discovery

--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -8,7 +8,8 @@ metadata:
     # custom tasks defined in this repo https://pipelinesascode.com/docs/guide/resolver/#tasks-or-pipelines-inside-the-repository
     pipelinesascode.tekton.dev/task: '[.tekton/task/generate-version-labels.yaml]'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main, refs/tags/*]"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: discovery


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-969

Worflow for tagging and opening PR against other branches was tested on yaka repo.