### PR TITLE
fix(sourceConnection): reset state on close

### DIFF
--- a/src/views/sources/__tests__/showSourceConnectionsModal.test.tsx
+++ b/src/views/sources/__tests__/showSourceConnectionsModal.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -59,5 +60,17 @@ describe('ShowConnectionsModal', () => {
     await user.click(screen.getByLabelText('Close'));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reset expanded state on close', async () => {
+    const user = userEvent.setup();
+    const failedName = 'Amet';
+
+    await user.click(document.querySelector('button[id^=failed]')!);
+    expect(screen.getByText(failedName)).toBeVisible();
+    await user.click(screen.getByLabelText('Close'));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(failedName)).not.toBeVisible();
   });
 });

--- a/src/views/sources/showSourceConnectionsModal.tsx
+++ b/src/views/sources/showSourceConnectionsModal.tsx
@@ -42,9 +42,19 @@ const ShowConnectionsModal: React.FC<ShowConnectionsModalProps> = ({
       variant={ModalVariant.small}
       title={source?.name}
       isOpen={isOpen}
-      onClose={() => onClose()}
+      onClose={() => {
+        setExpanded([]);
+        return onClose();
+      }}
       actions={[
-        <Button key="cancel" variant="secondary" onClick={() => onClose()}>
+        <Button
+          key="cancel"
+          variant="secondary"
+          onClick={() => {
+            setExpanded([]);
+            return onClose();
+          }}
+        >
           Close
         </Button>
       ]}


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-820

## Summary by Sourcery

Reset the expanded state of the ShowConnectionsModal when it is closed and verify this behavior with a new test.

Bug Fixes:
- Clear the expanded sections state when the modal is closed either via the onClose handler or the Close button

Tests:
- Add a test to ensure the expanded state is reset and the onClose callback is invoked on modal close