### PR TITLE
fix(TypeaheadCheckboxes): don't show "check" twice

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -40,3 +40,10 @@ body,
 body .pf-v6-c-description-list.pf-m-fluid {
   --pf-v6-c-description-list--m-horizontal__term--width: fit-content(30ch);
 }
+
+/* TypeaheadCheckboxes - don't show "check" icon on the right, as we already have a standard checkbox
+ * on the left. Work around a PatternFly 6 bug. */
+.pf-v6-c-menu__item:has(input[type=checkbox]):is(:hover, :focus, .pf-m-selected) .pf-v6-c-menu__item-select-icon,
+.pf-v6-c-menu__item:has(input[type=checkbox]):is(:hover, :focus, .pf-m-selected) .pf-v6-c-menu__item-external-icon {
+  opacity: 0;
+}


### PR DESCRIPTION
PatternFly Menu and Select share some code. Menu items can be selected - a "check" icon will be displayed on the right end of the item. Select items may contain `<input type=checkbox>` to express the same idea.

In PatternFly 6, there seems to be a regression - Select items with `hasCheckbox={true}` **also** display a "check" icon on the right, but only on hover.

You can see that issue on PatternFly website: https://www.patternfly.org/components/menus/select/#multiple-typeahead-with-checkboxes - select few items and then move pointer up and down, to hover some. Note how icon on the right appears and disappears.

That was not a case on PatternFly 5: https://v5-archive.patternfly.org/components/menus/select/#multiple-typeahead-with-checkboxes

This PR works around the issue locally by overriding the default styles, so icon on right is never displayed if there's already an `<input>` element.

## Before
<img width="579" height="361" alt="Screenshot From 2025-10-07 14-27-34" src="https://github.com/user-attachments/assets/c697178d-7557-49f0-a6af-7a3e733a3aab" />


## After
<img width="579" height="361" alt="Screenshot From 2025-10-07 14-27-55" src="https://github.com/user-attachments/assets/dd001cc2-9699-470d-9de8-7832d08749c4" />

## Summary by Sourcery

Work around a PatternFly 6 regression by overriding CSS to prevent the default check icon from appearing on the right side of typeahead select items that already include a checkbox

Bug Fixes:
- Hide the duplicate "check" icon on menu items with checkboxes in typeahead selects to prevent it from showing twice

Enhancements:
- Add CSS overrides to hide the default check icon on hover, focus, and selected states for items containing input checkboxes