### PR TITLE
view(toolbar): Draw a border around icon on top

### DIFF
--- a/src/components/viewLayout/viewLayoutToolbar.css
+++ b/src/components/viewLayout/viewLayoutToolbar.css
@@ -1,0 +1,3 @@
+button[data-ouia-component-id="help_menu_toggle"] [class$=menu-toggle__controls] {
+  display: none;
+}

--- a/src/components/viewLayout/viewLayoutToolbar.tsx
+++ b/src/components/viewLayout/viewLayoutToolbar.tsx
@@ -24,6 +24,7 @@ import { useLogoutApi, useUserApi } from '../../hooks/useLoginApi';
 import '@patternfly/react-styles/css/components/Avatar/avatar.css';
 import avatarImage from '../../images/imgAvatar.svg';
 import AboutModal from '../aboutModal/aboutModal';
+import './viewLayoutToolbar.css';
 
 interface AppToolbarProps {
   useLogout?: typeof useLogoutApi;
@@ -132,7 +133,6 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ useLogout = useLogoutApi, useUs
                     <MenuToggle
                       aria-label="Toggle"
                       ref={toggleRef}
-                      variant="plain"
                       onClick={() => setHelpOpen(prev => !prev)}
                       isExpanded={helpOpen}
                       ouiaId="help_menu_toggle"


### PR DESCRIPTION
A follow-up to #706 - I missed that mockup was not only about changing the icon, but also about drawing a border around it. It should look more like dropdown with username right next to it.

Unfortunately, it is not possible to do without custom CSS. Patternfly will display arrow pointing down icon for all variants of dropdown except "plain". So our options are to keep "plain" variant and add borders through CSS, ot to switch to some other variant and use CSS to hide arrow icon.

<img width="377" height="64" alt="Screenshot From 2025-09-26 12-12-22" src="https://github.com/user-attachments/assets/50fe088e-676f-4b4f-92cb-e34056e5bd69" />

Relates to JIRA: DISCOVERY-1098

## Summary by Sourcery

Enhancements:
- Style the help menu toggle with a border and hide the dropdown arrow via custom CSS