### PR TITLE
Properly isolate unit tests

### DIFF
--- a/src/components/i18n/__test__/i18n.test.tsx
+++ b/src/components/i18n/__test__/i18n.test.tsx
@@ -13,7 +13,7 @@ describe('I18n', () => {
   });
 
   it('should attempt to update locale', async () => {
-    const spyI18next = jest.spyOn(i18next, 'changeLanguage');
+    const spyI18next = jest.spyOn(i18next, 'changeLanguage').mockResolvedValue(jest.fn() as any);
     const props = {
       children: 'Lorem ipsum',
       locale: 'dolor-Sit'
@@ -21,6 +21,6 @@ describe('I18n', () => {
 
     await shallowComponent(<I18n {...props} />);
     expect(spyI18next.mock.calls).toMatchSnapshot('locale');
-    spyI18next.mockClear();
+    spyI18next.mockRestore();
   });
 });

--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -242,8 +242,8 @@ describe('downloadData', () => {
     mockCreateElement.click = mockElementClick;
     jest.spyOn(document, 'createElement').mockImplementation(() => mockCreateElement);
 
-    const appendChild = jest.spyOn(document.body, 'appendChild');
-    const removeChild = jest.spyOn(document.body, 'removeChild');
+    const appendChild = jest.spyOn(document.body, 'appendChild').mockImplementation(x => x);
+    const removeChild = jest.spyOn(document.body, 'removeChild').mockImplementation(x => x);
     const createObjectURLMock = jest.fn();
     const revokeObjectURLMock = jest.fn();
     window.URL.createObjectURL = createObjectURLMock;
@@ -255,5 +255,7 @@ describe('downloadData', () => {
     expect(removeChild).toHaveBeenCalledTimes(1);
     expect(mockElementClick).toHaveBeenCalledTimes(1);
     expect(revokeObjectURLMock).toHaveBeenCalledWith(expect.any(String));
+
+    jest.restoreAllMocks();
   });
 });

--- a/src/hooks/__tests__/useCredentialApi.test.ts
+++ b/src/hooks/__tests__/useCredentialApi.test.ts
@@ -18,12 +18,12 @@ describe('useDeleteCredentialApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to delete credentials', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'post');
+    const spyAxios = jest.spyOn(axios, 'post').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall([456, 789]);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -160,12 +160,12 @@ describe('useAddCredentialApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to add credentials', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'post');
+    const spyAxios = jest.spyOn(axios, 'post').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall({ name: 'Lorem' });
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -227,12 +227,12 @@ describe('useEditCredentialApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to edit credentials', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'patch');
+    const spyAxios = jest.spyOn(axios, 'patch').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall({ id: 123, name: 'Lorem' }).catch(Function.prototype);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -292,12 +292,12 @@ describe('useGetCredentialsApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to retrieve credentials', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'get');
+    const spyAxios = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall().catch(Function.prototype);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');

--- a/src/hooks/__tests__/useLoginApi.test.ts
+++ b/src/hooks/__tests__/useLoginApi.test.ts
@@ -9,18 +9,18 @@ describe('useLoginApi', () => {
   let hookResult;
 
   beforeEach(() => {
-    spyCookies = jest.spyOn(cookies, 'set');
+    spyCookies = jest.spyOn(cookies, 'set').mockReturnValue('123');
     const hook = renderHook(() => useLoginApi());
     hookResult = hook?.result?.current;
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to login', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'post');
+    const spyAxios = jest.spyOn(axios, 'post').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall({ username: 'lorem', password: '123456' });
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -70,18 +70,18 @@ describe('useLogoutApi', () => {
   let hookResult;
 
   beforeEach(() => {
-    spyCookies = jest.spyOn(cookies, 'remove');
+    spyCookies = jest.spyOn(cookies, 'remove').mockReturnValue('123');
     const hook = renderHook(() => useLogoutApi());
     hookResult = hook?.result?.current;
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to logout', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'put');
+    const spyAxios = jest.spyOn(axios, 'put').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall().catch(Function.prototype);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -132,12 +132,12 @@ describe('useUserApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to get a user', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'get');
+    const spyAxios = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall();
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -199,7 +199,7 @@ describe('useGetSetAuthApi', () => {
 
   it('should attempt a call to get a token', () => {
     const { getToken } = hookResult;
-    const spyCookie = jest.spyOn(cookies, 'get');
+    const spyCookie = jest.spyOn(cookies, 'get').mockImplementationOnce(() => Promise.resolve({}));
 
     getToken();
     expect(spyCookie.mock.calls).toMatchSnapshot('getToken');
@@ -222,7 +222,7 @@ describe('useGetSetAuthApi', () => {
   it('should process an interceptor response success', async () => {
     const { interceptorResponseSuccess } = hookResult;
 
-    await expect(interceptorResponseSuccess()).toMatchSnapshot('interceptorResponseSuccess');
+    expect(interceptorResponseSuccess()).toMatchSnapshot('interceptorResponseSuccess');
   });
 
   it('should process interceptor request errors', async () => {

--- a/src/hooks/__tests__/useScanApi.test.ts
+++ b/src/hooks/__tests__/useScanApi.test.ts
@@ -19,12 +19,12 @@ describe('useShowConnectionsApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to show connections', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'get');
+    const spyAxios = jest.spyOn(axios, 'get').mockResolvedValueOnce({});
 
     apiCall({ id: 123, connection: { id: 456 } });
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -89,12 +89,12 @@ describe('useDeleteScanApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to delete scans', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'post');
+    const spyAxios = jest.spyOn(axios, 'post').mockResolvedValueOnce({});
 
     apiCall([456, 789]).catch(Function.prototype);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -203,12 +203,12 @@ describe('useCreateScanApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to create a scan', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'post');
+    const spyAxios = jest.spyOn(axios, 'post').mockResolvedValueOnce({});
 
     apiCall({ name: 'Lorem' });
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -271,12 +271,12 @@ describe('useGetScanJobsApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to retrieve a scanJob', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'get');
+    const spyAxios = jest.spyOn(axios, 'get').mockResolvedValueOnce({});
 
     apiCall(1);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -346,12 +346,12 @@ describe('useRunScanApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an API call to run a scan', async () => {
     const { apiCall } = hookResult;
-    const spyAxiosRun = jest.spyOn(axios, 'post');
+    const spyAxiosRun = jest.spyOn(axios, 'post').mockResolvedValueOnce({});
 
     await apiCall(123);
     expect(spyAxiosRun.mock.calls).toMatchSnapshot('apiCall');
@@ -425,12 +425,12 @@ describe('useGetAggregateReportApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to show an aggregate report summary', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'get');
+    const spyAxios = jest.spyOn(axios, 'get').mockResolvedValueOnce({});
 
     apiCall(123);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -510,13 +510,13 @@ describe('useDownloadReportApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
     jest.useRealTimers();
   });
 
   it('should attempt an API call to download a report', async () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'get');
+    const spyAxios = jest.spyOn(axios, 'get').mockResolvedValueOnce({});
 
     await apiCall(123);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');

--- a/src/hooks/__tests__/useSourceApi.test.ts
+++ b/src/hooks/__tests__/useSourceApi.test.ts
@@ -13,12 +13,12 @@ describe('useDeleteSourceApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to delete sources', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'post');
+    const spyAxios = jest.spyOn(axios, 'post').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall([456, 789]);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -155,12 +155,12 @@ describe('useAddSourceApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to add sources', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'post');
+    const spyAxios = jest.spyOn(axios, 'post').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall({ name: 'Lorem' });
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');
@@ -198,12 +198,12 @@ describe('useEditSourceApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to edit sources', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'put');
+    const spyAxios = jest.spyOn(axios, 'put').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall({ id: 123, name: 'Lorem' }).catch(Function.prototype);
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');

--- a/src/hooks/__tests__/useStatusApi.test.ts
+++ b/src/hooks/__tests__/useStatusApi.test.ts
@@ -11,12 +11,12 @@ describe('useStatusApi', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should attempt an api call to get a status', () => {
     const { apiCall } = hookResult;
-    const spyAxios = jest.spyOn(axios, 'get');
+    const spyAxios = jest.spyOn(axios, 'get').mockImplementationOnce(() => Promise.resolve({}));
 
     apiCall();
     expect(spyAxios.mock.calls).toMatchSnapshot('apiCall');

--- a/src/views/credentials/__tests__/addCredentialModal.test.tsx
+++ b/src/views/credentials/__tests__/addCredentialModal.test.tsx
@@ -28,7 +28,7 @@ describe('AddCredentialModal', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should render a basic component', async () => {
@@ -63,7 +63,7 @@ describe('useCredentialForm', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should work without formData', async () => {

--- a/src/views/sources/__tests__/addSourceModal.test.tsx
+++ b/src/views/sources/__tests__/addSourceModal.test.tsx
@@ -28,7 +28,7 @@ describe('AddSourceModal-network', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should render a basic component', async () => {
@@ -84,7 +84,7 @@ describe('AddSourceModal-openshift', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   const renderModal = async () => {
@@ -154,7 +154,7 @@ describe('AddSourceModalWithProxy', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should update proxy_url and submit it', async () => {
@@ -180,7 +180,7 @@ describe('useSourceForm', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   it('should initialize formData correctly', async () => {
@@ -264,6 +264,14 @@ describe('useSourceForm', () => {
 });
 
 describe('SourceForm', () => {
+  beforeEach(async () => {
+    jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({}));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should render a basic component', async () => {
     const component = await shallowComponent(<SourceForm />);
     expect(component).toMatchSnapshot('basic');


### PR DESCRIPTION
One commit per area. Commit messages are copy-pasted so they can be understood in isolation.

- prefer `mockRestore()` over `mockClear()`. `mockClear()` only clears internal mock data, while keeping mock in place. Since we spy on global objects, we ended up putting spies on top of other spies.
- make sure that every spy calls `mockResolvedValue`, `mockRejectedValue` or `mockImplementation`, which ensures that spied function is never called.

See also internal docs PR 97.

Relates to JIRA: DISCOVERY-1101

## Summary by Sourcery

Restore and isolate unit tests by using jest.restoreAllMocks and providing explicit mock implementations for spies

Tests:
- Replace jest.clearAllMocks() with jest.restoreAllMocks() across tests to fully restore spied methods between tests
- Add explicit mockResolvedValue, mockRejectedValue, mockImplementation, or mockReturnValue for jest.spyOn() calls on axios, cookies, document APIs, and i18next to prevent real implementations from running