### PR TITLE
fix(showAggregateReportModal): give labels more horizontal space

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -35,3 +35,8 @@ body,
 .pf-v6-theme-dark .pf-v6-c-about-modal-box {
   filter: invert(1.5) contrast(1.2);
 }
+
+/* Summary report table - give labels a bit more space to prevent line wrapping */
+body .pf-v6-c-description-list.pf-m-fluid {
+  --pf-v6-c-description-list--m-horizontal__term--width: fit-content(30ch);
+}


### PR DESCRIPTION
Override CSS variable to 30ch from PatternFly default 20ch. This gives labels more horizontal space and prevents wrapping.

PatternFly 5 did not change any of these variables, yet somehow it didn't wrap by default...

It **does** change PatternFly defaults, which is frowned upon, but I feel it is justified in this case.

| Before  | After |
| ------------- | ------------- |
| <img width="604" height="810" alt="Screenshot From 2025-08-27 17-29-50" src="https://github.com/user-attachments/assets/73155e7d-8582-4e37-8a60-43320e730166" /> | <img width="604" height="810" alt="Screenshot From 2025-08-27 17-30-15" src="https://github.com/user-attachments/assets/ddc0e30f-54cb-4ece-acd7-d835b0c9ded6" /> |


Relates to JIRA: DISCOVERY-1083

## Summary by Sourcery

Bug Fixes:
- Prevent label wrapping in showAggregateReportModal by increasing description list term width to 30ch via CSS override