### PR TITLE
Add/fix ouiaId for source kebab and typeAheadCheckboxes

### DIFF
--- a/src/components/typeAheadCheckboxes/typeaheadCheckboxes.tsx
+++ b/src/components/typeAheadCheckboxes/typeaheadCheckboxes.tsx
@@ -205,7 +205,7 @@ const TypeaheadCheckboxes: React.FC<TypeaheadCheckboxesProps> = ({
                 textInputRef?.current?.focus();
               }}
               aria-label="Clear input value"
-              ouiaId="credentials_list_toggle_button"
+              ouiaId="credentials_list_clear_button"
             >
               <TimesIcon aria-hidden />
             </Button>

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -392,10 +392,11 @@ const SourcesListView: React.FunctionComponent = () => {
                   <ActionMenu<SourceType>
                     item={source}
                     actions={[
-                      { label: t('table.label', { context: 'edit' }), onClick: onEditSource },
+                      { label: t('table.label', { context: 'edit' }), onClick: onEditSource, ouiaId: 'edit-source' },
                       {
                         label: t('table.label', { context: 'delete' }),
-                        onClick: setPendingDeleteSource
+                        onClick: setPendingDeleteSource,
+                        ouiaId: 'delete-source'
                       }
                     ]}
                   />

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -34,8 +34,8 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "views/credentials/viewCredentialsList.tsx:403:                console.error(err);",
   "views/sources/addSourceModal.tsx:106:          console.error(err);",
   "views/sources/viewSourcesList.tsx:319:                console.error(err);",
-  "views/sources/viewSourcesList.tsx:484:                console.error(err);",
-  "views/sources/viewSourcesList.tsx:501:                console.error(err);",
-  "views/sources/viewSourcesList.tsx:517:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:485:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:502:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:518:                console.error(err);",
 ]
 `;


### PR DESCRIPTION
Add missing ouiaId to source kebab, to make editing sources easier.

Also fix ouiaId of typeAheadCheckboxes "clear" element.

Relates to JIRA: DISCOVERY-983