### PR TITLE
test: Make `t` function stable

### DIFF
--- a/config/jest.setupTests.js
+++ b/config/jest.setupTests.js
@@ -23,9 +23,12 @@ jest.mock('i18next', () => {
 /**
  * Emulate for translation hook for snapshots
  */
+const stableT = (...args) => `t(${JSON.stringify(args, null, 2)})`;
 jest.mock('react-i18next', () => ({
   ...jest.requireActual('react-i18next'),
-  useTranslation: () => ({ t: (...args) => `t(${JSON.stringify(args, null, 2)})` })
+  useTranslation: () => ({
+    t: stableT
+  })
 }));
 
 /**

--- a/src/components/login/login.tsx
+++ b/src/components/login/login.tsx
@@ -34,12 +34,12 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
     setIsLoggedIn(isAuthorized);
   }, [isAuthorized]);
 
-  const onChangeUsername = (event: React.FormEvent<HTMLInputElement>, value: string) => {
+  const onChangeUsername = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setIsValidUsername(value !== '');
     setUsername(value);
   };
 
-  const onChangePassword = (event: React.FormEvent<HTMLInputElement>, value: string) => {
+  const onChangePassword = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setIsValidPassword(value !== '');
     setPassword(value);
   };
@@ -71,7 +71,7 @@ const Login: React.FC<LoginProps> = ({ children, useGetSetAuth = useGetSetAuthAp
           });
       }
     },
-    [isLoading, login]
+    [isLoading, login, t]
   );
 
   if (isLoggedIn) {


### PR DESCRIPTION
This allows tests to pass when useEffect is using `t` as dependency. It will be required for DISCOVERY-1050, currently in [dsc-1050 branch](https://github.com/quipucords/quipucords-ui/tree/dsc-1050).

Also, add `t` dependency in one place it is used, to fix the lint warning.

Relates to JIRA: DISCOVERY-1100

## Summary by Sourcery

Stabilize the translation function in tests and update component dependencies to ensure stable behavior and satisfy lint rules

Bug Fixes:
- Include missing `t` dependency in login component's useEffect to fix lint warning

Enhancements:
- Stabilize the `t` function in test mocks to prevent unnecessary re-renders

Tests:
- Update jest.setupTests.js to mock react-i18next with a shared stable translation function

Chores:
- Prefix unused event parameters with underscore in login handlers