### PR TITLE
chore: group GitHub Actions in MintMaker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
       "schedule": ["* 5-23 * * 5"]
     },
     {
+      "description": "GitHub Actions pipelines and tasks",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "schedule": ["* 5-23 * * 1-5"]
+    },
+    {
       "description": "Containerfile base image updates",
       "matchManagers": ["dockerfile"],
       "groupName": "containerfile",


### PR DESCRIPTION
Do something like https://github.com/quipucords/quipucords/pull/3191 , but automatically.

## Summary by Sourcery

Group and reorganize GitHub Actions–related configuration in the Renovate setup for MintMaker.