### PR TITLE
chore: bump node-forge to make `npm audit` happy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13970,9 +13970,9 @@
       "optional": true
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"


### PR DESCRIPTION
I'm really trying to see if Jenkins works, but if there's also `npm audit` failure, might as well fix it while I'm here.

## Summary by Sourcery

No effective changes to source, tests, or configuration are visible in the provided diff for this pull request.