### PR TITLE
build: bump task-source-build-oci-ta to 0.3

### DIFF
--- a/.tekton/discovery-ui-pull-request.yaml
+++ b/.tekton/discovery-ui-pull-request.yaml
@@ -307,11 +307,13 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:
@@ -319,7 +321,7 @@ spec:
         - name: name
           value: source-build-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:b424894fc8e806c12658daa565b835fd2d66e7f7608afc47529eb7b410f030d7
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:bfec1fabb0ed7c191e6c85d75e6cc577a04cabe9e6b35f9476529e8e5b3c0c82
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/discovery-ui-push.yaml
+++ b/.tekton/discovery-ui-push.yaml
@@ -304,11 +304,13 @@ spec:
     - name: build-source-image
       params:
       - name: BINARY_IMAGE
-        value: $(params.output-image)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: BINARY_IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:
       - build-image-index
       taskRef:
@@ -316,7 +318,7 @@ spec:
         - name: name
           value: source-build-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2@sha256:b424894fc8e806c12658daa565b835fd2d66e7f7608afc47529eb7b410f030d7
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:bfec1fabb0ed7c191e6c85d75e6cc577a04cabe9e6b35f9476529e8e5b3c0c82
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Migration docs:
https://github.com/konflux-ci/build-definitions/blob/main/task/source-build-oci-ta/0.3/MIGRATION.md

This is 54c33152defe491cdf2d454727b37a6571edef5c (part of #653), but for `main`.

## Summary by Sourcery

Bump the task-source-build-oci-ta task to version 0.3 and pass the image digest into the build-source-image steps in the discovery-ui pipelines.

Enhancements:
- Update the source-build-oci-ta task bundle reference to version 0.3 in discovery-ui-pull-request and discovery-ui-push pipelines
- Add BINARY_IMAGE_DIGEST parameter to build-source-image tasks to consume IMAGE_DIGEST from build-image-index results