### PR TITLE
refactor(source): switch bulk delete to use v2

### DIFF
--- a/.env
+++ b/.env
@@ -41,7 +41,7 @@ REACT_APP_SCAN_JOBS_SERVICE_CANCEL=/api/v1/jobs/{0}/cancel/
 REACT_APP_SCAN_JOBS_SERVICE_MERGE=/api/v1/jobs/merge/
 
 REACT_APP_SOURCES_SERVICE=/api/v2/sources/
-REACT_APP_SOURCES_SERVICE_BULK_DELETE=/api/v1/sources/bulk_delete/
+REACT_APP_SOURCES_SERVICE_BULK_DELETE=/api/v2/sources/bulk_delete/
 
 REACT_APP_USER_SERVICE_AUTH_TOKEN=/api/v1/token/
 REACT_APP_USER_SERVICE_CURRENT=/api/v1/users/current/

--- a/src/hooks/__tests__/__snapshots__/useSourceApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useSourceApi.test.ts.snap
@@ -56,7 +56,7 @@ exports[`useAddSourceApi should handle success while attempting to add a source:
 exports[`useDeleteSourceApi should attempt an api call to delete sources: apiCall 1`] = `
 [
   [
-    "/api/v1/sources/bulk_delete/",
+    "/api/v2/sources/bulk_delete/",
     {
       "ids": [
         456,


### PR DESCRIPTION
Replaces usage of the v1 bulk delete API with the v2 version to align with updated backend functionality. No UI behavior changes expected.

Relates to JIRA: DISCOVERY-1006

## Summary by Sourcery

Refactor the bulk delete functionality to use the v2 API and update related tests accordingly

Enhancements:
- Replace all v1 bulk delete API calls with the new v2 endpoint

Tests:
- Update useSourceApi test snapshots to reflect v2 API changes