### PR TITLE
feat(viewScansList): add a tooltip identifying Scan ActionMenu

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -256,6 +256,7 @@
     "label_ansible": "Ansible",
     "label_view": "View",
     "summary": "A generated table.",
+    "tooltip_action_menu": "More options",
     "tooltip_merge-reports": "Merge selected scan results into a single report"
   },
   "toast-notifications": {

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -35,6 +35,7 @@ import {
   PageSection,
   ToolbarContent,
   ToolbarItem,
+  Tooltip,
   getUniqueId
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
@@ -244,53 +245,55 @@ const ScansListView: React.FunctionComponent = () => {
                   </Button>
                 </Td>
                 <Td isActionCell columnKey="actions">
-                  <ActionMenu<Scan>
-                    popperProps={{ position: 'right' }}
-                    item={scan}
-                    actions={[
-                      {
-                        label: t('table.label', { context: 'summary' }),
-                        disabled: !helpers.canAccessMostRecentReport(scan?.most_recent),
-                        onClick: () => {
-                          if (scan?.most_recent) {
-                            getAggregateReport(scan.most_recent.report_id)
-                              .then(setAggregateReport)
-                              .catch(err => {
-                                if (!helpers.TEST_MODE) {
-                                  console.error(err);
-                                }
-                              });
-                          }
+                  <Tooltip content={t('table.tooltip_action_menu')}>
+                    <ActionMenu<Scan>
+                      popperProps={{ position: 'right' }}
+                      item={scan}
+                      actions={[
+                        {
+                          label: t('table.label', { context: 'summary' }),
+                          disabled: !helpers.canAccessMostRecentReport(scan?.most_recent),
+                          onClick: () => {
+                            if (scan?.most_recent) {
+                              getAggregateReport(scan.most_recent.report_id)
+                                .then(setAggregateReport)
+                                .catch(err => {
+                                  if (!helpers.TEST_MODE) {
+                                    console.error(err);
+                                  }
+                                });
+                            }
+                          },
+                          ouiaId: 'summary'
                         },
-                        ouiaId: 'summary'
-                      },
-                      {
-                        label: t('table.label', { context: 'delete' }),
-                        onClick: setPendingDeleteScan,
-                        ouiaId: 'delete'
-                      },
-                      {
-                        label: t('table.label', { context: 'rescan' }),
-                        onClick: () => {
-                          runScans(scan, true).finally(() => {
-                            queryClient.invalidateQueries({ queryKey: [API_SCANS_LIST_QUERY] });
-                            setScanSelected(undefined);
-                          });
+                        {
+                          label: t('table.label', { context: 'delete' }),
+                          onClick: setPendingDeleteScan,
+                          ouiaId: 'delete'
                         },
-                        ouiaId: 'rescan'
-                      },
-                      {
-                        label: t('table.label', { context: 'download' }),
-                        disabled: !helpers.canAccessMostRecentReport(scan?.most_recent),
-                        onClick: () => {
-                          if (scan?.most_recent) {
-                            downloadReport(scan.most_recent.report_id);
-                          }
+                        {
+                          label: t('table.label', { context: 'rescan' }),
+                          onClick: () => {
+                            runScans(scan, true).finally(() => {
+                              queryClient.invalidateQueries({ queryKey: [API_SCANS_LIST_QUERY] });
+                              setScanSelected(undefined);
+                            });
+                          },
+                          ouiaId: 'rescan'
                         },
-                        ouiaId: 'download'
-                      }
-                    ]}
-                  />
+                        {
+                          label: t('table.label', { context: 'download' }),
+                          disabled: !helpers.canAccessMostRecentReport(scan?.most_recent),
+                          onClick: () => {
+                            if (scan?.most_recent) {
+                              downloadReport(scan.most_recent.report_id);
+                            }
+                          },
+                          ouiaId: 'download'
+                        }
+                      ]}
+                    />
+                  </Tooltip>
                 </Td>
               </Tr>
             ))}

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -33,7 +33,7 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "hooks/useStatusApi.ts:43:        console.error(error);",
   "views/credentials/viewCredentialsList.tsx:387:                console.error(err);",
   "views/credentials/viewCredentialsList.tsx:404:                console.error(err);",
-  "views/scans/viewScansList.tsx:260:                                  console.error(err);",
+  "views/scans/viewScansList.tsx:262:                                    console.error(err);",
   "views/sources/addSourceModal.tsx:124:          console.error(err);",
   "views/sources/viewSourcesList.tsx:319:                console.error(err);",
   "views/sources/viewSourcesList.tsx:486:                console.error(err);",


### PR DESCRIPTION
This change will help document Scan Summary modal.

<img width="1894" height="726" alt="image" src="https://github.com/user-attachments/assets/746008cb-5040-476b-8126-7822a87924c8" />


Relates to JIRA: DISCOVERY-762

## Summary by Sourcery

Add a tooltip around the scan item action menu in the scans list view and update translations and snapshots accordingly.

New Features:
- Wrap the scan ActionMenu in a Tooltip to expose a descriptive tooltip for the Scan ActionMenu

Enhancements:
- Add a new translation key for the action menu tooltip in the English locale

Tests:
- Update snapshots to reflect the new tooltip wrapper