### PR TITLE
fix(useScanApi): increase page size on scan jobs API call

### DIFF
--- a/src/hooks/__tests__/__snapshots__/useScanApi.test.ts.snap
+++ b/src/hooks/__tests__/__snapshots__/useScanApi.test.ts.snap
@@ -425,6 +425,11 @@ exports[`useGetScanJobsApi should attempt an api call to retrieve a scanJob: api
 [
   [
     "/api/v1/scans/1/jobs/",
+    {
+      "params": {
+        "page_size": 1000,
+      },
+    },
   ],
 ]
 `;

--- a/src/hooks/useScanApi.ts
+++ b/src/hooks/useScanApi.ts
@@ -262,7 +262,7 @@ const useGetScanJobsApi = (onAddAlert: (alert: AlertProps) => void) => {
 
   const apiCall = useCallback(
     (scanId: number): Promise<AxiosResponse<ScanJobsResponse>> =>
-      axios.get(`${process.env.REACT_APP_SCANS_SERVICE}${scanId}/jobs/`),
+      axios.get(`${process.env.REACT_APP_SCANS_SERVICE}${scanId}/jobs/`, { params: { page_size: 1000 } }),
     []
   );
 


### PR DESCRIPTION
Updated the API call in useGetScanJobsApi to include a page_size parameter, ensuring that a maximum of 1000 scan jobs are retrieved per request.

Relates to JIRA: DISCOVERY-818

## Summary by Sourcery

Include a page_size parameter in useGetScanJobsApi to fetch up to 1000 scan jobs per request

Enhancements:
- Add page_size=1000 query parameter to the scan jobs API call in useGetScanJobsApi

Tests:
- Add unit test to verify axios.get is called with page_size=1000 parameter