### PR TITLE
Add select all/none checkbox functionality to scans table

### DIFF
--- a/src/views/scans/useScansQuery.ts
+++ b/src/views/scans/useScansQuery.ts
@@ -13,7 +13,7 @@ import { type TableState } from '../../vendor/react-table-batteries';
 
 export const SCANS_LIST_QUERY = 'scansList';
 
-type ScansColumnKey = 'name' | 'most_recent' | 'sources' | 'actions';
+type ScansColumnKey = 'selection' | 'name' | 'most_recent' | 'sources' | 'actions';
 
 type ScansSortableColumnKey = 'name' | 'most_recent';
 

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -36,7 +36,7 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "vendor/react-table-batteries/hooks/storage/useStorage.ts:40:    console.error(error);",
   "views/credentials/viewCredentialsList.tsx:406:                console.error(err);",
   "views/credentials/viewCredentialsList.tsx:423:                console.error(err);",
-  "views/scans/viewScansList.tsx:285:                                    console.error(err);",
+  "views/scans/viewScansList.tsx:302:                                    console.error(err);",
   "views/sources/addSourceModal.tsx:138:          console.error(err);",
   "views/sources/viewSourcesList.tsx:338:                console.error(err);",
   "views/sources/viewSourcesList.tsx:514:                console.error(err);",


### PR DESCRIPTION
Implements bulk selection controls for the scans list view, allowing users to select/deselect all currently visible scans without clicking individual checkboxes. This addresses the acceptance criteria for improving UX when managing many scans.

## Changes Made
Added ToolbarBulkSelector: Provides bulk selection dropdown in toolbar with select all/none/page actions
Integrated TrWithBatteries: Automatic checkbox rendering and selection handling for table rows
Enhanced selection logic: Support for both array and object-based selection states
Conditional rendering: ToolbarBulkSelector only appears when there are items to select (!isLoading && currentPageItems.length > 0)

## Technical Details
Leverages react-table-batteries library for consistent table interaction patterns
Selection state managed through useTableState and useTablePropHelpers
Removed manual checkbox implementation in favor of automated handling
Delete button state properly reflects selection status

## Summary by Sourcery

Implement bulk select/none functionality in the scans list by integrating react-table-batteries selection helpers, updating the table to include a selection column, and ensuring the delete button and toolbar behave correctly based on selection state.

New Features:
- Add bulk selection controls in the scans toolbar to allow select/deselect all currently visible scans

Enhancements:
- Replace manual checkbox handling with react-table-batteries helpers (useToolbarBulkSelectorWithBatteries and useTrWithBatteries)
- Show bulk selector only when scans are loaded and available
- Update delete button state to reflect enhanced selection logic for array- or object-based selection

Tests:
- Add unit tests and update snapshots for the updated scans list view