### PR TITLE
fix(lint): updating src/views/scans/viewScansList.tsx

### DIFF
--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -396,7 +396,9 @@ const ScansListView: React.FunctionComponent = () => {
         <List isPlain isBordered>
           {scanSelectedForSources?.sources
             .sort((a, b) => a.name.localeCompare(b.name))
-            .map(s => <ListItem key={s.id}>{s.name}</ListItem>)}
+            .map(s => (
+              <ListItem key={s.id}>{s.name}</ListItem>
+            ))}
         </List>
       </Modal>
       <ShowScansModal


### PR DESCRIPTION
- updating src/views/scans/viewScansList.tsx to keep npm run test:lint happy

## Summary by Sourcery

Chores:
- Wrap JSX in parentheses in the map callback for listing scan sources to satisfy linting rules.