### PR TITLE
test: Ensure Jenkins runs on known OpenStack images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library("smqe-shared-lib@master") _
 
-node("discovery_ci && fedora") {
+node("openstack && discovery_ci && fedora") {
   withEnv(["DYNACONF_camayoc__use_uiv2=True"]) {
     timestamps {
       stage("[fedora] Setup test environment") {


### PR DESCRIPTION
This ensures CI jobs are picked by OpenStack, which is known to work. This is temporary as we transition to AWS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build execution requirements to ensure pipelines run on the appropriate infrastructure.
  * Test setup, execution, and artifact handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->