### PR TITLE
test(sources): isolate form validation tests

### DIFF
--- a/src/views/sources/__tests__/addSourceModal.test.tsx
+++ b/src/views/sources/__tests__/addSourceModal.test.tsx
@@ -447,6 +447,14 @@ describe('SourceForm', () => {
 });
 
 describe('Form Validation', () => {
+  beforeEach(async () => {
+    jest.spyOn(axios, 'get').mockImplementation(() => Promise.resolve({}));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should validate required fields and show canSubmit correctly', async () => {
     const { result } = renderHook(() => useSourceForm({ sourceType: 'network' }));
 


### PR DESCRIPTION
`useSourceForm` contains effect that is called for each change in `typeValue` (which represents the source type). That effects makes API request. TypeValue is set (= changed) when `useSourceForm` is first called. Consequently, form validation tests made stray network requests, which showed as errors in test output (note that tests were still passing - but there was a message claiming there was an error).

Mock out axios get requests to properly isolate the tests and hide the error message.

## Summary by Sourcery

Isolate form validation tests by mocking axios GET requests to prevent unintended network calls and suppress error messages

Tests:
- Mock axios.get in beforeEach of the Form Validation suite to return a resolved promise
- Restore all Jest mocks after each test to clean up mocking