### PR TITLE
fix(viewScansList): Refresh scan list when closing modal

### DIFF
--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -84,6 +84,16 @@ const ScansListView: React.FunctionComponent = () => {
   };
 
   /**
+   * Closes the scans view by resetting selected scans and clearing related data.
+   * Ensures consistent state of list by forcing a refresh.
+   */
+  const scansModalOnClose = () => {
+    setScanSelected(undefined);
+    setScanJobs(undefined);
+    onRefresh();
+  };
+
+  /**
    * Configures table state for scan results, with URL persistence. Includes columns for name, last scanned,
    * sources, and actions. Enables name-based filtering, sorting by ID or last scanned, pagination, and row selection.
    * Utilizes `useTableState` for setup.
@@ -344,19 +354,9 @@ const ScansListView: React.FunctionComponent = () => {
         scanJobs={scanJobs}
         isOpen={scanSelected !== undefined}
         onDownload={downloadReport}
-        onClose={() => {
-          setScanSelected(undefined);
-          setScanJobs(undefined);
-        }}
+        onClose={scansModalOnClose}
         actions={[
-          <Button
-            key="close"
-            variant="secondary"
-            onClick={() => {
-              setScanSelected(undefined); // Close the modal when this is clicked
-              setScanJobs(undefined);
-            }}
-          >
+          <Button key="close" variant="secondary" onClick={scansModalOnClose}>
             {t('table.label', { context: 'close' })}
           </Button>
         ]}

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -107,10 +107,12 @@ const SourcesListView: React.FunctionComponent = () => {
 
   /**
    * Closes the connections view by resetting selected connections and clearing connection data.
+   * Ensures consistent state of list by forcing a refresh.
    */
   const onCloseConnections = () => {
     setConnectionsSelected(undefined);
     setConnectionsData(emptyConnectionData);
+    onRefresh();
   };
 
   /**

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -36,11 +36,11 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "vendor/react-table-batteries/hooks/storage/useStorage.ts:40:    console.error(error);",
   "views/credentials/viewCredentialsList.tsx:391:                console.error(err);",
   "views/credentials/viewCredentialsList.tsx:408:                console.error(err);",
-  "views/scans/viewScansList.tsx:275:                                    console.error(err);",
+  "views/scans/viewScansList.tsx:285:                                    console.error(err);",
   "views/sources/addSourceModal.tsx:138:          console.error(err);",
-  "views/sources/viewSourcesList.tsx:319:                console.error(err);",
-  "views/sources/viewSourcesList.tsx:494:                console.error(err);",
-  "views/sources/viewSourcesList.tsx:511:                console.error(err);",
-  "views/sources/viewSourcesList.tsx:527:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:321:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:496:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:513:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:529:                console.error(err);",
 ]
 `;


### PR DESCRIPTION
This ensures that if scan finished at the time modal was opened, it will show as finished on list shortly after closing a modal.

Apply the same fix to Sources "Last connection" modal, which also might be opened after scan finished running.

Relates to JIRA: DISCOVERY-827

## Summary by Sourcery

Refresh scan and source lists after closing their respective modals to ensure recent status changes are immediately reflected.

Enhancements:
- Invoke onRefresh when closing the scan details modal to update the scans list
- Invoke onRefresh when closing the sources connection modal to update the sources list

Tests:
- Update snapshot tests to account for new modal close handlers