### PR TITLE
remove normalizeTotal modulus

### DIFF
--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -214,15 +214,6 @@ describe('normalizeCommaSeparated', () => {
   });
 });
 
-describe('normalizeTotal', () => {
-  it('should normalize total values', () => {
-    expect(helpers.normalizeTotal({ count: 142 }, true, undefined)).toBe(42);
-    expect(helpers.normalizeTotal({}, true, undefined)).toBe(0);
-    expect(helpers.normalizeTotal({ count: 142 }, false, undefined)).toBe(142);
-    expect(helpers.normalizeTotal({ count: 142 }, true, 50)).toBe(42);
-  });
-});
-
 describe('downloadData', () => {
   it('downloads data as a file', async () => {
     const data = 'Test data';

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -119,28 +119,6 @@ const normalizeCommaSeparated = (data?: string) =>
     ?.split(',')
     ?.filter(Boolean);
 
-/**
- * Normalizes a total count to a non-negative number less than a given modulus,
- * optionally based on development mode.
- *
- * @param {object} data - The data object containing a count property.
- * @param {number} [data.count] - The count to be normalized.
- * @param {boolean} [devMode] - Flag to normalize count based on development mode.
- * @param {number} [modulus] - The modulus to use for normalization. Defaults to 100.
- * @returns {number} - The normalized total count.
- */
-const normalizeTotal = (
-  data: { count?: number; [key: string]: unknown } | undefined,
-  devMode: boolean = DEV_MODE,
-  modulus: number = 100
-) => {
-  let totalResults: number = data?.count || 0;
-  if (devMode) {
-    totalResults = Math.abs(totalResults) % modulus;
-  }
-  return totalResults;
-};
-
 enum authType {
   UsernameAndPassword = 'Username and Password',
   Token = 'Token',
@@ -264,7 +242,6 @@ const helpers = {
   getTitleImg,
   formatDate,
   normalizeCommaSeparated,
-  normalizeTotal,
   DEV_MODE,
   PROD_MODE,
   TEST_MODE,

--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -292,7 +292,7 @@ const CredentialsListView: React.FunctionComponent = () => {
     idProperty: 'id',
     isLoading,
     currentPageItems: data?.results || [],
-    totalItemCount: helpers.normalizeTotal(data)
+    totalItemCount: data?.count || 0
   });
 
   const {

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -153,7 +153,7 @@ const ScansListView: React.FunctionComponent = () => {
     idProperty: 'id',
     isLoading,
     currentPageItems: data?.results || [],
-    totalItemCount: helpers.normalizeTotal(data)
+    totalItemCount: data?.count || 0
   });
 
   const {

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -343,7 +343,7 @@ const SourcesListView: React.FunctionComponent = () => {
     idProperty: 'id',
     isLoading,
     currentPageItems: data?.results || [],
-    totalItemCount: helpers.normalizeTotal(data)
+    totalItemCount: data?.count || 0
   });
 
   const {


### PR DESCRIPTION
# Fix: Make normalizeTotal modulus optional

## Problem
Created 105 credentials to test source view pagination, but couldn't navigate to page 2 in credentials view to see all my test data. The `normalizeTotal` function was applying `count % 100` in development mode (105 → 5 total items), breaking pagination across all views.

## Solution
Removed the normalizeTotal helper function entirely and replaced all usages with direct data?.count || 0 access. This eliminates unnecessary complexity and fixes pagination issues in development mode by ensuring actual count values are always used.

## Changes
Remove normalizeTotal function and its tests from helpers.ts
Replace helpers.normalizeTotal(data) with data?.count || 0 in:
src/views/credentials/viewCredentialsList.tsx
src/views/scans/viewScansList.tsx
src/views/sources/viewSourcesList.tsx
Remove normalizeTotal from helpers module exports