### PR TITLE
chore(release): 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quipucords-ui",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quipucords-ui",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@patternfly/patternfly": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quipucords-ui",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Quipucords UI",
   "author": "Red Hat",
   "license": "GPL-3.0",


### PR DESCRIPTION
Note: This branch builds on top of `update-dependencies` and should wait for https://github.com/quipucords/quipucords-ui/pull/959 to merge first.

## Summary by Sourcery

Prepare the project for the 2.6.1 release.

Enhancements:
- Update base UBI Node.js and Nginx container images to newer digests.
- Enable the ESLint rule to warn when setting state inside React effects.

Build:
- Bump the application version to 2.6.1 in package.json.