### PR TITLE
fix(scans): hide deep scan options for non-network sources

### DIFF
--- a/src/hooks/useScanApi.ts
+++ b/src/hooks/useScanApi.ts
@@ -478,7 +478,7 @@ const useDownloadReportApi = (onAddAlert: (alert: AlertProps) => void) => {
 
 const useShowConnectionsApi = () => {
   const apiCall = useCallback((source: SourceResponse): Promise<AxiosResponse> => {
-    return axios.get(`${process.env.REACT_APP_SCAN_JOBS_SERVICE}${source.connection.id}/connection/`, {
+    return axios.get(`${process.env.REACT_APP_SCAN_JOBS_SERVICE}${source.connection?.id}/connection/`, {
       params: { page: 1, page_size: 1000, ordering: 'name', source_type: source.id }
     });
   }, []);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -104,7 +104,7 @@ export type SourceResponse = SourceBase & {
   id: number;
   credentials: CredentialResponse[];
   exclude_hosts: string[];
-  connection: SourceConnectionType;
+  connection?: SourceConnectionType;
 };
 
 export type ConnectionType = {

--- a/src/views/sources/__tests__/__snapshots__/addSourcesScanModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourcesScanModal.test.tsx.snap
@@ -54,3 +54,2419 @@ exports[`AddSourceModal should render a basic component: basic 1`] = `
   />
 </Modal>
 `;
+
+exports[`Conditional Deep Scan Display should NOT show deep scan options when scanning a non-network source: non-network source without deep scan options 1`] = `
+<body
+  class="pf-v6-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="pf-v6-c-backdrop"
+    id="pf-modal-part-7"
+  >
+    <div
+      class="pf-v6-l-bullseye"
+    >
+      <div
+        aria-describedby="pf-modal-part-6"
+        aria-labelledby="pf-modal-part-5"
+        aria-modal="true"
+        class="pf-v6-c-modal-box pf-m-sm"
+        data-ouia-component-id="OUIA-Generated-Modal-small-5"
+        data-ouia-component-type="PF6/ModalContent"
+        data-ouia-safe="true"
+        id="pf-modal-part-4"
+        role="dialog"
+      >
+        <div
+          class="pf-v6-c-modal-box__close"
+        >
+          <button
+            aria-label="Close"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Modal-small-5-ModalBoxCloseButton"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <header
+          class="pf-v6-c-modal-box__header"
+        >
+          <h1
+            class="pf-v6-c-modal-box__title"
+            id="pf-modal-part-5"
+          >
+            <span
+              class="pf-v6-c-modal-box__title-text"
+            >
+              t([
+  "view.sources.modal-title.new-scan"
+])
+            </span>
+          </h1>
+        </header>
+        <div
+          class="pf-v6-c-modal-box__body"
+          id="pf-modal-part-6"
+        >
+          <form
+            class="pf-v6-c-form"
+            novalidate=""
+          >
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="name"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.name.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    data-ouia-component-id="name"
+                    data-ouia-component-type="PF6/TextInput"
+                    data-ouia-safe="true"
+                    id="scan-name"
+                    name="name"
+                    placeholder="t([
+  "view.sources.scan-modal.name.placeholder"
+])"
+                    required=""
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="sources"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.sources.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both pf-m-disabled"
+                >
+                  <textarea
+                    aria-invalid="false"
+                    disabled=""
+                    id="scan-sources"
+                    name="sources"
+                    required=""
+                  >
+                    Satellite Source
+                  </textarea>
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="maxConcurrency"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.max-concurrency.label"
+])
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-number-input"
+                  data-ouia-component-id="scan_concurrency"
+                >
+                  <div
+                    class="pf-v6-c-input-group"
+                  >
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-minus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-9"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <span
+                        class="pf-v6-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-input"
+])"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-10"
+                          data-ouia-component-type="PF6/TextInput"
+                          data-ouia-safe="true"
+                          name="input"
+                          type="number"
+                          value="25"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-plus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-10"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group pf-m-action"
+            >
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-form__actions"
+                >
+                  <button
+                    class="pf-v6-c-button pf-m-primary"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-5"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.save"
+])
+                    </span>
+                  </button>
+                  <button
+                    class="pf-v6-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-5"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.cancel"
+])
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Conditional Deep Scan Display should NOT show deep scan options when scanning multiple non-network sources: multiple non-network sources without deep scan options 1`] = `
+<body
+  class="pf-v6-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="pf-v6-c-backdrop"
+    id="pf-modal-part-9"
+  >
+    <div
+      class="pf-v6-l-bullseye"
+    >
+      <div
+        aria-describedby="pf-modal-part-8"
+        aria-labelledby="pf-modal-part-7"
+        aria-modal="true"
+        class="pf-v6-c-modal-box pf-m-sm"
+        data-ouia-component-id="OUIA-Generated-Modal-small-7"
+        data-ouia-component-type="PF6/ModalContent"
+        data-ouia-safe="true"
+        id="pf-modal-part-6"
+        role="dialog"
+      >
+        <div
+          class="pf-v6-c-modal-box__close"
+        >
+          <button
+            aria-label="Close"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Modal-small-7-ModalBoxCloseButton"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <header
+          class="pf-v6-c-modal-box__header"
+        >
+          <h1
+            class="pf-v6-c-modal-box__title"
+            id="pf-modal-part-7"
+          >
+            <span
+              class="pf-v6-c-modal-box__title-text"
+            >
+              t([
+  "view.sources.modal-title.new-scan"
+])
+            </span>
+          </h1>
+        </header>
+        <div
+          class="pf-v6-c-modal-box__body"
+          id="pf-modal-part-8"
+        >
+          <form
+            class="pf-v6-c-form"
+            novalidate=""
+          >
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="name"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.name.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    data-ouia-component-id="name"
+                    data-ouia-component-type="PF6/TextInput"
+                    data-ouia-safe="true"
+                    id="scan-name"
+                    name="name"
+                    placeholder="t([
+  "view.sources.scan-modal.name.placeholder"
+])"
+                    required=""
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="sources"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.sources.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both pf-m-disabled"
+                >
+                  <textarea
+                    aria-invalid="false"
+                    disabled=""
+                    id="scan-sources"
+                    name="sources"
+                    required=""
+                  >
+                    Satellite Source, vCenter Source
+                  </textarea>
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="maxConcurrency"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.max-concurrency.label"
+])
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-number-input"
+                  data-ouia-component-id="scan_concurrency"
+                >
+                  <div
+                    class="pf-v6-c-input-group"
+                  >
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-minus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-13"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <span
+                        class="pf-v6-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-input"
+])"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-14"
+                          data-ouia-component-type="PF6/TextInput"
+                          data-ouia-safe="true"
+                          name="input"
+                          type="number"
+                          value="25"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-plus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-14"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group pf-m-action"
+            >
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-form__actions"
+                >
+                  <button
+                    class="pf-v6-c-button pf-m-primary"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-7"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.save"
+])
+                    </span>
+                  </button>
+                  <button
+                    class="pf-v6-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-7"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.cancel"
+])
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Conditional Deep Scan Display should NOT show search directories field for non-network sources even if sources prop is undefined: undefined sources without deep scan options 1`] = `
+<body
+  class="pf-v6-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="pf-v6-c-backdrop"
+    id="pf-modal-part-11"
+  >
+    <div
+      class="pf-v6-l-bullseye"
+    >
+      <div
+        aria-describedby="pf-modal-part-10"
+        aria-labelledby="pf-modal-part-9"
+        aria-modal="true"
+        class="pf-v6-c-modal-box pf-m-sm"
+        data-ouia-component-id="OUIA-Generated-Modal-small-9"
+        data-ouia-component-type="PF6/ModalContent"
+        data-ouia-safe="true"
+        id="pf-modal-part-8"
+        role="dialog"
+      >
+        <div
+          class="pf-v6-c-modal-box__close"
+        >
+          <button
+            aria-label="Close"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Modal-small-9-ModalBoxCloseButton"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <header
+          class="pf-v6-c-modal-box__header"
+        >
+          <h1
+            class="pf-v6-c-modal-box__title"
+            id="pf-modal-part-9"
+          >
+            <span
+              class="pf-v6-c-modal-box__title-text"
+            >
+              t([
+  "view.sources.modal-title.new-scan"
+])
+            </span>
+          </h1>
+        </header>
+        <div
+          class="pf-v6-c-modal-box__body"
+          id="pf-modal-part-10"
+        >
+          <form
+            class="pf-v6-c-form"
+            novalidate=""
+          >
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="name"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.name.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    data-ouia-component-id="name"
+                    data-ouia-component-type="PF6/TextInput"
+                    data-ouia-safe="true"
+                    id="scan-name"
+                    name="name"
+                    placeholder="t([
+  "view.sources.scan-modal.name.placeholder"
+])"
+                    required=""
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="sources"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.sources.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both pf-m-disabled"
+                >
+                  <textarea
+                    aria-invalid="false"
+                    disabled=""
+                    id="scan-sources"
+                    name="sources"
+                    required=""
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="maxConcurrency"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.max-concurrency.label"
+])
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-number-input"
+                  data-ouia-component-id="scan_concurrency"
+                >
+                  <div
+                    class="pf-v6-c-input-group"
+                  >
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-minus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-17"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <span
+                        class="pf-v6-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-input"
+])"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-18"
+                          data-ouia-component-type="PF6/TextInput"
+                          data-ouia-safe="true"
+                          name="input"
+                          type="number"
+                          value="25"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-plus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-18"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group pf-m-action"
+            >
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-form__actions"
+                >
+                  <button
+                    class="pf-v6-c-button pf-m-primary"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-9"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.save"
+])
+                    </span>
+                  </button>
+                  <button
+                    class="pf-v6-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-9"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.cancel"
+])
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Conditional Deep Scan Display should show deep scan options when scanning a network source: network source with deep scan options 1`] = `
+<body
+  class="pf-v6-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="pf-v6-c-backdrop"
+    id="pf-modal-part-6"
+  >
+    <div
+      class="pf-v6-l-bullseye"
+    >
+      <div
+        aria-describedby="pf-modal-part-5"
+        aria-labelledby="pf-modal-part-4"
+        aria-modal="true"
+        class="pf-v6-c-modal-box pf-m-sm"
+        data-ouia-component-id="OUIA-Generated-Modal-small-4"
+        data-ouia-component-type="PF6/ModalContent"
+        data-ouia-safe="true"
+        id="pf-modal-part-3"
+        role="dialog"
+      >
+        <div
+          class="pf-v6-c-modal-box__close"
+        >
+          <button
+            aria-label="Close"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Modal-small-4-ModalBoxCloseButton"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <header
+          class="pf-v6-c-modal-box__header"
+        >
+          <h1
+            class="pf-v6-c-modal-box__title"
+            id="pf-modal-part-4"
+          >
+            <span
+              class="pf-v6-c-modal-box__title-text"
+            >
+              t([
+  "view.sources.modal-title.new-scan"
+])
+            </span>
+          </h1>
+        </header>
+        <div
+          class="pf-v6-c-modal-box__body"
+          id="pf-modal-part-5"
+        >
+          <form
+            class="pf-v6-c-form"
+            novalidate=""
+          >
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="name"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.name.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    data-ouia-component-id="name"
+                    data-ouia-component-type="PF6/TextInput"
+                    data-ouia-safe="true"
+                    id="scan-name"
+                    name="name"
+                    placeholder="t([
+  "view.sources.scan-modal.name.placeholder"
+])"
+                    required=""
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="sources"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.sources.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both pf-m-disabled"
+                >
+                  <textarea
+                    aria-invalid="false"
+                    disabled=""
+                    id="scan-sources"
+                    name="sources"
+                    required=""
+                  >
+                    Network Source
+                  </textarea>
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="maxConcurrency"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.max-concurrency.label"
+])
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-number-input"
+                  data-ouia-component-id="scan_concurrency"
+                >
+                  <div
+                    class="pf-v6-c-input-group"
+                  >
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-minus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-7"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <span
+                        class="pf-v6-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-input"
+])"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-8"
+                          data-ouia-component-type="PF6/TextInput"
+                          data-ouia-safe="true"
+                          name="input"
+                          type="number"
+                          value="25"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-plus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-8"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-labelledby="deepScans-legend"
+              class="pf-v6-c-form__group"
+              role="group"
+            >
+              <div
+                class="pf-v6-c-form__group-label pf-m-no-padding-top"
+                id="deepScans-legend"
+              >
+                <span
+                  class="pf-v6-c-form__label"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.label"
+])
+                  </span>
+                </span>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control pf-m-stack"
+              >
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_eap"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_eap"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_eap"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_eap"
+])
+                  </label>
+                </div>
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_fuse"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_fuse"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_fuse"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_fuse"
+])
+                  </label>
+                </div>
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_ws"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_ws"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_ws"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_ws"
+])
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group pf-m-action"
+            >
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-form__actions"
+                >
+                  <button
+                    class="pf-v6-c-button pf-m-primary"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-4"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.save"
+])
+                    </span>
+                  </button>
+                  <button
+                    class="pf-v6-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-4"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.cancel"
+])
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Conditional Deep Scan Display should show deep scan options when scanning mixed source types including network: mixed sources with deep scan options 1`] = `
+<body
+  class="pf-v6-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="pf-v6-c-backdrop"
+    id="pf-modal-part-8"
+  >
+    <div
+      class="pf-v6-l-bullseye"
+    >
+      <div
+        aria-describedby="pf-modal-part-7"
+        aria-labelledby="pf-modal-part-6"
+        aria-modal="true"
+        class="pf-v6-c-modal-box pf-m-sm"
+        data-ouia-component-id="OUIA-Generated-Modal-small-6"
+        data-ouia-component-type="PF6/ModalContent"
+        data-ouia-safe="true"
+        id="pf-modal-part-5"
+        role="dialog"
+      >
+        <div
+          class="pf-v6-c-modal-box__close"
+        >
+          <button
+            aria-label="Close"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Modal-small-6-ModalBoxCloseButton"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <header
+          class="pf-v6-c-modal-box__header"
+        >
+          <h1
+            class="pf-v6-c-modal-box__title"
+            id="pf-modal-part-6"
+          >
+            <span
+              class="pf-v6-c-modal-box__title-text"
+            >
+              t([
+  "view.sources.modal-title.new-scan"
+])
+            </span>
+          </h1>
+        </header>
+        <div
+          class="pf-v6-c-modal-box__body"
+          id="pf-modal-part-7"
+        >
+          <form
+            class="pf-v6-c-form"
+            novalidate=""
+          >
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="name"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.name.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    data-ouia-component-id="name"
+                    data-ouia-component-type="PF6/TextInput"
+                    data-ouia-safe="true"
+                    id="scan-name"
+                    name="name"
+                    placeholder="t([
+  "view.sources.scan-modal.name.placeholder"
+])"
+                    required=""
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="sources"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.sources.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both pf-m-disabled"
+                >
+                  <textarea
+                    aria-invalid="false"
+                    disabled=""
+                    id="scan-sources"
+                    name="sources"
+                    required=""
+                  >
+                    Network Source, Satellite Source
+                  </textarea>
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="maxConcurrency"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.max-concurrency.label"
+])
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-number-input"
+                  data-ouia-component-id="scan_concurrency"
+                >
+                  <div
+                    class="pf-v6-c-input-group"
+                  >
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-minus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-11"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <span
+                        class="pf-v6-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-input"
+])"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-12"
+                          data-ouia-component-type="PF6/TextInput"
+                          data-ouia-safe="true"
+                          name="input"
+                          type="number"
+                          value="25"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-plus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-12"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-labelledby="deepScans-legend"
+              class="pf-v6-c-form__group"
+              role="group"
+            >
+              <div
+                class="pf-v6-c-form__group-label pf-m-no-padding-top"
+                id="deepScans-legend"
+              >
+                <span
+                  class="pf-v6-c-form__label"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.label"
+])
+                  </span>
+                </span>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control pf-m-stack"
+              >
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_eap"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_eap"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_eap"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_eap"
+])
+                  </label>
+                </div>
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_fuse"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_fuse"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_fuse"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_fuse"
+])
+                  </label>
+                </div>
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_ws"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_ws"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_ws"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_ws"
+])
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group pf-m-action"
+            >
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-form__actions"
+                >
+                  <button
+                    class="pf-v6-c-button pf-m-primary"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-6"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.save"
+])
+                    </span>
+                  </button>
+                  <button
+                    class="pf-v6-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-6"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.cancel"
+])
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Conditional Deep Scan Display should show search directories field when deep scan is checked and source is network: network source with search directories after deep scan check 1`] = `
+<body
+  class="pf-v6-c-backdrop__open"
+>
+  <div
+    aria-hidden="true"
+  />
+  <div
+    class="pf-v6-c-backdrop"
+    id="pf-modal-part-10"
+  >
+    <div
+      class="pf-v6-l-bullseye"
+    >
+      <div
+        aria-describedby="pf-modal-part-9"
+        aria-labelledby="pf-modal-part-8"
+        aria-modal="true"
+        class="pf-v6-c-modal-box pf-m-sm"
+        data-ouia-component-id="OUIA-Generated-Modal-small-8"
+        data-ouia-component-type="PF6/ModalContent"
+        data-ouia-safe="true"
+        id="pf-modal-part-7"
+        role="dialog"
+      >
+        <div
+          class="pf-v6-c-modal-box__close"
+        >
+          <button
+            aria-label="Close"
+            class="pf-v6-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Modal-small-8-ModalBoxCloseButton"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <span
+              class="pf-v6-c-button__icon"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-v6-svg"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+        <header
+          class="pf-v6-c-modal-box__header"
+        >
+          <h1
+            class="pf-v6-c-modal-box__title"
+            id="pf-modal-part-8"
+          >
+            <span
+              class="pf-v6-c-modal-box__title-text"
+            >
+              t([
+  "view.sources.modal-title.new-scan"
+])
+            </span>
+          </h1>
+        </header>
+        <div
+          class="pf-v6-c-modal-box__body"
+          id="pf-modal-part-9"
+        >
+          <form
+            class="pf-v6-c-form"
+            novalidate=""
+          >
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="name"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.name.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control"
+                >
+                  <input
+                    aria-invalid="false"
+                    data-ouia-component-id="name"
+                    data-ouia-component-type="PF6/TextInput"
+                    data-ouia-safe="true"
+                    id="scan-name"
+                    name="name"
+                    placeholder="t([
+  "view.sources.scan-modal.name.placeholder"
+])"
+                    required=""
+                    type="text"
+                    value=""
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="sources"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.sources.label"
+])
+                  </span>
+                  <span
+                    aria-hidden="true"
+                    class="pf-v6-c-form__label-required"
+                  >
+                     
+                    *
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both pf-m-disabled"
+                >
+                  <textarea
+                    aria-invalid="false"
+                    disabled=""
+                    id="scan-sources"
+                    name="sources"
+                    required=""
+                  >
+                    Network Source
+                  </textarea>
+                </span>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="maxConcurrency"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.max-concurrency.label"
+])
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-number-input"
+                  data-ouia-component-id="scan_concurrency"
+                >
+                  <div
+                    class="pf-v6-c-input-group"
+                  >
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-minus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-15"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <span
+                        class="pf-v6-c-form-control"
+                      >
+                        <input
+                          aria-invalid="false"
+                          aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-input"
+])"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-16"
+                          data-ouia-component-type="PF6/TextInput"
+                          data-ouia-safe="true"
+                          name="input"
+                          type="number"
+                          value="25"
+                        />
+                      </span>
+                    </div>
+                    <div
+                      class="pf-v6-c-input-group__item"
+                    >
+                      <button
+                        aria-label="t([
+  "view.sources.scan-modal.max-concurrency.aria-plus"
+])"
+                        class="pf-v6-c-button pf-m-control"
+                        data-ouia-component-id="OUIA-Generated-Button-control-16"
+                        data-ouia-component-type="PF6/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <span
+                          class="pf-v6-c-button__icon"
+                        >
+                          <span
+                            class="pf-v6-c-number-input__icon"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="pf-v6-svg"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              viewBox="0 0 448 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-labelledby="deepScans-legend"
+              class="pf-v6-c-form__group"
+              role="group"
+            >
+              <div
+                class="pf-v6-c-form__group-label pf-m-no-padding-top"
+                id="deepScans-legend"
+              >
+                <span
+                  class="pf-v6-c-form__label"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.label"
+])
+                  </span>
+                </span>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control pf-m-stack"
+              >
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_eap"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_eap"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_eap"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_eap"
+])
+                  </label>
+                </div>
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_fuse"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_fuse"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_fuse"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_fuse"
+])
+                  </label>
+                </div>
+                <div
+                  class="pf-v6-c-check"
+                >
+                  <input
+                    aria-invalid="false"
+                    class="pf-v6-c-check__input"
+                    data-ouia-component-id="options_jboss_ws"
+                    data-ouia-component-type="PF6/Checkbox"
+                    data-ouia-safe="true"
+                    id="deep-scan-jboss_ws"
+                    type="checkbox"
+                  />
+                  <label
+                    class="pf-v6-c-check__label"
+                    for="deep-scan-jboss_ws"
+                  >
+                    t([
+  "view.sources.scan-modal.deep-scan.jboss_ws"
+])
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group"
+            >
+              <div
+                class="pf-v6-c-form__group-label"
+              >
+                <label
+                  class="pf-v6-c-form__label"
+                  for="searchDirectories"
+                >
+                  <span
+                    class="pf-v6-c-form__label-text"
+                  >
+                    t([
+  "view.sources.scan-modal.search-dirs.label"
+])
+                  </span>
+                </label>
+                  
+              </div>
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <span
+                  class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both"
+                >
+                  <textarea
+                    aria-invalid="false"
+                    data-ouia-component-id="scan_alt_dirs"
+                    id="scan-alt-scan"
+                    name="searchDirectories"
+                  />
+                </span>
+                <div
+                  class="pf-v6-c-helper-text"
+                >
+                  t([
+  "view.sources.scan-modal.search-dirs.helper"
+])
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-form__group pf-m-action"
+            >
+              <div
+                class="pf-v6-c-form__group-control"
+              >
+                <div
+                  class="pf-v6-c-form__actions"
+                >
+                  <button
+                    class="pf-v6-c-button pf-m-primary"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-8"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.save"
+])
+                    </span>
+                  </button>
+                  <button
+                    class="pf-v6-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-8"
+                    data-ouia-component-type="PF6/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-button__text"
+                    >
+                      t([
+  "view.sources.scan-modal.actions.cancel"
+])
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/src/views/sources/__tests__/addSourcesScanModal.test.tsx
+++ b/src/views/sources/__tests__/addSourcesScanModal.test.tsx
@@ -42,22 +42,6 @@ describe('AddSourceModal', () => {
 });
 
 describe('Conditional Deep Scan Display', () => {
-  const mockConnection = {
-    end_time: '2023-01-01T00:00:00Z',
-    id: 1,
-    report_id: 1,
-    source_systems_count: 1,
-    source_systems_failed: 0,
-    source_systems_scanned: 1,
-    source_systems_unreachable: 0,
-    start_time: '2023-01-01T00:00:00Z',
-    status: 'completed',
-    status_details: { job_status_message: 'Success' },
-    systems_count: 1,
-    systems_scanned: 1,
-    systems_failed: 0
-  };
-
   it('should show deep scan options when scanning a network source', async () => {
     const networkSources = [
       {
@@ -68,7 +52,6 @@ describe('Conditional Deep Scan Display', () => {
         hosts: ['host1'],
         exclude_hosts: [],
         credentials: [],
-        connection: mockConnection,
         ssl_cert_verify: false,
         disable_ssl: false
       }
@@ -94,7 +77,6 @@ describe('Conditional Deep Scan Display', () => {
         hosts: ['satellite.example.com'],
         exclude_hosts: [],
         credentials: [],
-        connection: mockConnection,
         ssl_cert_verify: true,
         disable_ssl: false
       }
@@ -118,7 +100,6 @@ describe('Conditional Deep Scan Display', () => {
         hosts: ['host1'],
         exclude_hosts: [],
         credentials: [],
-        connection: mockConnection,
         ssl_cert_verify: false,
         disable_ssl: false
       },
@@ -130,7 +111,6 @@ describe('Conditional Deep Scan Display', () => {
         hosts: ['satellite.example.com'],
         exclude_hosts: [],
         credentials: [],
-        connection: { ...mockConnection, id: 2 },
         ssl_cert_verify: true,
         disable_ssl: false
       }
@@ -154,7 +134,6 @@ describe('Conditional Deep Scan Display', () => {
         hosts: ['satellite.example.com'],
         exclude_hosts: [],
         credentials: [],
-        connection: mockConnection,
         ssl_cert_verify: true,
         disable_ssl: false
       },
@@ -166,7 +145,6 @@ describe('Conditional Deep Scan Display', () => {
         hosts: ['vcenter.example.com'],
         exclude_hosts: [],
         credentials: [],
-        connection: { ...mockConnection, id: 2 },
         ssl_cert_verify: true,
         disable_ssl: false
       }
@@ -189,7 +167,6 @@ describe('Conditional Deep Scan Display', () => {
         hosts: ['host1'],
         exclude_hosts: [],
         credentials: [],
-        connection: mockConnection,
         ssl_cert_verify: false,
         disable_ssl: false
       }
@@ -294,22 +271,6 @@ describe('Form Validation', () => {
   });
 
   it('should filter form data correctly for API submission', async () => {
-    const mockConnection = {
-      end_time: '2023-01-01T00:00:00Z',
-      id: 1,
-      report_id: 1,
-      source_systems_count: 1,
-      source_systems_failed: 0,
-      source_systems_scanned: 1,
-      source_systems_unreachable: 0,
-      start_time: '2023-01-01T00:00:00Z',
-      status: 'completed',
-      status_details: { job_status_message: 'Success' },
-      systems_count: 1,
-      systems_scanned: 1,
-      systems_failed: 0
-    };
-
     const sources = [
       {
         id: 1,
@@ -319,7 +280,6 @@ describe('Form Validation', () => {
         hosts: ['host1'],
         exclude_hosts: [],
         credentials: [],
-        connection: mockConnection,
         ssl_cert_verify: false,
         disable_ssl: false
       },
@@ -331,7 +291,6 @@ describe('Form Validation', () => {
         hosts: ['host2'],
         exclude_hosts: [],
         credentials: [],
-        connection: { ...mockConnection, id: 2 },
         ssl_cert_verify: false,
         disable_ssl: false
       }
@@ -381,22 +340,6 @@ describe('Form Validation', () => {
   });
 
   it('should reset form when sources change', async () => {
-    const mockConnection = {
-      end_time: '2023-01-01T00:00:00Z',
-      id: 1,
-      report_id: 1,
-      source_systems_count: 1,
-      source_systems_failed: 0,
-      source_systems_scanned: 1,
-      source_systems_unreachable: 0,
-      start_time: '2023-01-01T00:00:00Z',
-      status: 'completed',
-      status_details: { job_status_message: 'Success' },
-      systems_count: 1,
-      systems_scanned: 1,
-      systems_failed: 0
-    };
-
     const initialSources = [
       {
         id: 1,
@@ -406,7 +349,6 @@ describe('Form Validation', () => {
         hosts: ['host1'],
         exclude_hosts: [],
         credentials: [],
-        connection: mockConnection,
         ssl_cert_verify: false,
         disable_ssl: false
       }
@@ -430,7 +372,6 @@ describe('Form Validation', () => {
         hosts: ['host2'],
         exclude_hosts: [],
         credentials: [],
-        connection: { ...mockConnection, id: 2 },
         ssl_cert_verify: false,
         disable_ssl: false
       }

--- a/src/views/sources/__tests__/addSourcesScanModal.test.tsx
+++ b/src/views/sources/__tests__/addSourcesScanModal.test.tsx
@@ -41,6 +41,186 @@ describe('AddSourceModal', () => {
   });
 });
 
+describe('Conditional Deep Scan Display', () => {
+  const mockConnection = {
+    end_time: '2023-01-01T00:00:00Z',
+    id: 1,
+    report_id: 1,
+    source_systems_count: 1,
+    source_systems_failed: 0,
+    source_systems_scanned: 1,
+    source_systems_unreachable: 0,
+    start_time: '2023-01-01T00:00:00Z',
+    status: 'completed',
+    status_details: { job_status_message: 'Success' },
+    systems_count: 1,
+    systems_scanned: 1,
+    systems_failed: 0
+  };
+
+  it('should show deep scan options when scanning a network source', async () => {
+    const networkSources = [
+      {
+        id: 1,
+        name: 'Network Source',
+        port: 22,
+        source_type: 'network',
+        hosts: ['host1'],
+        exclude_hosts: [],
+        credentials: [],
+        connection: mockConnection,
+        ssl_cert_verify: false,
+        disable_ssl: false
+      }
+    ];
+
+    await act(async () => {
+      await render(<AddSourcesScanModal isOpen={true} sources={networkSources} />);
+    });
+
+    expect(screen.getByText(/deep-scan\.label/)).toBeInTheDocument();
+    expect(screen.getByText(/deep-scan\.jboss_eap/)).toBeInTheDocument();
+    expect(screen.getByText(/deep-scan\.jboss_fuse/)).toBeInTheDocument();
+    expect(screen.getByText(/deep-scan\.jboss_ws/)).toBeInTheDocument();
+  });
+
+  it('should NOT show deep scan options when scanning a non-network source', async () => {
+    const satelliteSources = [
+      {
+        id: 1,
+        name: 'Satellite Source',
+        port: 443,
+        source_type: 'satellite',
+        hosts: ['satellite.example.com'],
+        exclude_hosts: [],
+        credentials: [],
+        connection: mockConnection,
+        ssl_cert_verify: true,
+        disable_ssl: false
+      }
+    ];
+
+    await act(async () => {
+      await render(<AddSourcesScanModal isOpen={true} sources={satelliteSources} />);
+    });
+
+    expect(screen.queryByText(/deep-scan\.label/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/deep-scan\.jboss_eap/)).not.toBeInTheDocument();
+  });
+
+  it('should show deep scan options when scanning mixed source types including network', async () => {
+    const mixedSources = [
+      {
+        id: 1,
+        name: 'Network Source',
+        port: 22,
+        source_type: 'network',
+        hosts: ['host1'],
+        exclude_hosts: [],
+        credentials: [],
+        connection: mockConnection,
+        ssl_cert_verify: false,
+        disable_ssl: false
+      },
+      {
+        id: 2,
+        name: 'Satellite Source',
+        port: 443,
+        source_type: 'satellite',
+        hosts: ['satellite.example.com'],
+        exclude_hosts: [],
+        credentials: [],
+        connection: { ...mockConnection, id: 2 },
+        ssl_cert_verify: true,
+        disable_ssl: false
+      }
+    ];
+
+    await act(async () => {
+      await render(<AddSourcesScanModal isOpen={true} sources={mixedSources} />);
+    });
+
+    expect(screen.getByText(/deep-scan\.label/)).toBeInTheDocument();
+    expect(screen.getByText(/deep-scan\.jboss_eap/)).toBeInTheDocument();
+  });
+
+  it('should NOT show deep scan options when scanning multiple non-network sources', async () => {
+    const nonNetworkSources = [
+      {
+        id: 1,
+        name: 'Satellite Source',
+        port: 443,
+        source_type: 'satellite',
+        hosts: ['satellite.example.com'],
+        exclude_hosts: [],
+        credentials: [],
+        connection: mockConnection,
+        ssl_cert_verify: true,
+        disable_ssl: false
+      },
+      {
+        id: 2,
+        name: 'vCenter Source',
+        port: 443,
+        source_type: 'vcenter',
+        hosts: ['vcenter.example.com'],
+        exclude_hosts: [],
+        credentials: [],
+        connection: { ...mockConnection, id: 2 },
+        ssl_cert_verify: true,
+        disable_ssl: false
+      }
+    ];
+
+    await act(async () => {
+      await render(<AddSourcesScanModal isOpen={true} sources={nonNetworkSources} />);
+    });
+
+    expect(screen.queryByText(/deep-scan\.label/)).not.toBeInTheDocument();
+  });
+
+  it('should show search directories field when deep scan is checked and source is network', async () => {
+    const networkSources = [
+      {
+        id: 1,
+        name: 'Network Source',
+        port: 22,
+        source_type: 'network',
+        hosts: ['host1'],
+        exclude_hosts: [],
+        credentials: [],
+        connection: mockConnection,
+        ssl_cert_verify: false,
+        disable_ssl: false
+      }
+    ];
+
+    await act(async () => {
+      await render(<AddSourcesScanModal isOpen={true} sources={networkSources} />);
+    });
+
+    // Initially, search directories field should not be visible
+    expect(screen.queryByText(/search-dirs\.label/)).not.toBeInTheDocument();
+
+    // Click a deep scan checkbox
+    const user = userEvent.setup();
+    const jbossEapCheckbox = screen.getByLabelText(/deep-scan\.jboss_eap/);
+    await user.click(jbossEapCheckbox);
+
+    // Now search directories field should appear
+    expect(screen.getByText(/search-dirs\.label/)).toBeInTheDocument();
+  });
+
+  it('should NOT show search directories field for non-network sources even if sources prop is undefined', async () => {
+    await act(async () => {
+      await render(<AddSourcesScanModal isOpen={true} sources={undefined} />);
+    });
+
+    expect(screen.queryByText(/deep-scan\.label/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/search-dirs\.label/)).not.toBeInTheDocument();
+  });
+});
+
 describe('Form Validation', () => {
   it('should validate required fields and show canSubmit correctly', async () => {
     const { result } = renderHook(() => useScanForm());

--- a/src/views/sources/__tests__/addSourcesScanModal.test.tsx
+++ b/src/views/sources/__tests__/addSourcesScanModal.test.tsx
@@ -57,14 +57,12 @@ describe('Conditional Deep Scan Display', () => {
       }
     ];
 
+    let baseElement;
     await act(async () => {
-      await render(<AddSourcesScanModal isOpen={true} sources={networkSources} />);
+      ({ baseElement } = render(<AddSourcesScanModal isOpen={true} sources={networkSources} />));
     });
 
-    expect(screen.getByText(/deep-scan\.label/)).toBeInTheDocument();
-    expect(screen.getByText(/deep-scan\.jboss_eap/)).toBeInTheDocument();
-    expect(screen.getByText(/deep-scan\.jboss_fuse/)).toBeInTheDocument();
-    expect(screen.getByText(/deep-scan\.jboss_ws/)).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot('network source with deep scan options');
   });
 
   it('should NOT show deep scan options when scanning a non-network source', async () => {
@@ -82,12 +80,12 @@ describe('Conditional Deep Scan Display', () => {
       }
     ];
 
+    let baseElement;
     await act(async () => {
-      await render(<AddSourcesScanModal isOpen={true} sources={satelliteSources} />);
+      ({ baseElement } = render(<AddSourcesScanModal isOpen={true} sources={satelliteSources} />));
     });
 
-    expect(screen.queryByText(/deep-scan\.label/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/deep-scan\.jboss_eap/)).not.toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot('non-network source without deep scan options');
   });
 
   it('should show deep scan options when scanning mixed source types including network', async () => {
@@ -116,12 +114,12 @@ describe('Conditional Deep Scan Display', () => {
       }
     ];
 
+    let baseElement;
     await act(async () => {
-      await render(<AddSourcesScanModal isOpen={true} sources={mixedSources} />);
+      ({ baseElement } = render(<AddSourcesScanModal isOpen={true} sources={mixedSources} />));
     });
 
-    expect(screen.getByText(/deep-scan\.label/)).toBeInTheDocument();
-    expect(screen.getByText(/deep-scan\.jboss_eap/)).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot('mixed sources with deep scan options');
   });
 
   it('should NOT show deep scan options when scanning multiple non-network sources', async () => {
@@ -150,11 +148,12 @@ describe('Conditional Deep Scan Display', () => {
       }
     ];
 
+    let baseElement;
     await act(async () => {
-      await render(<AddSourcesScanModal isOpen={true} sources={nonNetworkSources} />);
+      ({ baseElement } = render(<AddSourcesScanModal isOpen={true} sources={nonNetworkSources} />));
     });
 
-    expect(screen.queryByText(/deep-scan\.label/)).not.toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot('multiple non-network sources without deep scan options');
   });
 
   it('should show search directories field when deep scan is checked and source is network', async () => {
@@ -172,12 +171,10 @@ describe('Conditional Deep Scan Display', () => {
       }
     ];
 
+    let baseElement;
     await act(async () => {
-      await render(<AddSourcesScanModal isOpen={true} sources={networkSources} />);
+      ({ baseElement } = render(<AddSourcesScanModal isOpen={true} sources={networkSources} />));
     });
-
-    // Initially, search directories field should not be visible
-    expect(screen.queryByText(/search-dirs\.label/)).not.toBeInTheDocument();
 
     // Click a deep scan checkbox
     const user = userEvent.setup();
@@ -185,16 +182,16 @@ describe('Conditional Deep Scan Display', () => {
     await user.click(jbossEapCheckbox);
 
     // Now search directories field should appear
-    expect(screen.getByText(/search-dirs\.label/)).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot('network source with search directories after deep scan check');
   });
 
   it('should NOT show search directories field for non-network sources even if sources prop is undefined', async () => {
+    let baseElement;
     await act(async () => {
-      await render(<AddSourcesScanModal isOpen={true} sources={undefined} />);
+      ({ baseElement } = render(<AddSourcesScanModal isOpen={true} sources={undefined} />));
     });
 
-    expect(screen.queryByText(/deep-scan\.label/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/search-dirs\.label/)).not.toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot('undefined sources without deep scan options');
   });
 });
 

--- a/src/views/sources/addSourcesScanModal.tsx
+++ b/src/views/sources/addSourcesScanModal.tsx
@@ -226,6 +226,9 @@ const ScanForm: React.FC<ScanFormProps> = ({
     onClearErrors
   });
 
+  // Check if at least one network source is being scanned
+  const hasNetworkSource = sources?.some(s => s.source_type === 'network') ?? false;
+
   const scrollToFirstError = useCallback(() => {
     const errorFields = Object.keys(errors);
     if (errorFields.length > 0) {
@@ -307,29 +310,31 @@ const ScanForm: React.FC<ScanFormProps> = ({
           data-ouia-component-id="scan_concurrency"
         />
       </FormGroup>
-      <FormGroup
-        label={t('view.sources.scan-modal.deep-scan.label')}
-        isStack
-        fieldId="deepScans"
-        hasNoPaddingTop
-        role="group"
-      >
-        {[
-          { label: t('view.sources.scan-modal.deep-scan.jboss_eap'), value: 'jboss_eap' },
-          { label: t('view.sources.scan-modal.deep-scan.jboss_fuse'), value: 'jboss_fuse' },
-          { label: t('view.sources.scan-modal.deep-scan.jboss_ws'), value: 'jboss_ws' }
-        ].map(o => (
-          <Checkbox
-            key={`deep-scan-${o.value}`}
-            label={o.label}
-            id={`deep-scan-${o.value}`}
-            isChecked={formData.deepScans.includes(o.value)}
-            onChange={(_ev, ch) => onDeepScanChange(o.value, ch)}
-            ouiaId={`options_${o.value}`}
-          />
-        ))}
-      </FormGroup>
-      {!!formData.deepScans.length && (
+      {hasNetworkSource && (
+        <FormGroup
+          label={t('view.sources.scan-modal.deep-scan.label')}
+          isStack
+          fieldId="deepScans"
+          hasNoPaddingTop
+          role="group"
+        >
+          {[
+            { label: t('view.sources.scan-modal.deep-scan.jboss_eap'), value: 'jboss_eap' },
+            { label: t('view.sources.scan-modal.deep-scan.jboss_fuse'), value: 'jboss_fuse' },
+            { label: t('view.sources.scan-modal.deep-scan.jboss_ws'), value: 'jboss_ws' }
+          ].map(o => (
+            <Checkbox
+              key={`deep-scan-${o.value}`}
+              label={o.label}
+              id={`deep-scan-${o.value}`}
+              isChecked={formData.deepScans.includes(o.value)}
+              onChange={(_ev, ch) => onDeepScanChange(o.value, ch)}
+              ouiaId={`options_${o.value}`}
+            />
+          ))}
+        </FormGroup>
+      )}
+      {hasNetworkSource && !!formData.deepScans.length && (
         <FormGroup label={t('view.sources.scan-modal.search-dirs.label')} fieldId="searchDirectories">
           <TextArea
             value={formData.searchDirectories}

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -443,13 +443,13 @@ const SourcesListView: React.FunctionComponent = () => {
         </Button>
       );
     }
+    // At this point, we know source.connection exists due to the guard above
+    const connection = source.connection!;
     const isPending =
-      source.connection.status === 'created' ||
-      source.connection.status === 'pending' ||
-      source.connection.status === 'running';
-    const scanTime = (isPending && source.connection.start_time) || source.connection.end_time;
+      connection.status === 'created' || connection.status === 'pending' || connection.status === 'running';
+    const scanTime = (isPending && connection.start_time) || connection.end_time;
 
-    const statusString = t(`table.label_status_${source.connection.status}`, { context: 'sources' });
+    const statusString = t(`table.label_status_${connection.status}`, { context: 'sources' });
     return (
       <Button
         variant={ButtonVariant.link}
@@ -465,7 +465,7 @@ const SourcesListView: React.FunctionComponent = () => {
           setConnectionsSelected(source);
         }}
       >
-        <ContextIcon symbol={ContextIconVariant[source.connection.status]} /> {statusString}{' '}
+        <ContextIcon symbol={ContextIconVariant[connection.status]} /> {statusString}{' '}
         {helpers.getTimeDisplayHowLongAgo(scanTime)}
       </Button>
     );


### PR DESCRIPTION
This change fixes a years-old misleading UI behavior that wrongly implied that the "deep scan" options applied to all source types.

Deep scan options (JBoss EAP/Fuse/WS checkboxes and alternate directories field) are only relevant to the backend API for network-type sources. Previously, these options appeared for all source types, causing confusion when creating scans for satellite, vcenter, openshift, rhacs, or ansible sources.

The scan modal now checks if at least one network source is included and only displays the deep scan section when applicable. This works for both single-source and multi-source scan creation flows.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

## Demo video

https://github.com/user-attachments/assets/f78abcdc-ed72-4e59-bb23-8b889f72ddc8

## Summary by Sourcery

Restrict deep scan options in the source scan modal to network-type sources and adjust related UI behavior accordingly.

Bug Fixes:
- Prevent deep scan checkboxes from appearing for non-network sources in the scan creation modal.
- Hide the search directories field when deep scan options are not applicable to the selected sources.

Tests:
- Add tests covering deep scan visibility for network, non-network, mixed, and undefined source selections, including conditional display of the search directories field.