### PR TITLE
refactor: migrate all modals from deprecated PatternFly Modal API

### DIFF
--- a/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
+++ b/src/views/credentials/__tests__/__snapshots__/addCredentialModal.test.tsx.snap
@@ -11,33 +11,30 @@ exports[`AddCredentialModal should call onSubmit with the correct filtered data 
 
 exports[`AddCredentialModal should render a basic component: basic 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_v_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
+  variant="small"
+>
+  <ModalHeader
+    labelId="_r_v_"
+    title="t([
   "view.credentials.modal-title.add",
   {
     "type": ""
   }
 ])"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="small"
->
-  <CredentialForm
-    onClearErrors={[Function]}
-    onClose={[Function]}
-    onSubmit={[Function]}
   />
+  <ModalBody>
+    <CredentialForm
+      onClearErrors={[Function]}
+      onClose={[Function]}
+      onSubmit={[Function]}
+    />
+  </ModalBody>
 </Modal>
 `;
 
@@ -2414,9 +2411,9 @@ exports[`CredentialForm should submit updated credential data: edit credential f
   "view.credentials.add-modal.become_password.label"
 ])</span></label>&nbsp;&nbsp;</div><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-input-group"><div class="pf-v6-c-input-group__item pf-m-fill"><span class="pf-v6-c-form-control"><input id="become_password" aria-invalid="false" placeholder="t([
   &quot;view.credentials.add-modal.become_password.placeholder&quot;
-])" data-ouia-component-type="PF6/TextInput" data-ouia-safe="true" data-ouia-component-id="become_password" type="password" value="" name="become_password"></span></div></div></div></div><div class="pf-v6-c-form__group pf-m-action"><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-form__actions"><button class="pf-v6-c-button pf-m-primary" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-primary-_r_7s_"><span class="pf-v6-c-button__text">t([
+])" data-ouia-component-type="PF6/TextInput" data-ouia-safe="true" data-ouia-component-id="become_password" type="password" value="" name="become_password"></span></div></div></div></div><div class="pf-v6-c-form__group pf-m-action"><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-form__actions"><button class="pf-v6-c-button pf-m-primary" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-primary-_r_80_"><span class="pf-v6-c-button__text">t([
   "view.credentials.add-modal.actions.save"
-])</span></button><button class="pf-v6-c-button pf-m-link" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-_r_7t_"><span class="pf-v6-c-button__text">t([
+])</span></button><button class="pf-v6-c-button pf-m-link" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-_r_81_"><span class="pf-v6-c-button__text">t([
   "view.credentials.add-modal.actions.cancel"
 ])</span></button></div></div></div></form>"
 `;
@@ -2452,9 +2449,9 @@ exports[`CredentialForm should work with default onClose: onClose 1`] = `
   "view.credentials.add-modal.become_password.label"
 ])</span></label>&nbsp;&nbsp;</div><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-input-group"><div class="pf-v6-c-input-group__item pf-m-fill"><span class="pf-v6-c-form-control"><input id="become_password" aria-invalid="false" placeholder="t([
   &quot;view.credentials.add-modal.become_password.placeholder&quot;
-])" data-ouia-component-type="PF6/TextInput" data-ouia-safe="true" data-ouia-component-id="become_password" type="password" name="become_password"></span></div></div></div></div><div class="pf-v6-c-form__group pf-m-action"><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-form__actions"><button class="pf-v6-c-button pf-m-primary" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-primary-_r_6c_"><span class="pf-v6-c-button__text">t([
+])" data-ouia-component-type="PF6/TextInput" data-ouia-safe="true" data-ouia-component-id="become_password" type="password" name="become_password"></span></div></div></div></div><div class="pf-v6-c-form__group pf-m-action"><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-form__actions"><button class="pf-v6-c-button pf-m-primary" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-primary-_r_6g_"><span class="pf-v6-c-button__text">t([
   "view.credentials.add-modal.actions.save"
-])</span></button><button class="pf-v6-c-button pf-m-link" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-_r_6d_"><span class="pf-v6-c-button__text">t([
+])</span></button><button class="pf-v6-c-button pf-m-link" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-_r_6h_"><span class="pf-v6-c-button__text">t([
   "view.credentials.add-modal.actions.cancel"
 ])</span></button></div></div></div></form>"
 `;
@@ -2490,9 +2487,9 @@ exports[`CredentialForm should work with default onSubmit: onSave 1`] = `
   "view.credentials.add-modal.become_password.label"
 ])</span></label>&nbsp;&nbsp;</div><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-input-group"><div class="pf-v6-c-input-group__item pf-m-fill"><span class="pf-v6-c-form-control"><input id="become_password" aria-invalid="false" placeholder="t([
   &quot;view.credentials.add-modal.become_password.placeholder&quot;
-])" data-ouia-component-type="PF6/TextInput" data-ouia-safe="true" data-ouia-component-id="become_password" type="password" name="become_password"></span></div></div></div></div><div class="pf-v6-c-form__group pf-m-action"><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-form__actions"><button class="pf-v6-c-button pf-m-primary" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-primary-_r_77_"><span class="pf-v6-c-button__text">t([
+])" data-ouia-component-type="PF6/TextInput" data-ouia-safe="true" data-ouia-component-id="become_password" type="password" name="become_password"></span></div></div></div></div><div class="pf-v6-c-form__group pf-m-action"><div class="pf-v6-c-form__group-control"><div class="pf-v6-c-form__actions"><button class="pf-v6-c-button pf-m-primary" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-primary-_r_7b_"><span class="pf-v6-c-button__text">t([
   "view.credentials.add-modal.actions.save"
-])</span></button><button class="pf-v6-c-button pf-m-link" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-_r_78_"><span class="pf-v6-c-button__text">t([
+])</span></button><button class="pf-v6-c-button pf-m-link" type="button" data-ouia-component-type="PF6/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-_r_7c_"><span class="pf-v6-c-button__text">t([
   "view.credentials.add-modal.actions.cancel"
 ])</span></button></div></div></div></form>"
 `;

--- a/src/views/credentials/addCredentialModal.tsx
+++ b/src/views/credentials/addCredentialModal.tsx
@@ -11,12 +11,15 @@ import {
   Form,
   FormGroup,
   FormHelperText,
-  TextArea,
-  TextInput,
   HelperText,
-  HelperTextItem
+  HelperTextItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+  TextArea,
+  TextInput
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { SecretInput } from '../../components/secretInput/secretInput';
 import { SimpleDropdown } from '../../components/simpleDropdown/simpleDropdown';
@@ -763,24 +766,26 @@ const AddCredentialModal: React.FC<AddCredentialModalProps> = ({
   onClearErrors = () => {}
 }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   return (
-    <Modal
-      variant={ModalVariant.small}
-      title={
-        (credential && t('view.credentials.modal-title.edit', { name: credential.name || '' })) ||
-        t('view.credentials.modal-title.add', { type: credentialType || '' })
-      }
-      isOpen={isOpen}
-      onClose={() => onClose()}
-    >
-      <CredentialForm
-        credential={credential}
-        credentialType={credentialType}
-        errors={errors}
-        onClose={onClose}
-        onSubmit={onSubmit}
-        onClearErrors={onClearErrors}
+    <Modal variant={ModalVariant.small} isOpen={isOpen} aria-labelledby={titleId} onClose={() => onClose()}>
+      <ModalHeader
+        title={
+          (credential && t('view.credentials.modal-title.edit', { name: credential.name || '' })) ||
+          t('view.credentials.modal-title.add', { type: credentialType || '' })
+        }
+        labelId={titleId}
       />
+      <ModalBody>
+        <CredentialForm
+          credential={credential}
+          credentialType={credentialType}
+          errors={errors}
+          onClose={onClose}
+          onSubmit={onSubmit}
+          onClearErrors={onClearErrors}
+        />
+      </ModalBody>
     </Modal>
   );
 };

--- a/src/views/credentials/viewCredentialsList.tsx
+++ b/src/views/credentials/viewCredentialsList.tsx
@@ -22,12 +22,16 @@ import {
   EmptyStateFooter,
   List,
   ListItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
   PageSection,
   ToolbarContent,
   ToolbarItem,
   getUniqueId
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import ActionMenu from '../../components/actionMenu/actionMenu';
 import { ErrorMessage } from '../../components/errorMessage/errorMessage';
@@ -52,6 +56,8 @@ import { useCredentialsQuery } from './useCredentialsQuery';
 
 const CredentialsListView: React.FunctionComponent = () => {
   const { t } = useTranslation();
+  const sourcesModalTitleId = React.useId();
+  const deleteModalTitleId = React.useId();
   const [refreshTime, setRefreshTime] = React.useState<Date | null>();
   const [sourcesSelected, setSourcesSelected] = React.useState<SourceResponse[]>([]);
   const [pendingDeleteCredential, setPendingDeleteCredential] = React.useState<CredentialResponse>();
@@ -451,10 +457,22 @@ const CredentialsListView: React.FunctionComponent = () => {
       <Pagination variant="bottom" widgetId="server-paginated-example-pagination" />
       <Modal
         variant={ModalVariant.small}
-        title={t('form-dialog.label', { context: 'sources' })}
         isOpen={sourcesSelected.length > 0}
+        aria-labelledby={sourcesModalTitleId}
         onClose={() => setSourcesSelected([])}
-        actions={[
+      >
+        <ModalHeader title={t('form-dialog.label', { context: 'sources' })} labelId={sourcesModalTitleId} />
+        <ModalBody>
+          <List isPlain isBordered>
+            {sourcesSelected
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map(c => (
+                <ListItem key={c.name}>{c.name}</ListItem>
+              ))}
+          </List>
+          {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
+        </ModalBody>
+        <ModalFooter>
           <Button
             key="confirm"
             variant="secondary"
@@ -464,23 +482,25 @@ const CredentialsListView: React.FunctionComponent = () => {
           >
             {t('table.label', { context: 'close' })}
           </Button>
-        ]}
-      >
-        <List isPlain isBordered>
-          {sourcesSelected
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map(c => (
-              <ListItem key={c.name}>{c.name}</ListItem>
-            ))}
-        </List>
-        {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
+        </ModalFooter>
       </Modal>
       <Modal
         variant={ModalVariant.small}
-        title={t('form-dialog.confirmation', { context: 'title_delete-credential' })}
         isOpen={pendingDeleteCredential !== undefined}
+        aria-labelledby={deleteModalTitleId}
         onClose={() => setPendingDeleteCredential(undefined)}
-        actions={[
+      >
+        <ModalHeader
+          title={t('form-dialog.confirmation', { context: 'title_delete-credential' })}
+          labelId={deleteModalTitleId}
+        />
+        <ModalBody>
+          {t('form-dialog.confirmation_heading', {
+            context: 'delete-credential',
+            name: pendingDeleteCredential?.name
+          })}
+        </ModalBody>
+        <ModalFooter>
           <Button
             key="confirm"
             variant="danger"
@@ -493,16 +513,11 @@ const CredentialsListView: React.FunctionComponent = () => {
             }}
           >
             {t('table.label', { context: 'delete' })}
-          </Button>,
+          </Button>
           <Button key="cancel" variant="link" onClick={() => setPendingDeleteCredential(undefined)}>
             {t('form-dialog.label', { context: 'cancel' })}
           </Button>
-        ]}
-      >
-        {t('form-dialog.confirmation_heading', {
-          context: 'delete-credential',
-          name: pendingDeleteCredential?.name
-        })}
+        </ModalFooter>
       </Modal>
       <AddCredentialModal
         isOpen={editCredentialForm.isOpen}

--- a/src/views/reports/viewReportsList.tsx
+++ b/src/views/reports/viewReportsList.tsx
@@ -18,12 +18,15 @@ import {
   Content,
   EmptyState,
   EmptyStateBody,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
   PageSection,
   ToolbarContent,
   ToolbarItem,
   getUniqueId
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { ConnectedIcon, DisconnectedIcon } from '@patternfly/react-icons';
 import ActionMenu from '../../components/actionMenu/actionMenu';
 import { ErrorMessage } from '../../components/errorMessage/errorMessage';
@@ -48,6 +51,7 @@ import { useReportsQuery } from './useReportsQuery';
 
 const ReportsListView: React.FunctionComponent = () => {
   const { t } = useTranslation();
+  const lightspeedModalTitleId = React.useId();
   const [refreshTime, setRefreshTime] = React.useState<Date | null>();
   const { queryClient } = useQueryClientConfig();
   const { alerts, addAlert, removeAlert } = useAlerts();
@@ -346,14 +350,20 @@ const ReportsListView: React.FunctionComponent = () => {
       <Pagination variant="bottom" widgetId="reports-pagination-bottom" />
       <Modal
         variant={ModalVariant.small}
-        title={t('external-auth.lightspeed.modal', { context: 'title-not-logged-in' })}
         isOpen={lightspeedAuthModal}
+        aria-labelledby={lightspeedModalTitleId}
         onClose={() => {
           setLightspeedAuthModal(false);
           cancelLightspeedAuth();
         }}
       >
-        <LightspeedAuth lightspeedAuthFlowState={lightspeedAuthFlowState} />
+        <ModalHeader
+          title={t('external-auth.lightspeed.modal', { context: 'title-not-logged-in' })}
+          labelId={lightspeedModalTitleId}
+        />
+        <ModalBody>
+          <LightspeedAuth lightspeedAuthFlowState={lightspeedAuthFlowState} />
+        </ModalBody>
       </Modal>
       <AlertGroup isToast isLiveRegion>
         {alerts.map(({ id, variant, title }) => (

--- a/src/views/scans/__tests__/__snapshots__/mergeReportsModal.test.tsx.snap
+++ b/src/views/scans/__tests__/__snapshots__/mergeReportsModal.test.tsx.snap
@@ -2,136 +2,127 @@
 
 exports[`MergeReportsModal should render a basic component: basic 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_0_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
+  variant="medium"
+>
+  <ModalHeader
+    labelId="_r_0_"
+    title="t([
   "merge.modal",
   {
     "context": "title"
   }
 ])"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="medium"
->
-  <Bullseye>
-    <EmptyState
-      headingLevel="h2"
-      icon={[Function]}
-      titleText="t([
+  />
+  <ModalBody>
+    <Bullseye>
+      <EmptyState
+        headingLevel="h2"
+        icon={[Function]}
+        titleText="t([
   "merge.modal",
   {
     "context": "body-in-progress"
   }
 ])"
-    />
-  </Bullseye>
+      />
+    </Bullseye>
+  </ModalBody>
 </Modal>
 `;
 
 exports[`MergeReportsModal should render a component after merge failed: errored 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_2_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
+  variant="medium"
+>
+  <ModalHeader
+    labelId="_r_2_"
+    title="t([
   "merge.modal",
   {
     "context": "title"
   }
 ])"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="medium"
->
-  <Bullseye>
-    <EmptyState
-      headingLevel="h2"
-      icon={[Function]}
-      titleText="t([
+  />
+  <ModalBody>
+    <Bullseye>
+      <EmptyState
+        headingLevel="h2"
+        icon={[Function]}
+        titleText="t([
   "merge.modal",
   {
     "context": "header-errored"
   }
 ])"
-    >
-      <EmptyStateBody>
-        t([
+      >
+        <EmptyStateBody>
+          t([
   "merge.modal",
   {
     "context": "body-errored",
     "msg": "Lorem ipsum dolor sit"
   }
 ])
-      </EmptyStateBody>
-    </EmptyState>
-  </Bullseye>
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  </ModalBody>
 </Modal>
 `;
 
 exports[`MergeReportsModal should render a component after merge succeeded: success 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_1_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
+  variant="medium"
+>
+  <ModalHeader
+    labelId="_r_1_"
+    title="t([
   "merge.modal",
   {
     "context": "title"
   }
 ])"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="medium"
->
-  <Bullseye>
-    <EmptyState
-      headingLevel="h2"
-      icon={[Function]}
-      titleText="t([
+  />
+  <ModalBody>
+    <Bullseye>
+      <EmptyState
+        headingLevel="h2"
+        icon={[Function]}
+        titleText="t([
   "merge.modal",
   {
     "context": "header-successful"
   }
 ])"
-    >
-      <EmptyStateBody>
-        t([
+      >
+        <EmptyStateBody>
+          t([
   "merge.modal",
   {
     "context": "body-successful"
   }
 ])
-      </EmptyStateBody>
-    </EmptyState>
-  </Bullseye>
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  </ModalBody>
 </Modal>
 `;

--- a/src/views/scans/__tests__/__snapshots__/showAggregateReportModal.test.tsx.snap
+++ b/src/views/scans/__tests__/__snapshots__/showAggregateReportModal.test.tsx.snap
@@ -40,45 +40,42 @@ exports[`ShowAggregateReportModal should have a consistent title: title 1`] = `
 
 exports[`ShowAggregateReportModal should render a basic component: basic 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_5_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
+  variant="small"
+>
+  <ModalHeader
+    labelId="_r_5_"
+    title="t([
   "modal.title",
   {
     "context": "scan-summary"
   }
 ])"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="small"
->
-  <Title
-    className="pf-v6-u-mb-lg"
-    headingLevel="h2"
-    size="md"
-  >
-    t([
+  />
+  <ModalBody>
+    <Title
+      className="pf-v6-u-mb-lg"
+      headingLevel="h2"
+      size="md"
+    >
+      t([
   "modal.subtitle",
   {
     "context": "scan-id"
   }
 ])
-  </Title>
-  <DescriptionList
-    isCompact={true}
-    isFluid={true}
-    isHorizontal={true}
-  />
+    </Title>
+    <DescriptionList
+      isCompact={true}
+      isFluid={true}
+      isHorizontal={true}
+    />
+  </ModalBody>
 </Modal>
 `;
 

--- a/src/views/scans/__tests__/__snapshots__/showScansModal.test.tsx.snap
+++ b/src/views/scans/__tests__/__snapshots__/showScansModal.test.tsx.snap
@@ -24,38 +24,35 @@ exports[`ShowScansModal should have the correct title: title 1`] = `
 
 exports[`ShowScansModal should render a basic component: basic 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_8_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
+  variant="medium"
+>
+  <ModalHeader
+    labelId="_r_8_"
+    title="t([
   "view.label",
   {
     "context": "scans-names",
     "name": "Lorem ipsum"
   }
 ])"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="medium"
->
-  <Bullseye>
-    <EmptyState
-      headingLevel="h2"
-      icon={[Function]}
-      titleText="t([
+  />
+  <ModalBody>
+    <Bullseye>
+      <EmptyState
+        headingLevel="h2"
+        icon={[Function]}
+        titleText="t([
   "view.scans.show-modal.loading"
 ])"
-    />
-  </Bullseye>
+      />
+    </Bullseye>
+  </ModalBody>
 </Modal>
 `;
 

--- a/src/views/scans/mergeReportsModal.tsx
+++ b/src/views/scans/mergeReportsModal.tsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Bullseye, EmptyState, EmptyStateBody, Spinner } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+  Spinner
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon, CheckCircleIcon } from '@patternfly/react-icons';
 import { useMergeReportsApi } from '../../hooks/useScanApi';
 
@@ -19,6 +27,7 @@ const MergeReportsModal: React.FC<MergeReportsModalProps> = ({
   onSuccess = Function.prototype
 }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   const { requestReportsMerge, cancelReportsMerge, mergeProcessState } = useMergeReportsApi();
   // Workaround the following problem:
   // 1. onSuccess is called. This causes report to download and sets reportIdsToMerge to []
@@ -47,48 +56,46 @@ const MergeReportsModal: React.FC<MergeReportsModalProps> = ({
   }, [mergeProcessState, onSuccess]);
 
   return (
-    <Modal
-      variant={ModalVariant.medium}
-      title={t('merge.modal', { context: 'title' })}
-      isOpen={isOpen}
-      onClose={() => onClose()}
-    >
-      {mergeProcessState.state === 'InProgress' && (
-        <Bullseye>
-          <EmptyState
-            headingLevel="h2"
-            icon={Spinner}
-            titleText={t('merge.modal', { context: 'body-in-progress' })}
-          ></EmptyState>
-        </Bullseye>
-      )}
-      {mergeProcessState.state === 'Successful' && (
-        <Bullseye>
-          <EmptyState
-            headingLevel="h2"
-            icon={CheckCircleIcon}
-            titleText={t('merge.modal', { context: 'header-successful' })}
-          >
-            <EmptyStateBody>{t('merge.modal', { context: 'body-successful' })}</EmptyStateBody>
-          </EmptyState>
-        </Bullseye>
-      )}
-      {mergeProcessState.state === 'Errored' && (
-        <Bullseye>
-          <EmptyState
-            headingLevel="h2"
-            icon={ExclamationCircleIcon}
-            titleText={t('merge.modal', { context: 'header-errored' })}
-          >
-            <EmptyStateBody>
-              {t('merge.modal', {
-                context: 'body-errored',
-                msg: mergeProcessState.errorMessage
-              })}
-            </EmptyStateBody>
-          </EmptyState>
-        </Bullseye>
-      )}
+    <Modal variant={ModalVariant.medium} isOpen={isOpen} aria-labelledby={titleId} onClose={() => onClose()}>
+      <ModalHeader title={t('merge.modal', { context: 'title' })} labelId={titleId} />
+      <ModalBody>
+        {mergeProcessState.state === 'InProgress' && (
+          <Bullseye>
+            <EmptyState
+              headingLevel="h2"
+              icon={Spinner}
+              titleText={t('merge.modal', { context: 'body-in-progress' })}
+            ></EmptyState>
+          </Bullseye>
+        )}
+        {mergeProcessState.state === 'Successful' && (
+          <Bullseye>
+            <EmptyState
+              headingLevel="h2"
+              icon={CheckCircleIcon}
+              titleText={t('merge.modal', { context: 'header-successful' })}
+            >
+              <EmptyStateBody>{t('merge.modal', { context: 'body-successful' })}</EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        )}
+        {mergeProcessState.state === 'Errored' && (
+          <Bullseye>
+            <EmptyState
+              headingLevel="h2"
+              icon={ExclamationCircleIcon}
+              titleText={t('merge.modal', { context: 'header-errored' })}
+            >
+              <EmptyStateBody>
+                {t('merge.modal', {
+                  context: 'body-errored',
+                  msg: mergeProcessState.errorMessage
+                })}
+              </EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        )}
+      </ModalBody>
     </Modal>
   );
 };

--- a/src/views/scans/showAggregateReportModal.tsx
+++ b/src/views/scans/showAggregateReportModal.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DescriptionList,
-  DescriptionListTerm,
   DescriptionListDescription,
   DescriptionListGroup,
+  DescriptionListTerm,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
   Title
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { helpers } from '../../helpers';
 import { type ReportAggregateDiagnosticsType, type ReportAggregateResultsType } from '../../types/types';
 
@@ -81,29 +85,28 @@ const ShowAggregateReportModal: React.FC<ShowAggregateReportModalProps> = ({
   actions
 }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   const stats = formatSortFilterReportStats(report?.report);
 
   return (
-    <Modal
-      variant={ModalVariant.small}
-      title={t('modal.title', { context: 'scan-summary' })}
-      isOpen={isOpen}
-      onClose={() => onClose()}
-      {...(actions && { actions })}
-    >
-      <Title className="pf-v6-u-mb-lg" headingLevel="h2" size="md">
-        {t('modal.subtitle', { context: 'scan-id', value: report?.id })}
-      </Title>
-      <DescriptionList isHorizontal isFluid isCompact>
-        {stats.map(([key, value]) => {
-          return (
-            <DescriptionListGroup data-ouia-component-id={key} key={key}>
-              <DescriptionListTerm>{t('modal.label', { context: key })}</DescriptionListTerm>
-              <DescriptionListDescription>{value}</DescriptionListDescription>
-            </DescriptionListGroup>
-          );
-        })}
-      </DescriptionList>
+    <Modal variant={ModalVariant.small} isOpen={isOpen} aria-labelledby={titleId} onClose={() => onClose()}>
+      <ModalHeader title={t('modal.title', { context: 'scan-summary' })} labelId={titleId} />
+      <ModalBody>
+        <Title className="pf-v6-u-mb-lg" headingLevel="h2" size="md">
+          {t('modal.subtitle', { context: 'scan-id', value: report?.id })}
+        </Title>
+        <DescriptionList isHorizontal isFluid isCompact>
+          {stats.map(([key, value]) => {
+            return (
+              <DescriptionListGroup data-ouia-component-id={key} key={key}>
+                <DescriptionListTerm>{t('modal.label', { context: key })}</DescriptionListTerm>
+                <DescriptionListDescription>{value}</DescriptionListDescription>
+              </DescriptionListGroup>
+            );
+          })}
+        </DescriptionList>
+      </ModalBody>
+      {actions && <ModalFooter>{actions}</ModalFooter>}
     </Modal>
   );
 };

--- a/src/views/scans/showScansModal.tsx
+++ b/src/views/scans/showScansModal.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Bullseye, Button, EmptyState, Spinner } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Bullseye,
+  Button,
+  EmptyState,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Spinner
+} from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tr, Th, Tbody, Td, type ThProps } from '@patternfly/react-table';
 import { helpers } from '../../helpers';
@@ -71,6 +80,7 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
   actions
 }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   const [activeSortIndex, setActiveSortIndex] = useState<number | undefined>();
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc' | undefined>();
   const [sortedScanJobs, setSortedScanJobs] = useState<PartialScanJob[]>([]);
@@ -97,53 +107,51 @@ const ShowScansModal: React.FC<ShowScansModalProps> = ({
   });
 
   return (
-    <Modal
-      variant={ModalVariant.medium}
-      title={t('view.label', { context: 'scans-names', name: scan?.name })}
-      isOpen={isOpen}
-      onClose={() => onClose()}
-      {...(actions && { actions })}
-    >
-      {sortedScanJobs.length ? (
-        <React.Fragment>
-          <div>{t('view.scans.show-modal.title', { count: sortedScanJobs.length })}</div>
-          <br />
-          <Table aria-label={t('view.scans.show-modal.aria-table')} ouiaId="scan_jobs_table">
-            <Thead>
-              <Tr>
-                <Th sort={getSortParams(0)} data-ouia-component-id="header_scan_time">
-                  {t('view.scans.show-modal.scan-time')}
-                </Th>
-                <Th sort={getSortParams(1)} data-ouia-component-id="header_scan_result">
-                  {t('view.scans.show-modal.scan-result')}
-                </Th>
-                <Th screenReaderText={t('view.scans.show-modal.scan-download-screenreader')}></Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {sortedScanJobs.map(job => (
-                <Tr key={job.id}>
-                  <Td dataLabel={t('view.scans.show-modal.scan-time')}>
-                    {helpers.formatDate(job.end_time || job.start_time)}
-                  </Td>
-                  <Td dataLabel={t('view.scans.show-modal.scan-result')}>{job.status}</Td>
-                  <Td dataLabel={t('view.scans.show-modal.scan-download')} isActionCell>
-                    {helpers.canAccessMostRecentReport(job) && (
-                      <Button onClick={() => onDownload(job.report_id)} icon={<DownloadIcon />} variant="link">
-                        {t('view.scans.show-modal.scan-download')}
-                      </Button>
-                    )}
-                  </Td>
+    <Modal variant={ModalVariant.medium} isOpen={isOpen} aria-labelledby={titleId} onClose={() => onClose()}>
+      <ModalHeader title={t('view.label', { context: 'scans-names', name: scan?.name })} labelId={titleId} />
+      <ModalBody>
+        {sortedScanJobs.length ? (
+          <React.Fragment>
+            <div>{t('view.scans.show-modal.title', { count: sortedScanJobs.length })}</div>
+            <br />
+            <Table aria-label={t('view.scans.show-modal.aria-table')} ouiaId="scan_jobs_table">
+              <Thead>
+                <Tr>
+                  <Th sort={getSortParams(0)} data-ouia-component-id="header_scan_time">
+                    {t('view.scans.show-modal.scan-time')}
+                  </Th>
+                  <Th sort={getSortParams(1)} data-ouia-component-id="header_scan_result">
+                    {t('view.scans.show-modal.scan-result')}
+                  </Th>
+                  <Th screenReaderText={t('view.scans.show-modal.scan-download-screenreader')}></Th>
                 </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </React.Fragment>
-      ) : (
-        <Bullseye>
-          <EmptyState headingLevel="h2" icon={Spinner} titleText={t('view.scans.show-modal.loading')}></EmptyState>
-        </Bullseye>
-      )}
+              </Thead>
+              <Tbody>
+                {sortedScanJobs.map(job => (
+                  <Tr key={job.id}>
+                    <Td dataLabel={t('view.scans.show-modal.scan-time')}>
+                      {helpers.formatDate(job.end_time || job.start_time)}
+                    </Td>
+                    <Td dataLabel={t('view.scans.show-modal.scan-result')}>{job.status}</Td>
+                    <Td dataLabel={t('view.scans.show-modal.scan-download')} isActionCell>
+                      {helpers.canAccessMostRecentReport(job) && (
+                        <Button onClick={() => onDownload(job.report_id)} icon={<DownloadIcon />} variant="link">
+                          {t('view.scans.show-modal.scan-download')}
+                        </Button>
+                      )}
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </React.Fragment>
+        ) : (
+          <Bullseye>
+            <EmptyState headingLevel="h2" icon={Spinner} titleText={t('view.scans.show-modal.loading')}></EmptyState>
+          </Bullseye>
+        )}
+      </ModalBody>
+      {actions && <ModalFooter>{actions}</ModalFooter>}
     </Modal>
   );
 };

--- a/src/views/scans/viewScansList.tsx
+++ b/src/views/scans/viewScansList.tsx
@@ -22,13 +22,17 @@ import {
   EmptyStateFooter,
   List,
   ListItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
   PageSection,
   ToolbarContent,
   ToolbarItem,
   Tooltip,
   getUniqueId
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import ActionMenu from '../../components/actionMenu/actionMenu';
 import { ContextIcon, ContextIconVariant } from '../../components/contextIcon/contextIcon';
@@ -61,6 +65,8 @@ import { useScansQuery } from './useScansQuery';
 
 const ScansListView: React.FunctionComponent = () => {
   const { t } = useTranslation();
+  const sourcesModalTitleId = React.useId();
+  const deleteModalTitleId = React.useId();
   const [refreshTime, setRefreshTime] = React.useState<Date | null>();
   const [scanSelectedForSources, setScanSelectedForSources] = React.useState<ScanResponse>();
   const [scanSelected, setScanSelected] = React.useState<ScanResponse>();
@@ -386,10 +392,21 @@ const ScansListView: React.FunctionComponent = () => {
       <Pagination variant="bottom" widgetId="server-paginated-example-pagination" />
       <Modal
         variant={ModalVariant.small}
-        title={t('view.label', { context: 'sources' })}
         isOpen={scanSelectedForSources !== undefined}
+        aria-labelledby={sourcesModalTitleId}
         onClose={() => setScanSelectedForSources(undefined)}
-        actions={[
+      >
+        <ModalHeader title={t('view.label', { context: 'sources' })} labelId={sourcesModalTitleId} />
+        <ModalBody>
+          <List isPlain isBordered>
+            {scanSelectedForSources?.sources
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map(s => (
+                <ListItem key={s.id}>{s.name}</ListItem>
+              ))}
+          </List>
+        </ModalBody>
+        <ModalFooter>
           <Button
             key="confirm"
             variant="secondary"
@@ -399,15 +416,7 @@ const ScansListView: React.FunctionComponent = () => {
           >
             {t('table.label', { context: 'close' })}
           </Button>
-        ]}
-      >
-        <List isPlain isBordered>
-          {scanSelectedForSources?.sources
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map(s => (
-              <ListItem key={s.id}>{s.name}</ListItem>
-            ))}
-        </List>
+        </ModalFooter>
       </Modal>
       <ShowScansModal
         scan={scanSelected}
@@ -452,10 +461,22 @@ const ScansListView: React.FunctionComponent = () => {
       />
       <Modal
         variant={ModalVariant.small}
-        title={t('form-dialog.confirmation', { context: 'title_delete-scan' })}
         isOpen={pendingDeleteScan !== undefined}
+        aria-labelledby={deleteModalTitleId}
         onClose={() => setPendingDeleteScan(undefined)}
-        actions={[
+      >
+        <ModalHeader
+          title={t('form-dialog.confirmation', { context: 'title_delete-scan' })}
+          labelId={deleteModalTitleId}
+        />
+        <ModalBody>
+          {t('form-dialog.confirmation_heading', {
+            context: 'delete-scan',
+            name: pendingDeleteScan?.name
+          })}
+          {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
+        </ModalBody>
+        <ModalFooter>
           <Button
             key="confirm"
             variant="danger"
@@ -469,17 +490,11 @@ const ScansListView: React.FunctionComponent = () => {
             }}
           >
             {t('table.label', { context: 'delete' })}
-          </Button>,
+          </Button>
           <Button key="cancel" variant="link" onClick={() => setPendingDeleteScan(undefined)}>
             {t('form-dialog.label', { context: 'cancel' })}
           </Button>
-        ]}
-      >
-        {t('form-dialog.confirmation_heading', {
-          context: 'delete-scan',
-          name: pendingDeleteScan?.name
-        })}
-        {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
+        </ModalFooter>
       </Modal>
       <AlertGroup isToast isLiveRegion>
         {alerts.map(({ id, variant, title }) => (

--- a/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourceModal.test.tsx.snap
@@ -17,33 +17,30 @@ exports[`AddSourceModal-network should call onSubmit with the correct filtered d
 
 exports[`AddSourceModal-network should render a basic component: basic 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_h_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
+  variant="small"
+>
+  <ModalHeader
+    labelId="_r_h_"
+    title="t([
   "view.sources.modal-title.add",
   {
     "type": ""
   }
 ])"
-  titleIconVariant={null}
-  titleLabel=""
-  variant="small"
->
-  <SourceForm
-    onClearErrors={[Function]}
-    onClose={[Function]}
-    onSubmit={[Function]}
   />
+  <ModalBody>
+    <SourceForm
+      onClearErrors={[Function]}
+      onClose={[Function]}
+      onSubmit={[Function]}
+    />
+  </ModalBody>
 </Modal>
 `;
 

--- a/src/views/sources/__tests__/__snapshots__/addSourcesScanModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/addSourcesScanModal.test.tsx.snap
@@ -28,30 +28,27 @@ exports[`AddSourceModal should call onSubmit with the correct filtered data when
 
 exports[`AddSourceModal should render a basic component: basic 1`] = `
 <Modal
-  actions={[]}
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_f_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="t([
-  "view.sources.modal-title.new-scan"
-])"
-  titleIconVariant={null}
-  titleLabel=""
   variant="small"
 >
-  <ScanForm
-    onClearErrors={[Function]}
-    onClose={[Function]}
-    onSubmit={[Function]}
+  <ModalHeader
+    labelId="_r_f_"
+    title="t([
+  "view.sources.modal-title.new-scan"
+])"
   />
+  <ModalBody>
+    <ScanForm
+      onClearErrors={[Function]}
+      onClose={[Function]}
+      onSubmit={[Function]}
+    />
+  </ModalBody>
 </Modal>
 `;
 
@@ -64,17 +61,16 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
   />
   <div
     class="pf-v6-c-backdrop"
-    id="pf-modal-part-7"
+    id="pf-modal-part-5"
   >
     <div
       class="pf-v6-l-bullseye"
     >
       <div
-        aria-describedby="pf-modal-part-6"
-        aria-labelledby="pf-modal-part-5"
+        aria-labelledby="_r_24_"
         aria-modal="true"
         class="pf-v6-c-modal-box pf-m-sm"
-        data-ouia-component-id="OUIA-Generated-Modal-small-_r_20_"
+        data-ouia-component-id="OUIA-Generated-Modal-small-_r_26_"
         data-ouia-component-type="PF6/ModalContent"
         data-ouia-safe="true"
         id="pf-modal-part-4"
@@ -86,7 +82,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
           <button
             aria-label="Close"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Modal-small-_r_20_-ModalBoxCloseButton"
+            data-ouia-component-id="OUIA-Generated-Modal-small-_r_26_-ModalBoxCloseButton"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             type="button"
@@ -115,7 +111,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
         >
           <h1
             class="pf-v6-c-modal-box__title"
-            id="pf-modal-part-5"
+            id="_r_24_"
           >
             <span
               class="pf-v6-c-modal-box__title-text"
@@ -128,7 +124,6 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
         </header>
         <div
           class="pf-v6-c-modal-box__body"
-          id="pf-modal-part-6"
         >
           <form
             class="pf-v6-c-form"
@@ -267,7 +262,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
   "view.sources.scan-modal.max-concurrency.aria-minus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_27_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_2d_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -318,7 +313,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
                           aria-label="t([
   "view.sources.scan-modal.max-concurrency.aria-input"
 ])"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_29_"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_2f_"
                           data-ouia-component-type="PF6/TextInput"
                           data-ouia-safe="true"
                           name="input"
@@ -335,7 +330,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
   "view.sources.scan-modal.max-concurrency.aria-plus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_2a_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_2g_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -390,7 +385,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
                 >
                   <button
                     class="pf-v6-c-button pf-m-primary"
-                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_2b_"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_2h_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     disabled=""
@@ -406,7 +401,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
                   </button>
                   <button
                     class="pf-v6-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-_r_2c_"
+                    data-ouia-component-id="OUIA-Generated-Button-link-_r_2i_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -439,17 +434,16 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
   />
   <div
     class="pf-v6-c-backdrop"
-    id="pf-modal-part-9"
+    id="pf-modal-part-7"
   >
     <div
       class="pf-v6-l-bullseye"
     >
       <div
-        aria-describedby="pf-modal-part-8"
-        aria-labelledby="pf-modal-part-7"
+        aria-labelledby="_r_39_"
         aria-modal="true"
         class="pf-v6-c-modal-box pf-m-sm"
-        data-ouia-component-id="OUIA-Generated-Modal-small-_r_33_"
+        data-ouia-component-id="OUIA-Generated-Modal-small-_r_3b_"
         data-ouia-component-type="PF6/ModalContent"
         data-ouia-safe="true"
         id="pf-modal-part-6"
@@ -461,7 +455,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
           <button
             aria-label="Close"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Modal-small-_r_33_-ModalBoxCloseButton"
+            data-ouia-component-id="OUIA-Generated-Modal-small-_r_3b_-ModalBoxCloseButton"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             type="button"
@@ -490,7 +484,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
         >
           <h1
             class="pf-v6-c-modal-box__title"
-            id="pf-modal-part-7"
+            id="_r_39_"
           >
             <span
               class="pf-v6-c-modal-box__title-text"
@@ -503,7 +497,6 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
         </header>
         <div
           class="pf-v6-c-modal-box__body"
-          id="pf-modal-part-8"
         >
           <form
             class="pf-v6-c-form"
@@ -642,7 +635,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
   "view.sources.scan-modal.max-concurrency.aria-minus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_3a_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_3i_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -693,7 +686,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
                           aria-label="t([
   "view.sources.scan-modal.max-concurrency.aria-input"
 ])"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_3c_"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_3k_"
                           data-ouia-component-type="PF6/TextInput"
                           data-ouia-safe="true"
                           name="input"
@@ -710,7 +703,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
   "view.sources.scan-modal.max-concurrency.aria-plus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_3d_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_3l_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -765,7 +758,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
                 >
                   <button
                     class="pf-v6-c-button pf-m-primary"
-                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_3e_"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_3m_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     disabled=""
@@ -781,7 +774,7 @@ exports[`Conditional Deep Scan Display should NOT show deep scan options when sc
                   </button>
                   <button
                     class="pf-v6-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-_r_3f_"
+                    data-ouia-component-id="OUIA-Generated-Button-link-_r_3n_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -814,17 +807,16 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
   />
   <div
     class="pf-v6-c-backdrop"
-    id="pf-modal-part-11"
+    id="pf-modal-part-9"
   >
     <div
       class="pf-v6-l-bullseye"
     >
       <div
-        aria-describedby="pf-modal-part-10"
-        aria-labelledby="pf-modal-part-9"
+        aria-labelledby="_r_4f_"
         aria-modal="true"
         class="pf-v6-c-modal-box pf-m-sm"
-        data-ouia-component-id="OUIA-Generated-Modal-small-_r_47_"
+        data-ouia-component-id="OUIA-Generated-Modal-small-_r_4h_"
         data-ouia-component-type="PF6/ModalContent"
         data-ouia-safe="true"
         id="pf-modal-part-8"
@@ -836,7 +828,7 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
           <button
             aria-label="Close"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Modal-small-_r_47_-ModalBoxCloseButton"
+            data-ouia-component-id="OUIA-Generated-Modal-small-_r_4h_-ModalBoxCloseButton"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             type="button"
@@ -865,7 +857,7 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
         >
           <h1
             class="pf-v6-c-modal-box__title"
-            id="pf-modal-part-9"
+            id="_r_4f_"
           >
             <span
               class="pf-v6-c-modal-box__title-text"
@@ -878,7 +870,6 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
         </header>
         <div
           class="pf-v6-c-modal-box__body"
-          id="pf-modal-part-10"
         >
           <form
             class="pf-v6-c-form"
@@ -1015,7 +1006,7 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
   "view.sources.scan-modal.max-concurrency.aria-minus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_4e_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_4o_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -1066,7 +1057,7 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
                           aria-label="t([
   "view.sources.scan-modal.max-concurrency.aria-input"
 ])"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_4g_"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_4q_"
                           data-ouia-component-type="PF6/TextInput"
                           data-ouia-safe="true"
                           name="input"
@@ -1083,7 +1074,7 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
   "view.sources.scan-modal.max-concurrency.aria-plus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_4h_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_4r_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -1138,7 +1129,7 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
                 >
                   <button
                     class="pf-v6-c-button pf-m-primary"
-                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_4i_"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_4s_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     disabled=""
@@ -1154,7 +1145,7 @@ exports[`Conditional Deep Scan Display should NOT show search directories field 
                   </button>
                   <button
                     class="pf-v6-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-_r_4j_"
+                    data-ouia-component-id="OUIA-Generated-Button-link-_r_4t_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -1187,17 +1178,16 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
   />
   <div
     class="pf-v6-c-backdrop"
-    id="pf-modal-part-6"
+    id="pf-modal-part-4"
   >
     <div
       class="pf-v6-l-bullseye"
     >
       <div
-        aria-describedby="pf-modal-part-5"
-        aria-labelledby="pf-modal-part-4"
+        aria-labelledby="_r_1e_"
         aria-modal="true"
         class="pf-v6-c-modal-box pf-m-sm"
-        data-ouia-component-id="OUIA-Generated-Modal-small-_r_1b_"
+        data-ouia-component-id="OUIA-Generated-Modal-small-_r_1g_"
         data-ouia-component-type="PF6/ModalContent"
         data-ouia-safe="true"
         id="pf-modal-part-3"
@@ -1209,7 +1199,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
           <button
             aria-label="Close"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Modal-small-_r_1b_-ModalBoxCloseButton"
+            data-ouia-component-id="OUIA-Generated-Modal-small-_r_1g_-ModalBoxCloseButton"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             type="button"
@@ -1238,7 +1228,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
         >
           <h1
             class="pf-v6-c-modal-box__title"
-            id="pf-modal-part-4"
+            id="_r_1e_"
           >
             <span
               class="pf-v6-c-modal-box__title-text"
@@ -1251,7 +1241,6 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
         </header>
         <div
           class="pf-v6-c-modal-box__body"
-          id="pf-modal-part-5"
         >
           <form
             class="pf-v6-c-form"
@@ -1390,7 +1379,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
   "view.sources.scan-modal.max-concurrency.aria-minus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_1i_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_1n_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -1441,7 +1430,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
                           aria-label="t([
   "view.sources.scan-modal.max-concurrency.aria-input"
 ])"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_1k_"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_1p_"
                           data-ouia-component-type="PF6/TextInput"
                           data-ouia-safe="true"
                           name="input"
@@ -1458,7 +1447,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
   "view.sources.scan-modal.max-concurrency.aria-plus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_1l_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_1q_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -1603,7 +1592,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
                 >
                   <button
                     class="pf-v6-c-button pf-m-primary"
-                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_1t_"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_22_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     disabled=""
@@ -1619,7 +1608,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
                   </button>
                   <button
                     class="pf-v6-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-_r_1u_"
+                    data-ouia-component-id="OUIA-Generated-Button-link-_r_23_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -1652,17 +1641,16 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
   />
   <div
     class="pf-v6-c-backdrop"
-    id="pf-modal-part-8"
+    id="pf-modal-part-6"
   >
     <div
       class="pf-v6-l-bullseye"
     >
       <div
-        aria-describedby="pf-modal-part-7"
-        aria-labelledby="pf-modal-part-6"
+        aria-labelledby="_r_2j_"
         aria-modal="true"
         class="pf-v6-c-modal-box pf-m-sm"
-        data-ouia-component-id="OUIA-Generated-Modal-small-_r_2e_"
+        data-ouia-component-id="OUIA-Generated-Modal-small-_r_2l_"
         data-ouia-component-type="PF6/ModalContent"
         data-ouia-safe="true"
         id="pf-modal-part-5"
@@ -1674,7 +1662,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
           <button
             aria-label="Close"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Modal-small-_r_2e_-ModalBoxCloseButton"
+            data-ouia-component-id="OUIA-Generated-Modal-small-_r_2l_-ModalBoxCloseButton"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             type="button"
@@ -1703,7 +1691,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
         >
           <h1
             class="pf-v6-c-modal-box__title"
-            id="pf-modal-part-6"
+            id="_r_2j_"
           >
             <span
               class="pf-v6-c-modal-box__title-text"
@@ -1716,7 +1704,6 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
         </header>
         <div
           class="pf-v6-c-modal-box__body"
-          id="pf-modal-part-7"
         >
           <form
             class="pf-v6-c-form"
@@ -1855,7 +1842,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
   "view.sources.scan-modal.max-concurrency.aria-minus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_2l_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_2s_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -1906,7 +1893,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
                           aria-label="t([
   "view.sources.scan-modal.max-concurrency.aria-input"
 ])"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_2n_"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_2u_"
                           data-ouia-component-type="PF6/TextInput"
                           data-ouia-safe="true"
                           name="input"
@@ -1923,7 +1910,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
   "view.sources.scan-modal.max-concurrency.aria-plus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_2o_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_2v_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -2068,7 +2055,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
                 >
                   <button
                     class="pf-v6-c-button pf-m-primary"
-                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_30_"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_37_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     disabled=""
@@ -2084,7 +2071,7 @@ exports[`Conditional Deep Scan Display should show deep scan options when scanni
                   </button>
                   <button
                     class="pf-v6-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-_r_31_"
+                    data-ouia-component-id="OUIA-Generated-Button-link-_r_38_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     type="button"
@@ -2117,17 +2104,16 @@ exports[`Conditional Deep Scan Display should show search directories field when
   />
   <div
     class="pf-v6-c-backdrop"
-    id="pf-modal-part-10"
+    id="pf-modal-part-8"
   >
     <div
       class="pf-v6-l-bullseye"
     >
       <div
-        aria-describedby="pf-modal-part-9"
-        aria-labelledby="pf-modal-part-8"
+        aria-labelledby="_r_3o_"
         aria-modal="true"
         class="pf-v6-c-modal-box pf-m-sm"
-        data-ouia-component-id="OUIA-Generated-Modal-small-_r_3h_"
+        data-ouia-component-id="OUIA-Generated-Modal-small-_r_3q_"
         data-ouia-component-type="PF6/ModalContent"
         data-ouia-safe="true"
         id="pf-modal-part-7"
@@ -2139,7 +2125,7 @@ exports[`Conditional Deep Scan Display should show search directories field when
           <button
             aria-label="Close"
             class="pf-v6-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Modal-small-_r_3h_-ModalBoxCloseButton"
+            data-ouia-component-id="OUIA-Generated-Modal-small-_r_3q_-ModalBoxCloseButton"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
             type="button"
@@ -2168,7 +2154,7 @@ exports[`Conditional Deep Scan Display should show search directories field when
         >
           <h1
             class="pf-v6-c-modal-box__title"
-            id="pf-modal-part-8"
+            id="_r_3o_"
           >
             <span
               class="pf-v6-c-modal-box__title-text"
@@ -2181,7 +2167,6 @@ exports[`Conditional Deep Scan Display should show search directories field when
         </header>
         <div
           class="pf-v6-c-modal-box__body"
-          id="pf-modal-part-9"
         >
           <form
             class="pf-v6-c-form"
@@ -2320,7 +2305,7 @@ exports[`Conditional Deep Scan Display should show search directories field when
   "view.sources.scan-modal.max-concurrency.aria-minus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_3o_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_41_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -2371,7 +2356,7 @@ exports[`Conditional Deep Scan Display should show search directories field when
                           aria-label="t([
   "view.sources.scan-modal.max-concurrency.aria-input"
 ])"
-                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_3q_"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-_r_43_"
                           data-ouia-component-type="PF6/TextInput"
                           data-ouia-safe="true"
                           name="input"
@@ -2388,7 +2373,7 @@ exports[`Conditional Deep Scan Display should show search directories field when
   "view.sources.scan-modal.max-concurrency.aria-plus"
 ])"
                         class="pf-v6-c-button pf-m-control"
-                        data-ouia-component-id="OUIA-Generated-Button-control-_r_3r_"
+                        data-ouia-component-id="OUIA-Generated-Button-control-_r_44_"
                         data-ouia-component-type="PF6/Button"
                         data-ouia-safe="true"
                         type="button"
@@ -2575,7 +2560,7 @@ exports[`Conditional Deep Scan Display should show search directories field when
                 >
                   <button
                     class="pf-v6-c-button pf-m-primary"
-                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_43_"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-_r_4c_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     disabled=""
@@ -2591,7 +2576,7 @@ exports[`Conditional Deep Scan Display should show search directories field when
                   </button>
                   <button
                     class="pf-v6-c-button pf-m-link"
-                    data-ouia-component-id="OUIA-Generated-Button-link-_r_44_"
+                    data-ouia-component-id="OUIA-Generated-Button-link-_r_4d_"
                     data-ouia-component-type="PF6/Button"
                     data-ouia-safe="true"
                     type="button"

--- a/src/views/sources/__tests__/__snapshots__/showSourceConnectionsModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/showSourceConnectionsModal.test.tsx.snap
@@ -10,197 +10,193 @@ exports[`ShowConnectionsModal should have the correct title: title 1`] = `
 
 exports[`ShowConnectionsModal should render a basic component: basic 1`] = `
 <Modal
-  actions={
-    [
-      <Button
-        onClick={[Function]}
-        variant="secondary"
-      >
-        t([
-  "view.sources.show-connections-modal.actions.close"
-])
-      </Button>,
-    ]
-  }
   appendTo={[Function]}
-  aria-describedby=""
-  aria-label=""
-  aria-labelledby=""
-  className=""
-  hasNoBodyWrapper={false}
+  aria-labelledby="_r_f_"
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}
   position="default"
-  showClose={true}
-  title="Lorem ipsum"
-  titleIconVariant={null}
-  titleLabel=""
   variant="small"
 >
-  <Table
-    aria-label="t([
+  <ModalHeader
+    labelId="_r_f_"
+    title="Lorem ipsum"
+  />
+  <ModalBody>
+    <Table
+      aria-label="t([
   "view.sources.show-connections-modal.aria-list"
 ])"
-    hasAnimations={true}
-    isExpandable={true}
-  >
-    <Tbody
-      isExpanded={false}
+      hasAnimations={true}
+      isExpandable={true}
     >
-      <Tr>
-        <Td
-          expand={
-            {
-              "expandId": "failed-expandable",
-              "isExpanded": false,
-              "onToggle": [Function],
-              "rowIndex": 0,
+      <Tbody
+        isExpanded={false}
+      >
+        <Tr>
+          <Td
+            expand={
+              {
+                "expandId": "failed-expandable",
+                "isExpanded": false,
+                "onToggle": [Function],
+                "rowIndex": 0,
+              }
             }
-          }
-          width={10}
-        />
-        <Td
-          width={10}
-        >
-          <Icon
-            status="danger"
+            width={10}
+          />
+          <Td
+            width={10}
           >
-            <ExclamationCircleIcon
-              noDefaultStyle={false}
-            />
-          </Icon>
-        </Td>
-        <Td
-          width={80}
-        >
-          t([
+            <Icon
+              status="danger"
+            >
+              <ExclamationCircleIcon
+                noDefaultStyle={false}
+              />
+            </Icon>
+          </Td>
+          <Td
+            width={80}
+          >
+            t([
   "view.sources.show-connections-modal.failed"
 ])
-        </Td>
-      </Tr>
-      <Tr
+          </Td>
+        </Tr>
+        <Tr
+          isExpanded={false}
+        >
+          <Td />
+          <Td />
+          <Td>
+            <ExpandableRowContent>
+              <List
+                isPlain={true}
+              >
+                <ListItem>
+                  Amet
+                </ListItem>
+              </List>
+            </ExpandableRowContent>
+          </Td>
+        </Tr>
+      </Tbody>
+      <Tbody
         isExpanded={false}
       >
-        <Td />
-        <Td />
-        <Td>
-          <ExpandableRowContent>
-            <List
-              isPlain={true}
-            >
-              <ListItem>
-                Amet
-              </ListItem>
-            </List>
-          </ExpandableRowContent>
-        </Td>
-      </Tr>
-    </Tbody>
-    <Tbody
-      isExpanded={false}
-    >
-      <Tr>
-        <Td
-          expand={
-            {
-              "expandId": "unreachable-expandable",
-              "isExpanded": false,
-              "onToggle": [Function],
-              "rowIndex": 1,
+        <Tr>
+          <Td
+            expand={
+              {
+                "expandId": "unreachable-expandable",
+                "isExpanded": false,
+                "onToggle": [Function],
+                "rowIndex": 1,
+              }
             }
-          }
-          width={10}
-        />
-        <Td
-          width={10}
-        >
-          <Icon
-            status="warning"
+            width={10}
+          />
+          <Td
+            width={10}
           >
-            <ExclamationTriangleIcon
-              noDefaultStyle={false}
-            />
-          </Icon>
-        </Td>
-        <Td
-          width={80}
-        >
-          t([
+            <Icon
+              status="warning"
+            >
+              <ExclamationTriangleIcon
+                noDefaultStyle={false}
+              />
+            </Icon>
+          </Td>
+          <Td
+            width={80}
+          >
+            t([
   "view.sources.show-connections-modal.unreachable"
 ])
-        </Td>
-      </Tr>
-      <Tr
+          </Td>
+        </Tr>
+        <Tr
+          isExpanded={false}
+        >
+          <Td />
+          <Td />
+          <Td>
+            <ExpandableRowContent>
+              <List
+                isPlain={true}
+              >
+                <ListItem>
+                  Ipsum
+                </ListItem>
+              </List>
+            </ExpandableRowContent>
+          </Td>
+        </Tr>
+      </Tbody>
+      <Tbody
         isExpanded={false}
       >
-        <Td />
-        <Td />
-        <Td>
-          <ExpandableRowContent>
-            <List
-              isPlain={true}
-            >
-              <ListItem>
-                Ipsum
-              </ListItem>
-            </List>
-          </ExpandableRowContent>
-        </Td>
-      </Tr>
-    </Tbody>
-    <Tbody
-      isExpanded={false}
-    >
-      <Tr>
-        <Td
-          expand={
-            {
-              "expandId": "successful-expandable",
-              "isExpanded": false,
-              "onToggle": [Function],
-              "rowIndex": 2,
+        <Tr>
+          <Td
+            expand={
+              {
+                "expandId": "successful-expandable",
+                "isExpanded": false,
+                "onToggle": [Function],
+                "rowIndex": 2,
+              }
             }
-          }
-          width={10}
-        />
-        <Td
-          width={10}
-        >
-          <Icon
-            status="success"
+            width={10}
+          />
+          <Td
+            width={10}
           >
-            <CheckCircleIcon
-              noDefaultStyle={false}
-            />
-          </Icon>
-        </Td>
-        <Td
-          width={80}
-        >
-          t([
+            <Icon
+              status="success"
+            >
+              <CheckCircleIcon
+                noDefaultStyle={false}
+              />
+            </Icon>
+          </Td>
+          <Td
+            width={80}
+          >
+            t([
   "view.sources.show-connections-modal.successful"
 ])
-        </Td>
-      </Tr>
-      <Tr
-        isExpanded={false}
-      >
-        <Td />
-        <Td />
-        <Td>
-          <ExpandableRowContent>
-            <List
-              isPlain={true}
-            >
-              <ListItem>
-                Dolor sit
-              </ListItem>
-            </List>
-          </ExpandableRowContent>
-        </Td>
-      </Tr>
-    </Tbody>
-  </Table>
+          </Td>
+        </Tr>
+        <Tr
+          isExpanded={false}
+        >
+          <Td />
+          <Td />
+          <Td>
+            <ExpandableRowContent>
+              <List
+                isPlain={true}
+              >
+                <ListItem>
+                  Dolor sit
+                </ListItem>
+              </List>
+            </ExpandableRowContent>
+          </Td>
+        </Tr>
+      </Tbody>
+    </Table>
+  </ModalBody>
+  <ModalFooter>
+    <Button
+      onClick={[Function]}
+      variant="secondary"
+    >
+      t([
+  "view.sources.show-connections-modal.actions.close"
+])
+    </Button>
+  </ModalFooter>
 </Modal>
 `;

--- a/src/views/sources/addSourceModal.tsx
+++ b/src/views/sources/addSourceModal.tsx
@@ -17,10 +17,13 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
   TextArea,
   TextInput
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { SimpleDropdown } from '../../components/simpleDropdown/simpleDropdown';
 import { TypeaheadCheckboxes } from '../../components/typeAheadCheckboxes/typeaheadCheckboxes';
@@ -615,24 +618,26 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({
   onSubmit = () => {}
 }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   return (
-    <Modal
-      variant={ModalVariant.small}
-      title={
-        (source && t('view.sources.modal-title.edit', { name: source.name || '' })) ||
-        t('view.sources.modal-title.add', { type: sourceType || '' })
-      }
-      isOpen={isOpen}
-      onClose={() => onClose()}
-    >
-      <SourceForm
-        source={source}
-        sourceType={sourceType}
-        errors={errors}
-        onClearErrors={onClearErrors}
-        onClose={onClose}
-        onSubmit={onSubmit}
+    <Modal variant={ModalVariant.small} isOpen={isOpen} aria-labelledby={titleId} onClose={() => onClose()}>
+      <ModalHeader
+        title={
+          (source && t('view.sources.modal-title.edit', { name: source.name || '' })) ||
+          t('view.sources.modal-title.add', { type: sourceType || '' })
+        }
+        labelId={titleId}
       />
+      <ModalBody>
+        <SourceForm
+          source={source}
+          sourceType={sourceType}
+          errors={errors}
+          onClearErrors={onClearErrors}
+          onClose={onClose}
+          onSubmit={onSubmit}
+        />
+      </ModalBody>
     </Modal>
   );
 };

--- a/src/views/sources/addSourcesScanModal.tsx
+++ b/src/views/sources/addSourcesScanModal.tsx
@@ -9,11 +9,14 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
   NumberInput,
   TextArea,
   TextInput
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { helpers } from '../../helpers';
 import { type ScanRequest, type SourceResponse } from '../../types/types';
@@ -367,14 +370,19 @@ const AddSourcesScanModal: React.FC<AddSourcesScanModalProps> = ({
   onSubmit = async () => {}
 }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   return (
-    <Modal
-      variant={ModalVariant.small}
-      title={t('view.sources.modal-title.new-scan')}
-      isOpen={isOpen}
-      onClose={() => onClose()}
-    >
-      <ScanForm sources={sources} errors={errors} onClearErrors={onClearErrors} onClose={onClose} onSubmit={onSubmit} />
+    <Modal variant={ModalVariant.small} isOpen={isOpen} aria-labelledby={titleId} onClose={() => onClose()}>
+      <ModalHeader title={t('view.sources.modal-title.new-scan')} labelId={titleId} />
+      <ModalBody>
+        <ScanForm
+          sources={sources}
+          errors={errors}
+          onClearErrors={onClearErrors}
+          onClose={onClose}
+          onSubmit={onSubmit}
+        />
+      </ModalBody>
     </Modal>
   );
 };

--- a/src/views/sources/showSourceConnectionsModal.tsx
+++ b/src/views/sources/showSourceConnectionsModal.tsx
@@ -6,8 +6,18 @@
  */
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Icon, List, ListItem, Tooltip } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Icon,
+  List,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  Tooltip
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon, CheckCircleIcon } from '@patternfly/react-icons';
 import { Tbody, Tr, Td, Table, ExpandableRowContent } from '@patternfly/react-table';
 import { type SourceResponse, type Connections } from '../../types/types';
@@ -31,6 +41,7 @@ const ShowConnectionsModal: React.FC<ShowConnectionsModalProps> = ({
   connections
 }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   const [expanded, setExpanded] = useState<string[]>([]);
   const onToggle = useCallback(
     section => {
@@ -52,13 +63,89 @@ const ShowConnectionsModal: React.FC<ShowConnectionsModalProps> = ({
   return (
     <Modal
       variant={ModalVariant.small}
-      title={source?.name}
       isOpen={isOpen}
+      aria-labelledby={titleId}
       onClose={() => {
         setExpanded([]);
         return onClose();
       }}
-      actions={[
+    >
+      <ModalHeader title={source?.name} labelId={titleId} />
+      <ModalBody>
+        <Table aria-label={t('view.sources.show-connections-modal.aria-list')} isExpandable hasAnimations>
+          {[
+            {
+              category: 'failed',
+              icon: (
+                <Icon status="danger">
+                  <ExclamationCircleIcon />
+                </Icon>
+              ),
+              label: t('view.sources.show-connections-modal.failed')
+            },
+            {
+              category: 'unreachable',
+              icon: (
+                <Icon status="warning">
+                  <ExclamationTriangleIcon />
+                </Icon>
+              ),
+              label: t('view.sources.show-connections-modal.unreachable')
+            },
+            {
+              category: 'successful',
+              icon: (
+                <Icon status="success">
+                  <CheckCircleIcon />
+                </Icon>
+              ),
+              label: t('view.sources.show-connections-modal.successful')
+            }
+          ].map((obj, rowIndex) => {
+            return (
+              <Tbody key={obj.category} isExpanded={expanded.includes(obj.category)}>
+                <Tr>
+                  <Td
+                    width={10}
+                    expand={{
+                      rowIndex,
+                      isExpanded: expanded.includes(obj.category),
+                      onToggle: () => onToggle(obj.category),
+                      expandId: `${obj.category}-expandable`
+                    }}
+                  />
+                  <Td width={10}>{obj.icon}</Td>
+                  <Td width={80}>{obj.label}</Td>
+                </Tr>
+                <Tr isExpanded={expanded.includes(obj.category)}>
+                  <Td />
+                  <Td />
+                  <Td>
+                    <ExpandableRowContent>
+                      <List isPlain>
+                        {(connections[obj.category]?.length &&
+                          connections[obj.category]
+                            .slice(0, maxHostsPerCategory)
+                            .map(connection => <ListItem key={connection.name}>{connection.name}</ListItem>)) || (
+                          <ListItem>{t('view.sources.show-connections-modal.na')}</ListItem>
+                        )}
+                        {connections[obj.category]?.length > maxHostsPerCategory && (
+                          <ListItem key="more">
+                            <Tooltip content={additionalHostsToolTip(connections[obj.category]?.length)}>
+                              <span>{t('view.sources.show-connections-modal.more')}</span>
+                            </Tooltip>
+                          </ListItem>
+                        )}
+                      </List>
+                    </ExpandableRowContent>
+                  </Td>
+                </Tr>
+              </Tbody>
+            );
+          })}
+        </Table>
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="cancel"
           variant="secondary"
@@ -69,80 +156,7 @@ const ShowConnectionsModal: React.FC<ShowConnectionsModalProps> = ({
         >
           {t('view.sources.show-connections-modal.actions.close')}
         </Button>
-      ]}
-    >
-      <Table aria-label={t('view.sources.show-connections-modal.aria-list')} isExpandable hasAnimations>
-        {[
-          {
-            category: 'failed',
-            icon: (
-              <Icon status="danger">
-                <ExclamationCircleIcon />
-              </Icon>
-            ),
-            label: t('view.sources.show-connections-modal.failed')
-          },
-          {
-            category: 'unreachable',
-            icon: (
-              <Icon status="warning">
-                <ExclamationTriangleIcon />
-              </Icon>
-            ),
-            label: t('view.sources.show-connections-modal.unreachable')
-          },
-          {
-            category: 'successful',
-            icon: (
-              <Icon status="success">
-                <CheckCircleIcon />
-              </Icon>
-            ),
-            label: t('view.sources.show-connections-modal.successful')
-          }
-        ].map((obj, rowIndex) => {
-          return (
-            <Tbody key={obj.category} isExpanded={expanded.includes(obj.category)}>
-              <Tr>
-                <Td
-                  width={10}
-                  expand={{
-                    rowIndex,
-                    isExpanded: expanded.includes(obj.category),
-                    onToggle: () => onToggle(obj.category),
-                    expandId: `${obj.category}-expandable`
-                  }}
-                />
-                <Td width={10}>{obj.icon}</Td>
-                <Td width={80}>{obj.label}</Td>
-              </Tr>
-              <Tr isExpanded={expanded.includes(obj.category)}>
-                <Td />
-                <Td />
-                <Td>
-                  <ExpandableRowContent>
-                    <List isPlain>
-                      {(connections[obj.category]?.length &&
-                        connections[obj.category]
-                          .slice(0, maxHostsPerCategory)
-                          .map(connection => <ListItem key={connection.name}>{connection.name}</ListItem>)) || (
-                        <ListItem>{t('view.sources.show-connections-modal.na')}</ListItem>
-                      )}
-                      {connections[obj.category]?.length > maxHostsPerCategory && (
-                        <ListItem key="more">
-                          <Tooltip content={additionalHostsToolTip(connections[obj.category]?.length)}>
-                            <span>{t('view.sources.show-connections-modal.more')}</span>
-                          </Tooltip>
-                        </ListItem>
-                      )}
-                    </List>
-                  </ExpandableRowContent>
-                </Td>
-              </Tr>
-            </Tbody>
-          );
-        })}
-      </Table>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/views/sources/viewSourcesList.tsx
+++ b/src/views/sources/viewSourcesList.tsx
@@ -21,12 +21,16 @@ import {
   EmptyStateFooter,
   List,
   ListItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
   PageSection,
   ToolbarContent,
   ToolbarItem,
   getUniqueId
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import ActionMenu from '../../components/actionMenu/actionMenu';
 import { ContextIcon, ContextIconVariant } from '../../components/contextIcon/contextIcon';
@@ -61,6 +65,8 @@ import { SOURCES_LIST_QUERY, useSourcesQuery } from './useSourcesQuery';
 
 const SourcesListView: React.FunctionComponent = () => {
   const { t } = useTranslation();
+  const credentialsModalTitleId = React.useId();
+  const deleteModalTitleId = React.useId();
   const [refreshTime, setRefreshTime] = React.useState<Date | null>();
   const [credentialsSelected, setCredentialsSelected] = React.useState<CredentialResponse[]>([]);
   const [scanSelected, setScanSelected] = React.useState<SourceResponse[]>();
@@ -566,10 +572,22 @@ const SourcesListView: React.FunctionComponent = () => {
       <Pagination variant="bottom" widgetId="server-paginated-example-pagination" />
       <Modal
         variant={ModalVariant.small}
-        title={t('view.label', { context: 'credentials' })}
         isOpen={credentialsSelected.length > 0}
+        aria-labelledby={credentialsModalTitleId}
         onClose={() => setCredentialsSelected([])}
-        actions={[
+      >
+        <ModalHeader title={t('view.label', { context: 'credentials' })} labelId={credentialsModalTitleId} />
+        <ModalBody>
+          <List isPlain isBordered>
+            {credentialsSelected
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map(c => (
+                <ListItem key={c.name}>{c.name}</ListItem>
+              ))}
+          </List>
+          {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
+        </ModalBody>
+        <ModalFooter>
           <Button
             key="confirm"
             variant="secondary"
@@ -579,16 +597,7 @@ const SourcesListView: React.FunctionComponent = () => {
           >
             {t('table.label', { context: 'close' })}
           </Button>
-        ]}
-      >
-        <List isPlain isBordered>
-          {credentialsSelected
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map(c => (
-              <ListItem key={c.name}>{c.name}</ListItem>
-            ))}
-        </List>
-        {/* TODO: his modal should go on a list of getting it's own component * check PR #381 for details */}
+        </ModalFooter>
       </Modal>
       <ShowConnectionsModal
         isOpen={connectionsSelected !== undefined}
@@ -598,10 +607,21 @@ const SourcesListView: React.FunctionComponent = () => {
       />
       <Modal
         variant={ModalVariant.small}
-        title={t('form-dialog.confirmation', { context: 'title_delete-source' })}
         isOpen={pendingDeleteSource !== undefined}
+        aria-labelledby={deleteModalTitleId}
         onClose={() => setPendingDeleteSource(undefined)}
-        actions={[
+      >
+        <ModalHeader
+          title={t('form-dialog.confirmation', { context: 'title_delete-source' })}
+          labelId={deleteModalTitleId}
+        />
+        <ModalBody>
+          {t('form-dialog.confirmation_heading', {
+            context: 'delete-source',
+            name: pendingDeleteSource?.name
+          })}
+        </ModalBody>
+        <ModalFooter>
           <Button
             key="confirm"
             variant="danger"
@@ -614,16 +634,11 @@ const SourcesListView: React.FunctionComponent = () => {
             }}
           >
             {t('table.label', { context: 'delete' })}
-          </Button>,
+          </Button>
           <Button key="cancel" variant="link" onClick={() => setPendingDeleteSource(undefined)}>
             {t('form-dialog.label', { context: 'cancel' })}
           </Button>
-        ]}
-      >
-        {t('form-dialog.confirmation_heading', {
-          context: 'delete-source',
-          name: pendingDeleteSource?.name
-        })}
+        </ModalFooter>
       </Modal>
       {/* TODO: Simplify add/edit sources functionality * check PR #380 for details */}
       <AddSourceModal

--- a/tests/__snapshots__/code.test.ts.snap
+++ b/tests/__snapshots__/code.test.ts.snap
@@ -39,10 +39,10 @@ exports[`General code checks should only have specific console.[warn|log|info|er
   "vendor/react-table-batteries/hooks/selection/useSelectionDerivedState.ts:154:        console.warn(",
   "vendor/react-table-batteries/hooks/storage/useStorage.ts:14:    console.error(error);",
   "vendor/react-table-batteries/hooks/storage/useStorage.ts:40:    console.error(error);",
-  "views/credentials/viewCredentialsList.tsx:137:        console.error('Edit credential requires an id');",
-  "views/scans/viewScansList.tsx:324:                                    console.error(err);",
-  "views/sources/viewSourcesList.tsx:211:        console.error('Edit source requires an id');",
-  "views/sources/viewSourcesList.tsx:462:                console.error(err);",
-  "views/sources/viewSourcesList.tsx:660:                console.error(err);",
+  "views/credentials/viewCredentialsList.tsx:143:        console.error('Edit credential requires an id');",
+  "views/scans/viewScansList.tsx:330:                                    console.error(err);",
+  "views/sources/viewSourcesList.tsx:217:        console.error('Edit source requires an id');",
+  "views/sources/viewSourcesList.tsx:468:                console.error(err);",
+  "views/sources/viewSourcesList.tsx:675:                console.error(err);",
 ]
 `;


### PR DESCRIPTION
## Summary

- **Root cause:** The deprecated `Modal` from `@patternfly/react-core/deprecated` passes `inert=""` (empty string) on backdrop elements to block background interaction. React 19 now warns on this: _"Received an empty string for a boolean attribute `inert`. This will treat the attribute as if it were false."_ This warning surfaced in unit tests whenever any component using the deprecated Modal was rendered. Recent example from latest `main`:
  ```
   ● Console

    console.error
      Received an empty string for a boolean attribute `inert`. This will treat the attribute as if it were false. Either pass `false` to silence this warning, or pass `true` if you used an empty string in earlier versions of React to indicate this attribute is true.

      12 |   beforeEach(() => {
      13 |     mockOnClose = jest.fn();
    > 14 |     render(
         |           ^
      15 |       <ShowConnectionsModal
      16 |         connections={{
      17 |           successful: [],

      at setProp (node_modules/react-dom/cjs/react-dom-client.development.js:20222:21)
      at setInitialProperties (node_modules/react-dom/cjs/react-dom-client.development.js:20753:13)
      at completeWork (node_modules/react-dom/cjs/react-dom-client.development.js:12662:18)
      at runWithFiberInDEV (node_modules/react-dom/cjs/react-dom-client.development.js:874:13)
      at completeUnitOfWork (node_modules/react-dom/cjs/react-dom-client.development.js:17777:19)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom-client.development.js:17658:11)
      at workLoopSync (node_modules/react-dom/cjs/react-dom-client.development.js:17469:41)
      at renderRootSync (node_modules/react-dom/cjs/react-dom-client.development.js:17450:11)
      at performWorkOnRoot (node_modules/react-dom/cjs/react-dom-client.development.js:16504:11)
      at performSyncWorkOnRoot (node_modules/react-dom/cjs/react-dom-client.development.js:18972:7)
      at flushSyncWorkAcrossRoots_impl (node_modules/react-dom/cjs/react-dom-client.development.js:18814:21)
      at flushSpawnedWork (node_modules/react-dom/cjs/react-dom-client.development.js:18334:9)
      at commitRoot (node_modules/react-dom/cjs/react-dom-client.development.js:17955:9)
      at performWorkOnRoot (node_modules/react-dom/cjs/react-dom-client.development.js:16667:15)
      at performWorkOnRootViaSchedulerTask (node_modules/react-dom/cjs/react-dom-client.development.js:18957:7)
      at flushActQueue (node_modules/react/cjs/react.development.js:590:34)
      at process.env.NODE_ENV.exports.act (node_modules/react/cjs/react.development.js:884:10)
      at node_modules/@testing-library/react/dist/act-compat.js:46:25
      at renderRoot (node_modules/@testing-library/react/dist/pure.js:189:26)
      at render (node_modules/@testing-library/react/dist/pure.js:291:10)
      at Object.<anonymous> (src/views/sources/__tests__/showSourceConnectionsModal.test.tsx:14:11)
  ```
- Replaced all 11 usages of `Modal`/`ModalVariant` from `@patternfly/react-core/deprecated` with the composable API from `@patternfly/react-core`: `Modal` + `ModalHeader` + `ModalBody` + `ModalFooter`.
- Fixed a secondary accessibility issue discovered during migration: the new composable `Modal` requires an explicit `aria-labelledby` prop; without it, `ModalContent` falls back to pointing `aria-labelledby` at the dialog's own `id`, making the dialog self-labelling and causing `getByLabelText` queries to match the entire dialog element. Added `React.useId()` to each modal and wired `aria-labelledby`/`labelId` between `Modal` and `ModalHeader`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved modal labeling and screen-reader support across credential, source, scan, and report dialogs.

* **UI Improvements**
  * Updated dialogs with clearer header, body, and footer layouts.
  * Preserved existing forms, actions, loading states, and confirmation workflows.

* **Bug Fixes**
  * Updated modal behavior for more consistent opening, closing, cancellation, and delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->