### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.1](https://github.com/quipucords/quipucords-ui/compare/acf4633d1dab7cc3a280164c9a24ccc99b6d8d2f...5438fe792547b3b486196df948e6b753b36fceba) (2025-08-06)
+
+
+### Builds
+*  bump task-source-build-oci-ta to 0.3  ([5438fe7](https://github.com/quipucords/quipucords-ui/commit/5438fe792547b3b486196df948e6b753b36fceba))
+*  Include quay builds on release branches  ([6c299c4](https://github.com/quipucords/quipucords-ui/commit/6c299c4d75caebc992cfef130f0831d4709af583))
+*  make update-lockfiles  ([55956cb](https://github.com/quipucords/quipucords-ui/commit/55956cb78db5aa4d29e4bf7ca1fde18298f21073))
+
+### Bug Fixes
+* **deps** patch various vulnerabilities  ([c4bbb1b](https://github.com/quipucords/quipucords-ui/commit/c4bbb1b278034b390dcd3319588f53e09569f21b))
+
 ## [2.0.0](https://github.com/quipucords/quipucords-ui/compare/26384921cab9bf1cdc63d939eded0fd655b315d6...69d4afe444d39a54d1b029b4efdbb9c35f8a8402) (2025-07-14)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quipucords-ui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quipucords-ui",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@mturley-latest/react-table-batteries": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quipucords-ui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Quipucords UI",
   "author": "Red Hat",
   "license": "GPL-3.0",


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-1054

## Summary by Sourcery

Prepare release 2.0.1 by bumping the package version, updating the changelog, adding build enhancements, and patching dependency vulnerabilities.

Bug Fixes:
- Patch various dependency vulnerabilities

Build:
- Bump task-source-build-oci-ta to version 0.3
- Include Quay builds on release branches
- Add lockfile updates in build process

Chores:
- Bump project version from 2.0.0 to 2.0.1