### PR TITLE
build: update minimum Node.js version to 22.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/quipucords/quipucords-ui/issues"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "api:dev": "node ./scripts/apiDev.js --port $MOCK_PORT --file https://raw.githubusercontent.com/quipucords/quipucords/master/docs/swagger.yml",


### PR DESCRIPTION
The @eslint/json package (added in 6859c3f) requires Node.js "^20.19.0 || ^22.13.0 || >=24", but the project's engines field still specified ">=22.0.0" from the earlier Node 22 bump (8db9cd2).

This caused ESLint to fail on Node.js 22.0.0-22.12.x with:
  Error [ERR_REQUIRE_ESM]: require() of ES Module
  @eslint/json/dist/index.js not supported

Developers using Node.js in the 22.0-22.12 range would encounter this error, even though the version satisfied the documented requirement.

Update engines.node to ">=22.13.0" to match the actual dependency requirements and prevent this incompatibility.

My local fix:
```
node --version # check version to see if it needs updating
# v22.11.0
nvm install 22.13.0  # or any 22.x >= 22.13.0, but this is the true minimum for now
nvm use 22.13.0
nvm alias default 22.13.0  # make it permanent
```