### PR TITLE
refactor: remove update-konflux-pipeline target from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ help:
 	@echo "  help                          to show this message"
 	@echo "  build-container               to build the container image for the quipucords UI"
 	@echo "  lock-baseimages               update the digests of base images on the Containerfile"
-	@echo "  update-konflux-pipeline       patch konflux pipeline with latest images"
 	@echo "  update-lockfiles       	   update all (but package-lock.json) lockfiles"
 
 all: help
@@ -47,12 +46,4 @@ lock-baseimages:
 	done; \
 	echo "$${separator}"
 
-update-konflux-pipeline:
-	@if which pipeline-patcher > /dev/null 2>&1; then \
-		pipeline-patcher bump-task-refs .; \
-	else \
-		echo "'pipeline-patcher' not found in PATH; Refer to https://github.com/simonbaird/konflux-pipeline-patcher/blob/main/README.md."; \
-		exit 1; \
-	fi
-
-update-lockfiles: lock-baseimages update-konflux-pipeline
+update-lockfiles: lock-baseimages


### PR DESCRIPTION
Recently it became clear that pipeline-patcher (which was used on update-konflux-pipeline target) was not enough to properly upgrade our tekton pipelines. It became clear that using this tool alone represents a risk, so let's remove it.

In the future we might reproduce what MintMaker does by running it locally [1] with MintMaker config [2], which relies on a tool called pipeline-migration-tool to properly handle migrations. Or maybe just on MintMaker to propose updates to our pipelines.

[1]: https://docs.renovatebot.com/modules/platform/local/
[2]: https://github.com/konflux-ci/mintmaker/blob/a3816e76f5e06ba3114731fc34fa14f76d442b6c/config/renovate/renovate.json#L70-L116