### PR TITLE
fix: silence two React 19 console.error warnings in tests

### DIFF
--- a/src/components/viewLayout/__tests__/__snapshots__/viewLayout.test.tsx.snap
+++ b/src/components/viewLayout/__tests__/__snapshots__/viewLayout.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`ViewLayout should render a basic component: basic 1`] = `
                   "default": "36px",
                 }
               }
+              src="title.svg"
             >
               <source
                 srcSet="title.svg"
@@ -151,6 +152,7 @@ NodeList [
     "name": "Discovery"
   }
 ])"
+    src="titleBrand.svg"
   />,
 ]
 `;

--- a/src/components/viewLayout/__tests__/__snapshots__/viewLayoutNavGroup.test.tsx.snap
+++ b/src/components/viewLayout/__tests__/__snapshots__/viewLayoutNavGroup.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`ViewLayout should render a basic component with NavGroup: basic 1`] = `
                   "default": "36px",
                 }
               }
+              src="title.svg"
             >
               <source
                 srcSet="title.svg"

--- a/src/components/viewLayout/viewLayout.tsx
+++ b/src/components/viewLayout/viewLayout.tsx
@@ -57,7 +57,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({
         </MastheadToggle>
         <MastheadBrand>
           <MastheadLogo>
-            <Brand alt={t('view.alt-logo', { name: uiName })} heights={{ default: '36px' }}>
+            <Brand src={titleImg} alt={t('view.alt-logo', { name: uiName })} heights={{ default: '36px' }}>
               <source srcSet={titleImg} />
             </Brand>
           </MastheadLogo>

--- a/src/views/sources/__tests__/__snapshots__/showSourceConnectionsModal.test.tsx.snap
+++ b/src/views/sources/__tests__/__snapshots__/showSourceConnectionsModal.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`ShowConnectionsModal should render a basic component: basic 1`] = `
     aria-label="t([
   "view.sources.show-connections-modal.aria-list"
 ])"
-    hasAnimations={true}
     isExpandable={true}
   >
     <Tbody

--- a/src/views/sources/showSourceConnectionsModal.tsx
+++ b/src/views/sources/showSourceConnectionsModal.tsx
@@ -71,7 +71,7 @@ const ShowConnectionsModal: React.FC<ShowConnectionsModalProps> = ({
         </Button>
       ]}
     >
-      <Table aria-label={t('view.sources.show-connections-modal.aria-list')} isExpandable hasAnimations>
+      <Table aria-label={t('view.sources.show-connections-modal.aria-list')} isExpandable>
         {[
           {
             category: 'failed',


### PR DESCRIPTION
## Summary

- Remove `hasAnimations` from the expandable `Table` in `ShowConnectionsModal` — `@patternfly/react-table`'s `Tr` passes `inert: ''` (empty string) on hidden rows when this prop is set, which React 19 warns about for boolean attributes
- Pass `src={titleImg}` to PatternFly's `Brand` component — when `Brand` has children it renders `<picture><img src={src} /></picture>`, but `src` defaults to `''`, triggering React 19's empty-string-on-src warning; the fix also correctly wires up the `<picture>` fallback image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logo rendering in the application header.
  * Removed animation from expandable host and status rows in the source connections dialog for a more consistent interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->