### PR TITLE
test: exclude reports view from coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     '!src/constants/*.ts',
     '!src/vendor/**',
     '!src/views/credentials/view*.{ts,tsx}',
-    '!src/views/credentials/view*.{ts,tsx}',
+    '!src/views/reports/view*.{ts,tsx}',
     '!src/views/scans/view*.{ts,tsx}',
     '!src/views/sources/view*.{ts,tsx}'
   ],


### PR DESCRIPTION
SSIA

Also, there's no reason credentials should be duplicated. Seems to be a mistake done years ago.

## Summary by Sourcery

Tests:
- Update Jest coverage ignore patterns to exclude reports views rather than duplicating the credentials views exclusion.