### PR TITLE
view(toolbar): Switch icon on top

### DIFF
--- a/src/components/viewLayout/viewLayoutToolbar.tsx
+++ b/src/components/viewLayout/viewLayoutToolbar.tsx
@@ -19,7 +19,7 @@ import {
   ToolbarGroup,
   ToolbarItem
 } from '@patternfly/react-core';
-import { EllipsisVIcon, MoonIcon, QuestionCircleIcon, SunIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon, MoonIcon, InfoCircleIcon, SunIcon } from '@patternfly/react-icons';
 import { useLogoutApi, useUserApi } from '../../hooks/useLoginApi';
 import '@patternfly/react-styles/css/components/Avatar/avatar.css';
 import avatarImage from '../../images/imgAvatar.svg';
@@ -137,7 +137,7 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ useLogout = useLogoutApi, useUs
                       isExpanded={helpOpen}
                       ouiaId="help_menu_toggle"
                     >
-                      <QuestionCircleIcon />
+                      <InfoCircleIcon />
                     </MenuToggle>
                   )}
                 >


### PR DESCRIPTION
The change is requested in DISCOVERY-1098 , but let's decouple it from overview page, which will take longer to merge.

Relates to JIRA: DISCOVERY-1098

<img width="346" height="70" alt="Screenshot From 2025-09-18 14-02-53" src="https://github.com/user-attachments/assets/cce7fbad-4b71-4be5-9af8-086c25188130" />
