### PR TITLE
fix(build): Make Containerfile recognize feature flag

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:bc98821fd474e197d6a935964a0de14b7cd69ddcf67f7580a7b4c42e00fc0851 as npm_builder
 ARG QUIPUCORDS_BRANDED="false"
+ARG REACT_APP_FEATURE_MERGE_BUTTON="true"
 # Become root before installing anything
 USER root
 # install dependencies in a separate layer to save dev time


### PR DESCRIPTION
Tell Containerfile to recognize `REACT_APP_FEATURE_MERGE_BUTTON` feature flag as a build arg.

Relates to JIRA: DISCOVERY-1050

## Summary by Sourcery

Build:
- Add REACT_APP_FEATURE_MERGE_BUTTON as an ARG in the Containerfile