### PR TITLE
fix(react-table-batteries): reset page table on sort or filter change

### DIFF
--- a/src/vendor/VENDORED_CHANGES.md
+++ b/src/vendor/VENDORED_CHANGES.md
@@ -19,3 +19,6 @@ This directory contains vendored code from external packages that are no longer 
 
 - **Ported isShiftKeyHeld from State to Ref** - See PR #676
   - File: `hooks/selection/useSelectionPropHelpers.ts`
+
+- **Reset table page back to 1 on sort or filter change** - See PR #678
+  - File: `src/vendor/react-table-batteries/hooks/useTableState.ts`

--- a/src/vendor/react-table-batteries/hooks/useTableState.ts
+++ b/src/vendor/react-table-batteries/hooks/useTableState.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { TableState, UseTableStateArgs } from '../types';
 import { mergeArgs } from '../utils';
 import { useActiveItemState } from './active-item';
@@ -28,6 +29,8 @@ export const useTableState = <
 >(
   args: UseTableStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>
 ): TableState<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix> => {
+  const lastFilterAndSort = useRef<string>('');
+
   const state = {
     filter: useFilterState<TItem, TFilterCategoryKey, TPersistenceKeyPrefix>(args),
     sort: useSortState<TItem, TSortableColumnKey, TPersistenceKeyPrefix>(args),
@@ -41,6 +44,15 @@ export const useTableState = <
     sort: { activeSort },
     pagination: { pageNumber, itemsPerPage }
   } = state;
+
+  const currentFilterAndSort = JSON.stringify({ filterValues, activeSort });
+  const requiresPageReset = lastFilterAndSort.current !== currentFilterAndSort;
+
+  if (pageNumber > 1 && requiresPageReset) {
+    state.pagination.setPageNumber(1);
+  }
+
   const cacheKey = JSON.stringify({ filterValues, activeSort, pageNumber, itemsPerPage });
+  lastFilterAndSort.current = currentFilterAndSort;
   return { ...mergeArgs(args, state), cacheKey };
 };


### PR DESCRIPTION
Changing filters (using toolbar on top) or sorting order (using table headers) will reset table page back to page 1.

`useTableState` hook is not a perfect place to put it, but it's about the only place I found that is aware of both filter and pagination. The alternative seems to be to teach filter about pagination (so filter change can request pagination changes), but that makes components intertwined.

Another alternative is to use hook in our codebase, without modifying vendored code. I explored that in [`dsc-830-hook`](https://github.com/quipucords/quipucords-ui/tree/dsc-830-hook) branch. I was about to submit it when I realized that page resetting happens **after** filtering/sorting, and that results in two requests being sent in quick succession - first for sort and filter state and current page, and then again, but this time for first page. We can't really guarantee that server will respond to requests in that exact order, and I don't know what React would do when responses come out of order, so I decided to change the approach.

Relates to JIRA: DISCOVERY-830
Assisted-by: claude-4-sonnet (in Cursor)

## Summary by Sourcery

Bug Fixes:
- Reset table page to 1 on filter or sort changes in useTableState hook