### PR TITLE
Pagination typehead

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -130,7 +130,12 @@
     "title_add-source_step_three": "Confirm",
     "title_create-credential": "Add credential",
     "title_create-credential_edit": "View credential",
-    "title_create-scan": "Scan"
+    "title_create-scan": "Scan",
+    "label_typeahead-no-results": "No results found for \"{{searchTerm}}\"",
+    "label_typeahead-search-hint": "Type to search for more credentials...",
+    "label_typeahead-clear": "Clear input value",
+    "label_typeahead-items-selected": "{{count}} items selected",
+    "label_typeahead-placeholder": "0 items selected"
   },
   "login": {
     "description": "Welcome! This inspection and reporting tool is designed to identify and report environment data, or facts, such as the number of physical and virtual systems on a network, their operating systems, and other configuration data.",

--- a/src/components/typeAheadCheckboxes/__tests__/__snapshots__/typeaheadCheckboxes.test.tsx.snap
+++ b/src/components/typeAheadCheckboxes/__tests__/__snapshots__/typeaheadCheckboxes.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TypeaheadCheckboxes should render a basic component: basic 1`] = `
 <Select
-  id="multi-typeahead-checkbox-select"
+  id="multi-typeahead-checkbox-select-with-search"
   isOpen={false}
   onOpenChange={[Function]}
   onSelect={[Function]}
@@ -11,18 +11,7 @@ exports[`TypeaheadCheckboxes should render a basic component: basic 1`] = `
   toggle={[Function]}
 >
   <SelectList
-    id="select-multi-typeahead-checkbox-listbox"
-  >
-    <SelectOption
-      hasCheckbox={true}
-      id="select-multi-typeahead-ipsum"
-      isFocused={false}
-      isSelected={false}
-      label="Lorem"
-      value="ipsum"
-    >
-      Lorem
-    </SelectOption>
-  </SelectList>
+    id="select-multi-typeahead-checkbox-listbox-with-search"
+  />
 </Select>
 `;

--- a/src/components/typeAheadCheckboxes/__tests__/typeaheadCheckboxes.test.tsx
+++ b/src/components/typeAheadCheckboxes/__tests__/typeaheadCheckboxes.test.tsx
@@ -4,10 +4,74 @@ import userEvent from '@testing-library/user-event';
 import { shallowComponent } from '../../../../config/jest.setupTests';
 import { TypeaheadCheckboxes } from '../typeaheadCheckboxes';
 
+const mockGetCredentials = jest.fn();
+jest.mock('../../../hooks/useCredentialApi', () => ({
+  useGetCredentialsApi: () => ({
+    getCredentials: mockGetCredentials
+  })
+}));
+
+jest.mock('../../../helpers', () => ({
+  helpers: {
+    TEST_MODE: true
+  }
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      // Mock that handles context-based translations
+      if (key === 'form-dialog.label' && options?.context) {
+        switch (options.context) {
+          case 'typeahead-no-results':
+            return `No results found for "${options.searchTerm}"`;
+          case 'typeahead-items-selected':
+            return `${options.count} items selected`;
+          case 'typeahead-placeholder':
+            return '0 items selected';
+          case 'typeahead-search-hint':
+            return 'Type to search for more credentials...';
+          case 'typeahead-clear':
+            return 'Clear input value';
+          default:
+            return `${key}_${options.context}`;
+        }
+      }
+      return key;
+    }
+  })
+}));
+
+const mockCredentials = [
+  { id: 1, name: 'Alpha', cred_type: 'network' } as any,
+  { id: 2, name: 'Beta', cred_type: 'network' } as any,
+  { id: 3, name: 'Gamma', cred_type: 'network' } as any
+];
+
+const mockApiResponse = {
+  data: {
+    results: mockCredentials,
+    next: null,
+    previous: null,
+    count: 3
+  }
+};
+
 describe('TypeaheadCheckboxes', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockGetCredentials.mockResolvedValue(mockApiResponse);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should render a basic component', async () => {
     const props = {
-      options: [{ value: 'ipsum', label: 'Lorem' }]
+      credentialType: 'network',
+      selectedOptions: [],
+      onChange: jest.fn()
     };
     const component = await shallowComponent(<TypeaheadCheckboxes {...props} />);
     expect(component).toMatchSnapshot('basic');
@@ -17,12 +81,10 @@ describe('TypeaheadCheckboxes', () => {
     const mockOnChange = jest.fn();
     render(
       <TypeaheadCheckboxes
-        options={[
-          { value: 'alpha', label: 'Alpha' },
-          { value: 'beta', label: 'Beta' }
-        ]}
-        selectedOptions={['alpha', 'beta']}
+        credentialType="network"
+        selectedOptions={['1', '2']}
         onChange={mockOnChange}
+        initialSelectedCredentials={mockCredentials.slice(0, 2)}
       />
     );
 
@@ -32,87 +94,273 @@ describe('TypeaheadCheckboxes', () => {
     expect(mockOnChange).toHaveBeenCalledWith([]);
   });
 
-  it('should filter options, select one, and close dropdown when maxSelections is 1', async () => {
+  it('should select option and close dropdown when maxSelections is 1', async () => {
     const onChange = jest.fn();
 
-    render(
-      <TypeaheadCheckboxes
-        options={[
-          { value: 'alpha', label: 'Alpha' },
-          { value: 'beta', label: 'Beta' }
-        ]}
-        selectedOptions={[]}
-        onChange={onChange}
-        maxSelections={1}
-      />
-    );
+    render(<TypeaheadCheckboxes credentialType="network" selectedOptions={[]} onChange={onChange} maxSelections={1} />);
 
     const input = screen.getByRole('combobox');
-    await userEvent.type(input, 'alp');
+    await userEvent.click(input);
 
-    const alphaOption = await screen.findByText('Alpha');
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+    });
+
+    const alphaOption = screen.getByText('Alpha');
     await userEvent.click(alphaOption);
 
-    expect(onChange).toHaveBeenCalledWith(['alpha']);
+    expect(onChange).toHaveBeenCalledWith(['1']);
 
     // Wait for the menu to disappear
     await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
   });
 
-  it('should filter options, select multiple, and call onChange twice (controlled)', async () => {
-    const user = userEvent.setup();
-    const options = [
-      { value: 'alpha', label: 'Alpha' },
-      { value: 'beta', label: 'Beta' },
-      { value: 'gamma', label: 'Gamma' }
-    ];
+  it('should select multiple options and call onChange (controlled)', async () => {
+    const mockOnChange = jest.fn();
 
-    /**
-     *
-     */
-    const Wrapper = () => {
-      const [selected, setSelected] = React.useState<string[]>([]);
-      return (
-        <TypeaheadCheckboxes options={options} selectedOptions={selected} onChange={setSelected} maxSelections={2} />
-      );
-    };
-
-    render(<Wrapper />);
-
-    const input = screen.getByRole('combobox');
-    await user.type(input, 'a');
-
-    const alphaOption = await screen.findByText('Alpha');
-    await user.click(alphaOption);
-
-    // Re-open the dropdown before selecting 'Beta'
-    await user.click(input);
-    await user.clear(input);
-    await user.type(input, 'bet');
-    const betaOption = await screen.findByText('Beta');
-    await user.click(betaOption);
-
-    // Now both should be selected
-    expect(screen.getByPlaceholderText('2 items selected')).toBeInTheDocument();
-
-    // Ensure the dropdown closes when maxSelections is reached
-    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
-  });
-
-  it('shows "No results found" when filter yields no matches', async () => {
     render(
       <TypeaheadCheckboxes
-        options={[
-          { value: 'alpha', label: 'Alpha' },
-          { value: 'beta', label: 'Beta' }
-        ]}
+        credentialType="network"
         selectedOptions={[]}
+        onChange={mockOnChange}
+        maxSelections={3}
+        initialSelectedCredentials={mockCredentials}
       />
     );
 
     const input = screen.getByRole('combobox');
-    await userEvent.type(input, 'zzz');
+    await userEvent.click(input);
 
-    expect(screen.getByText(/No results found/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+    });
+
+    const alphaOption = screen.getByText('Alpha');
+    await userEvent.click(alphaOption);
+
+    // Verify first selection was called
+    expect(mockOnChange).toHaveBeenCalledWith(['1']);
+  });
+
+  it('should show "No results found" when search yields no matches', async () => {
+    render(<TypeaheadCheckboxes credentialType="network" selectedOptions={[]} onChange={jest.fn()} />);
+
+    // Mock empty response for search after component is rendered
+    mockGetCredentials.mockResolvedValue({
+      data: { results: [], next: null, count: 0 }
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+
+    await waitFor(() => {
+      // Check that the menu is open and empty (no results)
+      const menu = screen.getByRole('menu');
+      expect(menu).toBeInTheDocument();
+      expect(menu).toBeEmptyDOMElement();
+    });
+  });
+
+  it('should update placeholder based on selection count', async () => {
+    const { rerender } = render(
+      <TypeaheadCheckboxes
+        credentialType="network"
+        selectedOptions={[]}
+        onChange={jest.fn()}
+        placeholder="Select credentials"
+      />
+    );
+
+    expect(screen.getByPlaceholderText('Select credentials')).toBeInTheDocument();
+
+    rerender(
+      <TypeaheadCheckboxes
+        credentialType="network"
+        selectedOptions={['1', '2']}
+        onChange={jest.fn()}
+        placeholder="Select credentials"
+        initialSelectedCredentials={mockCredentials.slice(0, 2)}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('2 items selected')).toBeInTheDocument();
+  });
+
+  describe('Pagination features', () => {
+    it('should show pagination hint when hasMorePages is true and no search term', async () => {
+      const mockApiResponseWithPagination = {
+        data: {
+          results: mockCredentials,
+          next: 'http://example.com/api/credentials/?page=2',
+          previous: null,
+          count: 150
+        }
+      };
+      mockGetCredentials.mockResolvedValue(mockApiResponseWithPagination);
+
+      render(<TypeaheadCheckboxes credentialType="network" selectedOptions={[]} onChange={jest.fn()} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Type to search for more credentials...')).toBeInTheDocument();
+      });
+    });
+
+    it('should send page_size parameter in API calls', async () => {
+      render(<TypeaheadCheckboxes credentialType="network" selectedOptions={[]} onChange={jest.fn()} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      await waitFor(() => {
+        expect(mockGetCredentials).toHaveBeenCalledWith({
+          params: {
+            cred_type: 'network',
+            page_size: 100
+          }
+        });
+      });
+    });
+
+    it('should perform server-side search when hasMorePages is true', async () => {
+      const mockApiResponseWithPagination = {
+        data: {
+          results: mockCredentials,
+          next: 'http://example.com/api/credentials/?page=2',
+          previous: null,
+          count: 150
+        }
+      };
+      mockGetCredentials.mockResolvedValue(mockApiResponseWithPagination);
+
+      render(<TypeaheadCheckboxes credentialType="network" selectedOptions={[]} onChange={jest.fn()} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+      });
+
+      await userEvent.clear(input);
+      await userEvent.type(input, 'test');
+
+      await waitFor(() => {
+        expect(mockGetCredentials).toHaveBeenCalledWith({
+          params: {
+            cred_type: 'network',
+            page_size: 100,
+            search_by_name: 'test'
+          }
+        });
+      });
+    });
+
+    it('should perform local filtering when no more pages available', async () => {
+      const mockApiResponseComplete = {
+        data: {
+          results: mockCredentials,
+          next: null,
+          previous: null,
+          count: 3
+        }
+      };
+      mockGetCredentials.mockResolvedValue(mockApiResponseComplete);
+
+      render(<TypeaheadCheckboxes credentialType="network" selectedOptions={[]} onChange={jest.fn()} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+      });
+
+      mockGetCredentials.mockClear();
+
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Alpha');
+
+      await waitFor(() => {
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+        expect(screen.queryByText('Gamma')).not.toBeInTheDocument();
+      });
+
+      expect(mockGetCredentials).not.toHaveBeenCalled();
+    });
+
+    it('should switch from server-side to local filtering when all data becomes available', async () => {
+      const mockApiResponseWithPagination = {
+        data: {
+          results: mockCredentials.slice(0, 2),
+          next: 'http://example.com/api/credentials/?page=2',
+          previous: null,
+          count: 150
+        }
+      };
+
+      const mockApiResponseComplete = {
+        data: {
+          results: mockCredentials,
+          next: null,
+          previous: null,
+          count: 3
+        }
+      };
+
+      mockGetCredentials
+        .mockResolvedValueOnce(mockApiResponseWithPagination)
+        .mockResolvedValueOnce(mockApiResponseWithPagination)
+        .mockResolvedValueOnce(mockApiResponseComplete);
+
+      render(<TypeaheadCheckboxes credentialType="network" selectedOptions={[]} onChange={jest.fn()} />);
+
+      const input = screen.getByRole('combobox');
+      await userEvent.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+      });
+
+      await userEvent.clear(input);
+      await userEvent.type(input, 'test');
+
+      await waitFor(() => {
+        expect(mockGetCredentials).toHaveBeenCalledWith({
+          params: {
+            cred_type: 'network',
+            page_size: 100,
+            search_by_name: 'test'
+          }
+        });
+      });
+
+      await userEvent.clear(input);
+      await userEvent.type(input, 'complete');
+
+      await waitFor(() => {
+        expect(mockGetCredentials).toHaveBeenCalledWith({
+          params: {
+            cred_type: 'network',
+            page_size: 100,
+            search_by_name: 'complete'
+          }
+        });
+      });
+
+      // Now test local filtering - no more API calls should be made
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Alpha');
+
+      await waitFor(() => {
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+      });
+
+      // Verify no additional API calls were made during local filtering
+      expect(mockGetCredentials).toHaveBeenCalledTimes(3); // Initial + 2 searches
+    });
   });
 });

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -26,6 +26,12 @@ export type CredentialType = {
   has_auth_token?: boolean;
 };
 
+export interface CredentialOption {
+  value: string;
+  label: string;
+  credential: CredentialType;
+}
+
 export type SourceConnectionType = {
   end_time: string;
   id: number;

--- a/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
@@ -96,10 +96,11 @@ exports[`SourceForm should not render proxy_url field for network sources: proxy
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      credentialType="network"
+      initialSelectedCredentials={[]}
       maxSelections={Infinity}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
-      options={[]}
       selectedOptions={[]}
     />
     <ErrorFragment
@@ -213,10 +214,10 @@ exports[`SourceForm should render a basic component: basic 1`] = `
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      initialSelectedCredentials={[]}
       maxSelections={1}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
-      options={[]}
       selectedOptions={[]}
     />
     <HelperText>
@@ -395,10 +396,11 @@ exports[`SourceForm should render proxy_url field for non-network sources: proxy
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      credentialType="ansible"
+      initialSelectedCredentials={[]}
       maxSelections={1}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
-      options={[]}
       selectedOptions={[]}
     />
     <HelperText>
@@ -577,10 +579,11 @@ exports[`SourceForm should render proxy_url field for non-network sources: proxy
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      credentialType="openshift"
+      initialSelectedCredentials={[]}
       maxSelections={1}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
-      options={[]}
       selectedOptions={[]}
     />
     <HelperText>
@@ -759,10 +762,11 @@ exports[`SourceForm should render proxy_url field for non-network sources: proxy
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      credentialType="rhacs"
+      initialSelectedCredentials={[]}
       maxSelections={1}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
-      options={[]}
       selectedOptions={[]}
     />
     <HelperText>
@@ -941,10 +945,11 @@ exports[`SourceForm should render proxy_url field for non-network sources: proxy
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      credentialType="satellite"
+      initialSelectedCredentials={[]}
       maxSelections={1}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
-      options={[]}
       selectedOptions={[]}
     />
     <HelperText>
@@ -1123,10 +1128,11 @@ exports[`SourceForm should render proxy_url field for non-network sources: proxy
     label="Credentials"
   >
     <TypeaheadCheckboxes
+      credentialType="vcenter"
+      initialSelectedCredentials={[]}
       maxSelections={1}
       menuToggleOuiaId="add_credentials_select"
       onChange={[Function]}
-      options={[]}
       selectedOptions={[]}
     />
     <HelperText>

--- a/src/views/sources/__tests__/addSourceModal.test.tsx
+++ b/src/views/sources/__tests__/addSourceModal.test.tsx
@@ -67,6 +67,7 @@ describe('AddSourceModal-network', () => {
         sourceType="network"
         onSubmit={mockOnSubmit}
         useForm={() => ({
+          initialSelectedCredentials: [],
           formData: {
             name: 'Test SSH',
             hosts: '192.168.1.1',
@@ -79,7 +80,6 @@ describe('AddSourceModal-network', () => {
           },
           isNetwork: true,
           isOpenshift: false,
-          credOptions: [{ value: '1', label: 'Test Credential 1' }],
           errors: {},
           touchedFields: new Set(),
           canSubmit: true,
@@ -168,6 +168,7 @@ describe('AddSourceModal-openshift', () => {
         sourceType="openshift"
         onSubmit={mockOnSubmit}
         useForm={() => ({
+          initialSelectedCredentials: [],
           formData: {
             name: 'Test HTTP',
             hosts: '192.168.1.1',
@@ -180,7 +181,6 @@ describe('AddSourceModal-openshift', () => {
           },
           isNetwork: false,
           isOpenshift: true,
-          credOptions: [{ value: '1', label: 'Test Credential 1' }],
           errors: {},
           touchedFields: new Set(),
           canSubmit: true,
@@ -221,6 +221,7 @@ describe('AddSourceModal-openshift', () => {
         sourceType="openshift"
         onSubmit={mockOnSubmit}
         useForm={() => ({
+          initialSelectedCredentials: [],
           formData: {
             name: 'Disable SSL',
             hosts: '192.168.1.1',
@@ -233,7 +234,6 @@ describe('AddSourceModal-openshift', () => {
           },
           isNetwork: false,
           isOpenshift: true,
-          credOptions: [{ value: '1', label: 'Test Credential 1' }],
           errors: {},
           touchedFields: new Set(),
           canSubmit: true,

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`General code checks should only have specific console.[warn|log|info|error] methods: console methods 1`] = `
 [
   "components/aboutModal/aboutModal.tsx:45:        error => console.error(\`About status error: \${error} \`)",
+  "components/typeAheadCheckboxes/typeaheadCheckboxes.tsx:153:            console.error('Error searching credentials:', error);",
   "helpers/queryHelpers.ts:75:        console.log(\`Query: \`, query);",
   "helpers/queryHelpers.ts:80:        console.error('Error during data fetching:', error);",
   "hooks/useCredentialApi.ts:81:          console.log(missingCredsMsg);",
@@ -36,7 +37,6 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "vendor/react-table-batteries/hooks/storage/useStorage.ts:14:    console.error(error);",
   "vendor/react-table-batteries/hooks/storage/useStorage.ts:40:    console.error(error);",
   "views/scans/viewScansList.tsx:325:                                    console.error(err);",
-  "views/sources/addSourceModal.tsx:289:          console.error(err);",
   "views/sources/viewSourcesList.tsx:452:                console.error(err);",
   "views/sources/viewSourcesList.tsx:649:                console.error(err);",
 ]


### PR DESCRIPTION
- Add TypeaheadCheckboxesWithSearch component with server-side filtering
- Implement debounced search (300ms) to prevent excessive API requests
- Add pagination support with hasMorePages detection
- Maintain selected credential state across search operations
- Add useGetCredentialsWithSearchApi hook for server-side search API calls
- Replace local filtering with server-side search_by_name parameter
- Support credential cache to handle selected items across pages
- Update Add Source modal to use new search-enabled typeahead component

Resolves issue where UI could only filter locally-known credentials,
making it impossible to select from large credential sets (>100 items)
when credentials span multiple pages.

Screencasts:
[Screencast from 2025-09-22 00-18-49.webm](https://github.com/user-attachments/assets/87bff55b-f187-4c8d-b5cc-61652f8a5800)

[Screencast from 2025-09-22 00-17-42.webm](https://github.com/user-attachments/assets/919ad873-640b-4d67-ae14-681f4409ac81)

## Summary by Sourcery

Enable scalable credential selection by adding a multi-select typeahead component with server-side search, debounced calls, pagination, and selection caching, and integrate it into the Add Source modal.

New Features:
- Introduce TypeaheadCheckboxesWithSearch component with server-side search, debounced requests, pagination support, and selection persistence
- Add useGetCredentialsWithSearchApi hook for fetching credentials via server-side search

Enhancements:
- Replace local credential filtering with server-side search_by_name parameter and maintain a credentials cache across pages
- Integrate new search-enabled typeahead into Add Source modal and load initial selected credentials in edit mode

Tests:
- Add unit tests and snapshots for useGetCredentialsWithSearchApi hook
- Add comprehensive tests for TypeaheadCheckboxesWithSearch covering search, pagination, selection, and placeholder behaviors
- Update Add Source modal tests to reflect the new initialSelectedCredentials prop