### PR TITLE
feat(creds): add vault_secret_key field to Vault auth

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package.json
+tsconfig.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "avoid",
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 120
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,7 @@ const globals = require('globals');
  */
 
 module.exports = defineConfig([
-  globalIgnores(['**/package.json', '**/package-lock.json', 'src/vendor/**']),
+  globalIgnores(['**/package.json', '**/package-lock.json', 'src/vendor/**', 'tsconfig.json']),
   commentLengthPlugin.configs['flat/recommended'],
   jsxA11YPlugin.flatConfigs.recommended,
   typescriptPlugin.configs.recommended,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -315,6 +315,10 @@
           "label": "Username",
           "placeholder": "Enter username"
         },
+        "vault_secret_key": {
+          "label": "Secret key",
+          "placeholder": "e.g. auth_token"
+        },
         "vault_secret_path": {
           "label": "Secret path",
           "placeholder": "e.g. ocp/prod/kv"

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -24,6 +24,7 @@ export type CredentialRequest = CredentialBase & {
   auth_token?: string;
   ssh_passphrase?: string;
   become_password?: string;
+  vault_secret_key?: string;
   vault_secret_path?: string;
   vault_mount_point?: string;
   id?: number;
@@ -43,6 +44,7 @@ export type CredentialResponse = CredentialBase & {
   has_ssh_passphrase?: boolean;
   has_become_password?: boolean;
   has_auth_token?: boolean;
+  vault_secret_key?: string | null;
   vault_secret_path?: string | null;
   vault_mount_point?: string | null;
 };

--- a/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
+++ b/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
@@ -2517,6 +2517,7 @@ exports[`useCredentialForm should allow editing a credential: formData, edit 1`]
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
+  "vault_secret_key": "",
   "vault_mount_point": "",
   "vault_secret_path": "",
 }
@@ -2550,6 +2551,7 @@ exports[`useCredentialForm should initialize formData correctly: formData 1`] = 
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
+  "vault_secret_key": "",
   "vault_mount_point": "",
   "vault_secret_path": "",
 }
@@ -2566,6 +2568,7 @@ exports[`useCredentialForm should support implausible case of credential without
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
+  "vault_secret_key": "",
   "vault_mount_point": "",
   "vault_secret_path": "",
 }
@@ -2583,6 +2586,7 @@ exports[`useCredentialForm should work without formData: emptyFormData 1`] = `
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
+  "vault_secret_key": "",
   "vault_mount_point": "",
   "vault_secret_path": "",
 }

--- a/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
+++ b/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
@@ -2270,6 +2270,27 @@ exports[`CredentialForm should render specific to authType for type openshift: o
   </FormGroup>
   <React.Fragment>
     <FormGroup
+      fieldId="vault_mount_point"
+      label="t([
+  "view.credentials.add-modal.vault_mount_point.label"
+])"
+    >
+      <TextInput
+        id="credential-vault-mount-point"
+        name="vault_mount_point"
+        onChange={[Function]}
+        ouiaId="vault_mount_point"
+        placeholder="t([
+  "view.credentials.add-modal.vault_mount_point.placeholder"
+])"
+        type="text"
+        validated="default"
+      />
+      <ErrorFragment
+        fieldTouched={false}
+      />
+    </FormGroup>
+    <FormGroup
       fieldId="vault_secret_path"
       isRequired={true}
       label="t([
@@ -2293,18 +2314,20 @@ exports[`CredentialForm should render specific to authType for type openshift: o
       />
     </FormGroup>
     <FormGroup
-      fieldId="vault_mount_point"
+      fieldId="vault_secret_key"
+      isRequired={true}
       label="t([
-  "view.credentials.add-modal.vault_mount_point.label"
+  "view.credentials.add-modal.vault_secret_key.label"
 ])"
     >
       <TextInput
-        id="credential-vault-mount-point"
-        name="vault_mount_point"
+        id="credential-vault-key"
+        isRequired={true}
+        name="vault_secret_key"
         onChange={[Function]}
-        ouiaId="vault_mount_point"
+        ouiaId="vault_secret_key"
         placeholder="t([
-  "view.credentials.add-modal.vault_mount_point.placeholder"
+  "view.credentials.add-modal.vault_secret_key.placeholder"
 ])"
         type="text"
         validated="default"
@@ -2517,8 +2540,8 @@ exports[`useCredentialForm should allow editing a credential: formData, edit 1`]
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
-  "vault_secret_key": "",
   "vault_mount_point": "",
+  "vault_secret_key": "",
   "vault_secret_path": "",
 }
 `;
@@ -2551,8 +2574,8 @@ exports[`useCredentialForm should initialize formData correctly: formData 1`] = 
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
-  "vault_secret_key": "",
   "vault_mount_point": "",
+  "vault_secret_key": "",
   "vault_secret_path": "",
 }
 `;
@@ -2568,8 +2591,8 @@ exports[`useCredentialForm should support implausible case of credential without
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
-  "vault_secret_key": "",
   "vault_mount_point": "",
+  "vault_secret_key": "",
   "vault_secret_path": "",
 }
 `;
@@ -2586,8 +2609,8 @@ exports[`useCredentialForm should work without formData: emptyFormData 1`] = `
   "ssh_key": "",
   "ssh_passphrase": "",
   "username": "",
-  "vault_secret_key": "",
   "vault_mount_point": "",
+  "vault_secret_key": "",
   "vault_secret_path": "",
 }
 `;

--- a/src/views/credentials/__tests__/addCredentialModal.test.tsx
+++ b/src/views/credentials/__tests__/addCredentialModal.test.tsx
@@ -1084,6 +1084,7 @@ describe('getCleanedFormData', () => {
   it('should clean formData for Vault secret path auth', () => {
     const fd = {
       name: 'vault-cred',
+      vault_secret_key: 'auth_token',
       vault_secret_path: 'ocp/prod',
       vault_mount_point: '',
       auth_token: 'should-clear',
@@ -1093,6 +1094,7 @@ describe('getCleanedFormData', () => {
     };
     const cleanedData = getCleanedFormData(fd, helpers.authType.VaultSecretPath);
     expect(cleanedData).toEqual({
+      vault_secret_key: 'auth_token',
       name: 'vault-cred',
       vault_secret_path: 'ocp/prod'
     });
@@ -1101,6 +1103,7 @@ describe('getCleanedFormData', () => {
   it('should keep vault mount point when set', () => {
     const fd = {
       name: 'vault-cred',
+      vault_secret_key: 'auth_token',
       vault_secret_path: 'path',
       vault_mount_point: 'custom-mount',
       auth_token: 'x'
@@ -1108,6 +1111,7 @@ describe('getCleanedFormData', () => {
     const cleanedData = getCleanedFormData(fd, helpers.authType.VaultSecretPath);
     expect(cleanedData).toEqual({
       name: 'vault-cred',
+      vault_secret_key: 'auth_token',
       vault_secret_path: 'path',
       vault_mount_point: 'custom-mount'
     });

--- a/src/views/credentials/addCredentialModal.tsx
+++ b/src/views/credentials/addCredentialModal.tsx
@@ -77,6 +77,7 @@ const getCleanedFormData = (
     case 'Token':
       cleanedData.password = '';
       cleanedData.username = '';
+      cleanedData.vault_secret_key = '';
       cleanedData.vault_secret_path = '';
       cleanedData.vault_mount_point = '';
       break;
@@ -84,11 +85,13 @@ const getCleanedFormData = (
       cleanedData.auth_token = '';
       cleanedData.ssh_key = '';
       cleanedData.ssh_passphrase = '';
+      cleanedData.vault_secret_key = '';
       cleanedData.vault_secret_path = '';
       cleanedData.vault_mount_point = '';
       break;
     case 'SSH Key':
       cleanedData.password = '';
+      cleanedData.vault_secret_key = '';
       cleanedData.vault_secret_path = '';
       cleanedData.vault_mount_point = '';
       break;
@@ -113,6 +116,7 @@ const getCleanedFormData = (
   deleteKeysIfEmptyOrUndefined(cleanedData, maskedKeysEmpty);
 
   if (authType !== helpers.authType.VaultSecretPath) {
+    delete cleanedData.vault_secret_key;
     delete cleanedData.vault_secret_path;
     delete cleanedData.vault_mount_point;
   }
@@ -155,6 +159,7 @@ const useCredentialForm = ({
     auth_token: '',
     become_method: '',
     username: '',
+    vault_secret_key: '',
     vault_secret_path: '',
     vault_mount_point: ''
   };
@@ -185,6 +190,7 @@ const useCredentialForm = ({
         name: !!credential?.name,
         become_user: !!credential?.become_user,
         become_method: !!credential?.become_method,
+        vault_secret_key: !!(credential?.vault_secret_key && String(credential.vault_secret_key).trim()),
         vault_secret_path: !!(credential?.vault_secret_path && String(credential.vault_secret_path).trim()),
         vault_mount_point: !!(credential?.vault_mount_point && String(credential.vault_mount_point).trim())
       };
@@ -204,7 +210,7 @@ const useCredentialForm = ({
       case 'SSH Key':
         return [...baseFields, 'username', 'ssh_key'];
       case helpers.authType.VaultSecretPath:
-        return [...baseFields, 'vault_secret_path'];
+        return [...baseFields, 'vault_secret_path', 'vault_secret_key'];
       default:
         return baseFields;
     }
@@ -265,6 +271,7 @@ const useCredentialForm = ({
         auth_token: '',
         become_method: credential?.become_method || '',
         username: credential?.username || '',
+        vault_secret_key: credential?.vault_secret_key || '',
         vault_secret_path: credential?.vault_secret_path || '',
         vault_mount_point: credential?.vault_mount_point || ''
       });
@@ -521,6 +528,20 @@ const CredentialForm: React.FC<CredentialFormProps> = ({
               errorMessage={errors?.vault_secret_path}
               fieldTouched={touchedFields.has('vault_secret_path')}
             />
+          </FormGroup>
+          <FormGroup label={t('view.credentials.add-modal.vault_secret_key.label')} isRequired fieldId="vault_secret_key">
+            <TextInput
+              value={formData?.vault_secret_key}
+              placeholder={t('view.credentials.add-modal.vault_secret_key.placeholder')}
+              isRequired
+              type="text"
+              id="credential-vault-key"
+              name="vault_secret_key"
+              validated={errors?.vault_secret_key ? 'error' : 'default'}
+              onChange={event => handleInputChange('vault_secret_key', (event.target as HTMLInputElement).value)}
+              ouiaId="vault_secret_key"
+            />
+            <ErrorFragment errorMessage={errors?.vault_secret_key} fieldTouched={touchedFields.has('vault_secret_key')} />
           </FormGroup>
           <FormGroup label={t('view.credentials.add-modal.vault_mount_point.label')} fieldId="vault_mount_point">
             <TextInput

--- a/src/views/credentials/addCredentialModal.tsx
+++ b/src/views/credentials/addCredentialModal.tsx
@@ -508,6 +508,22 @@ const CredentialForm: React.FC<CredentialFormProps> = ({
 
       {authType === helpers.authType.VaultSecretPath && (
         <React.Fragment>
+          <FormGroup label={t('view.credentials.add-modal.vault_mount_point.label')} fieldId="vault_mount_point">
+            <TextInput
+              value={formData?.vault_mount_point}
+              placeholder={t('view.credentials.add-modal.vault_mount_point.placeholder')}
+              type="text"
+              id="credential-vault-mount-point"
+              name="vault_mount_point"
+              validated={errors?.vault_mount_point ? 'error' : 'default'}
+              onChange={event => handleInputChange('vault_mount_point', (event.target as HTMLInputElement).value)}
+              ouiaId="vault_mount_point"
+            />
+            <ErrorFragment
+              errorMessage={errors?.vault_mount_point}
+              fieldTouched={touchedFields.has('vault_mount_point')}
+            />
+          </FormGroup>
           <FormGroup
             label={t('view.credentials.add-modal.vault_secret_path.label')}
             isRequired
@@ -529,7 +545,11 @@ const CredentialForm: React.FC<CredentialFormProps> = ({
               fieldTouched={touchedFields.has('vault_secret_path')}
             />
           </FormGroup>
-          <FormGroup label={t('view.credentials.add-modal.vault_secret_key.label')} isRequired fieldId="vault_secret_key">
+          <FormGroup
+            label={t('view.credentials.add-modal.vault_secret_key.label')}
+            isRequired
+            fieldId="vault_secret_key"
+          >
             <TextInput
               value={formData?.vault_secret_key}
               placeholder={t('view.credentials.add-modal.vault_secret_key.placeholder')}
@@ -541,22 +561,9 @@ const CredentialForm: React.FC<CredentialFormProps> = ({
               onChange={event => handleInputChange('vault_secret_key', (event.target as HTMLInputElement).value)}
               ouiaId="vault_secret_key"
             />
-            <ErrorFragment errorMessage={errors?.vault_secret_key} fieldTouched={touchedFields.has('vault_secret_key')} />
-          </FormGroup>
-          <FormGroup label={t('view.credentials.add-modal.vault_mount_point.label')} fieldId="vault_mount_point">
-            <TextInput
-              value={formData?.vault_mount_point}
-              placeholder={t('view.credentials.add-modal.vault_mount_point.placeholder')}
-              type="text"
-              id="credential-vault-mount-point"
-              name="vault_mount_point"
-              validated={errors?.vault_mount_point ? 'error' : 'default'}
-              onChange={event => handleInputChange('vault_mount_point', (event.target as HTMLInputElement).value)}
-              ouiaId="vault_mount_point"
-            />
             <ErrorFragment
-              errorMessage={errors?.vault_mount_point}
-              fieldTouched={touchedFields.has('vault_mount_point')}
+              errorMessage={errors?.vault_secret_key}
+              fieldTouched={touchedFields.has('vault_secret_key')}
             />
           </FormGroup>
         </React.Fragment>


### PR DESCRIPTION
vault_secret_key is a third and required input for the new Vault secret path auth type.

requires related server change at https://github.com/quipucords/quipucords/pull/3190

Relates to JIRA: DISCOVERY-1360

## Summary by Sourcery

Add support for a new vault_secret_key field in Vault secret path credentials and ensure it is handled across the credential form, types, and tests.

New Features:
- Introduce a required vault_secret_key field for Vault secret path authentication credentials in the add credential modal.

Enhancements:
- Extend credential request/response types and form handling to persist and validate the vault_secret_key field for Vault-based credentials.

Tests:
- Update credential modal tests and snapshots to cover the new vault_secret_key behavior for Vault secret path authentication.

## Summary by Sourcery

Add support for a vault_secret_key field in Vault secret path credentials and wire it through the form, types, and validation.

New Features:
- Introduce a required vault_secret_key field for Vault secret path authentication credentials in the add credential modal.

Enhancements:
- Extend credential request/response types, default form state, and cleaning logic to persist, validate, and conditionally send vault_secret_key and related Vault fields.
- Adjust Vault secret path form layout to include an optional vault_mount_point field and a separate required vault_secret_key input.
- Update linting and formatting configuration by ignoring tsconfig.json in ESLint and adding a Prettier configuration file and ignore rules.

Tests:
- Update credential modal unit tests and snapshots to cover vault_secret_key handling and Vault secret path cleaning behavior.